### PR TITLE
Start-OpenRose Batch file updated to take care of win-x64 as well as win-x86 folder name prefix

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Start-OpenRose.Bat
+++ b/OpenRose.Web/OpenRose.WebUI/Start-OpenRose.Bat
@@ -6,18 +6,30 @@ REM Licensed under the Apache License, Version 2.0.
 REM See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
 REM This script starts the OpenRose.API and OpenRose.WebUI applications in separate command windows.
-REM The script searches for the directories starting with OpenRose.API and OpenRose.WebUI in the parent directory of the script.
+REM It dynamically finds directories containing "OpenRose.API" and "OpenRose.WebUI" anywhere in their names.
 REM The script assumes that the applications are located in the same directory as the script.
+
 REM DESIGNED TO HELP USERS TO RUN OpenRose as a standalone application.
 
-REM Find the directory starting with OpenRose.API
-for /d %%d in (..\OpenRose.API*) do (
+REM Find the directory containing "OpenRose.API"
+for /d %%d in (..\*OpenRose.API*) do (
     set apidir=%%d
 )
 
-REM Find the directory starting with OpenRose.WebUI
-for /d %%d in (..\OpenRose.WebUI*) do (
+REM Find the directory containing "OpenRose.WebUI"
+for /d %%d in (..\*OpenRose.WebUI*) do (
     set wuidir=%%d
+)
+
+REM Check if the directories were found
+if not defined apidir (
+    echo OpenRose.API directory not found!
+    exit /b
+)
+
+if not defined wuidir (
+    echo OpenRose.WebUI directory not found!
+    exit /b
 )
 
 REM Start the applications in new command windows


### PR DESCRIPTION
Post upgrading to the latest version, we identified that we need to fix Start-OpenRose.Bat file to make sure that it supports having win-x64 or win-x86 or perhaps any other name as prefix in the future.

