### PR TITLE
Added support to generate Links in Mermaid Flow Chart Diagram

### DIFF
--- a/OpenRose.API/Controllers/ExportController.cs
+++ b/OpenRose.API/Controllers/ExportController.cs
@@ -363,12 +363,17 @@ namespace ItemzApp.API.Controllers
 		[Produces("text/plain")]
 		[HttpGet("ExportMermaidFlowChart", Name = "__Export_Mermaid_FlowChart__")]
 		public async Task<IActionResult> ExportMermaidFlowChart([FromQuery] Guid exportRecordId,
-																[FromQuery] bool exportIncludedBaselineItemzOnly = false)
+																[FromQuery] bool exportIncludedBaselineItemzOnly = false,
+																[FromQuery] string? baseUrl = null)
 		{
 			if (exportRecordId == Guid.Empty)
 			{
 				return BadRequest("ExportRecordId must be a valid GUID.");
 			}
+
+
+			baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? null : baseUrl.TrimEnd('/');
+
 
 			try
 			{
@@ -402,7 +407,7 @@ namespace ItemzApp.API.Controllers
 					var exportedItemzIds = CollectExportedIdsByType(rootNode, "Itemz");
 					var itemzTraces = await _itemzTraceExportService.GetTracesForExportAsync(exportedItemzIds);
 
-					var mermaidText = MermaidExporter.Generate(rootNode, itemzTraces, exportRecordId);
+					var mermaidText = MermaidExporter.Generate(rootNode, itemzTraces, exportRecordId, baseUrl);
 					return Content(mermaidText, "text/plain");
 				}
 
@@ -446,7 +451,7 @@ namespace ItemzApp.API.Controllers
 					var exportedBaselineItemzIds = CollectExportedIdsByType(rootNode, "BaselineItemz");
 					var baselineItemzTraces = await _baselineItemzTraceExportService.GetTracesForExportAsync(exportedBaselineItemzIds);
 
-					var mermaidText = MermaidExporter.GenerateBaseline(rootNode, baselineItemzTraces, exportRecordId);
+					var mermaidText = MermaidExporter.GenerateBaseline(rootNode, baselineItemzTraces, exportRecordId, baseUrl);
 					return Content(mermaidText, "text/plain");
 				}
 

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/DummyExportService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/DummyExportService.cs
@@ -15,12 +15,12 @@ namespace OpenRose.WebUI.Client.Services.Export
 	{
 
 		/// <inheritdoc/>
-		public async Task<(byte[]? fileContent, string? fileName)> DownloadExportHierarchyAsync(Guid exportRecordId, bool exportIncludedBaselineItemzOnly, CancellationToken cancellationToken = default)
+		public async Task<(byte[]? fileContent, string? fileName)> DownloadExportHierarchyAsync(Guid exportRecordId, bool exportIncludedBaselineItemzOnly,  CancellationToken cancellationToken = default)
 		{
 			throw new InvalidOperationException("OpenRose API base URL is not configured. Please provide a valid URL in the configuration file.");
 		}
 
-		public async Task<string> __GET_MermaidFlowChart_By_GUID_ID__Async(Guid exportRecordId, bool exportIncludedBaselineItemzOnly, CancellationToken cancellationToken = default)
+		public async Task<string> __GET_MermaidFlowChart_By_GUID_ID__Async(Guid exportRecordId, bool exportIncludedBaselineItemzOnly, string baseURL, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/ExportService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/ExportService.cs
@@ -76,6 +76,7 @@ namespace OpenRose.WebUI.Client.Services.Export
 		public async Task<string> __GET_MermaidFlowChart_By_GUID_ID__Async(
 			Guid exportRecordId,
 			bool exportIncludedBaselineItemzOnly,
+			string baseUrl,
 			CancellationToken cancellationToken = default)
 		{
 			try
@@ -92,6 +93,7 @@ namespace OpenRose.WebUI.Client.Services.Export
 				}
 
 				urlBuilder_.Append($"exportRecordId={exportRecordId}");
+				urlBuilder_.Append($"&baseUrl={Uri.EscapeDataString(baseUrl)}");
 
 				if (exportIncludedBaselineItemzOnly)
 				{

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/IExportService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/IExportService.cs
@@ -37,6 +37,7 @@ namespace OpenRose.WebUI.Client.Services.Export
 		/// </returns>
 		Task<string> __GET_MermaidFlowChart_By_GUID_ID__Async(Guid exportRecordId,
 																bool exportIncludedBaselineItemzOnly,
+																string baseUrl,
 																CancellationToken cancellationToken = default);
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportMermaidFlowChart.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportMermaidFlowChart.razor
@@ -10,6 +10,7 @@
 @using OpenRose.WebUI.Components.Dialogs
 @inject IExportService ExportService
 @inject IDialogService DialogService
+@inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 
 <MudPaper Class="pa-3 mb-3 align-start d-flex" Outlined="false">
@@ -166,8 +167,14 @@
         {
             Guid guid = Guid.Parse(targetGuidText.Trim());
             loading = true;
+
+            var clientBaseUrl = NavigationManager.BaseUri.TrimEnd('/');
+
             mermaidText = await ExportService.__GET_MermaidFlowChart_By_GUID_ID__Async(
-                guid, exportIncludedBaselineItemzOnly);
+                                                guid, 
+                                                exportIncludedBaselineItemzOnly,
+                                                clientBaseUrl);
+
             loading = false;
 
             if (string.IsNullOrWhiteSpace(mermaidText))


### PR DESCRIPTION
With this enhancement now users can navigate direct from the Mermaid Flow Chart Diagram elements into OpenRose. It mainly uses GoTo links to identify record and open the same in details view.

Team has tested working of this solution by taking generated output and generating Mermaid Diagrams in Mermaid.live which works as expected.