### PR TITLE
Rolling back to AutoMapper 12.0.1

### DIFF
--- a/OpenRose.API/OpenRose.API.csproj
+++ b/OpenRose.API/OpenRose.API.csproj
@@ -51,7 +51,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="15.1.0" />
+		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.10" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.10" />
 		<PackageReference Include="Microsoft.Build" Version="17.14.28" />

--- a/OpenRose.API/Startup.cs
+++ b/OpenRose.API/Startup.cs
@@ -142,7 +142,8 @@ namespace ItemzApp.API
 
             services.AddTransient<IPropertyMappingService, PropertyMappingService>();
 
-			services.AddAutoMapper(cfg => { }, AppDomain.CurrentDomain.GetAssemblies());
+			services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
+			//services.AddAutoMapper(cfg => { }, AppDomain.CurrentDomain.GetAssemblies());
 
 			services.AddScoped<IItemzRepository, ItemzRepository>();
             services.AddScoped<IProjectRepository, ProjectRepository>();


### PR DESCRIPTION
We decided to go back to the deprecated version due to the fact that AutoMapper latest version is Licensed one