### PR TITLE
Bug Fix - Runtime error reported when loading 2nd baseline json data file

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/WelcomeDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/WelcomeDialog.razor
@@ -24,7 +24,7 @@
             <!-- Download link -->
             <MudItem xs="12" class="d-flex justify-center">
                 <MudText Align="Align.Center" Color="Color.Primary">
-                    Download from https://github.com/openrose
+                    || Just search for <b> OpenRose </b> online ||
                 </MudText>
             </MudItem>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -316,6 +316,11 @@
         JsonFileDataSource.OnJsonChanged += HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged += HandleStateChangedAsync;
 
+        // await ReloadTreeAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
         await ReloadTreeAsync();
     }
 
@@ -493,8 +498,6 @@
 
     private async Task OnItemClick(TreeItemPresenter presenter)
     {
-
-        Console.WriteLine("Clicked node: " + presenter.Text + " (ID: " + presenter.Value + ", Type: " + presenter.RecordType + ", Level: " + presenter.Level + ")");
         // Detect root node click (Level == 0)
         if (presenter.Level == 0)
         {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -210,7 +210,7 @@
         JsonFileDataSource.OnJsonChanged += HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged += HandleStateChangedAsync;
 
-        await ReloadTreeAsync();
+       //  await ReloadTreeAsync();
 
     }
 


### PR DESCRIPTION
Irrespective of Server JSON file or Client JSON file, when user would load subsequent data file into the JSON view then it would throw runtime error. Cause of this issue was identified via several test and debugging sessions and then issue is now fixed. 
