### PR TITLE
StartUp Batch file now treats API as optional application

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Start-OpenRose.Bat
+++ b/OpenRose.Web/OpenRose.WebUI/Start-OpenRose.Bat
@@ -2,15 +2,17 @@
 setlocal
 
 REM OpenRose - Requirements Management
-REM Licensed under the Apache License, Version 2.0. 
+REM Licensed under the Apache License, Version 2.0.
 REM See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
-REM This script starts the OpenRose.API and OpenRose.WebUI applications in separate command windows.
+REM This script starts OpenRose.WebUI and, if available, OpenRose.API.
+REM If the API is missing, a warning is shown but WebUI still starts normally.
 REM It dynamically finds directories containing "OpenRose.API.Exe" and "OpenRose.WebUI.Exe".
 REM The script assumes that the applications are located in the same directory as the script.
 REM Searches for executables in any sibling directory of the parent folder.
 
 REM DESIGNED TO HELP USERS TO RUN OpenRose as a standalone application.
+
 
 set "parentDir=%~dp0.."
 
@@ -32,22 +34,32 @@ for /d %%d in ("%parentDir%\*") do (
     )
 )
 
-REM Validate results
-if not defined apidir (
-    echo ERROR: Could not find OpenRose.API.exe in any sibling directory.
-    exit /b
-)
-
+REM Validate WebUI (required)
 if not defined wuidir (
     echo ERROR: Could not find OpenRose.WebUI.exe in any sibling directory.
+    echo WebUI is required to run OpenRose.
     exit /b
 )
 
-echo Found API at: %apidir%
-echo Found WebUI at: %wuidir%
+REM API optional
+if not defined apidir (
+    echo WARNING: OpenRose.API.exe not found.
+    echo WebUI will start without API support.
+) else (
+    echo Found API at: %apidir%
+)
 
-REM Start applications
-start "" cmd /c "cd /d %apidir% && start OpenRose.API.exe"
+echo Found WebUI at: %wuidir%
+echo.
+
+REM Start API only if present
+if defined apidir (
+    echo Starting OpenRose.API...
+    start "" cmd /c "cd /d %apidir% && start OpenRose.API.exe"
+)
+
+REM Start WebUI (always)
+echo Starting OpenRose.WebUI...
 start "" cmd /c "cd /d %wuidir% && start OpenRose.WebUI.exe"
 
 endlocal


### PR DESCRIPTION
OpenRose API executable now will be treated as optional application within Start-up Batch file. It will try to find and start API application but if it's not present in the sibling directory then it will ignore it as not available. Start-Up batch file will not throw this as error but instead it will show warning message.

This is because now users can host just WebUI without API to be able to allow users to use Server JSON file and Client JSON files.

