### PR TITLE
Adding Traceability Data views in Requirement Item and Baseline Requirement Item

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
@@ -22,8 +22,11 @@
 	<BaselineBreadcrums produceBreadcrums="BreadcrumsParameter" />
 }
 
-<MudPaper Class="pa-2 mb-3 align-start d-flex" Style="width: auto" Outlined="false">
-	<MudText Typo="Typo.h6" Align="Align.Left">Baseline</MudText>
+<MudPaper Class="pa-3 mb-3 align-start d-flex" Style="width: auto " Outlined="false">
+	<MudStack Row="true" Spacing="3">
+		<MudIcon Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Large" Color="Color.Secondary" />
+		<MudText Typo="Typo.h6" Align="Align.Left">Baseline</MudText>
+	</MudStack>
 </MudPaper>
 
 <MudGrid>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
@@ -199,9 +199,10 @@
  		</MudItem>
         @if (ViewSettings.ShowTraceabilityInItemzDetails)
 		{
- 			<MudItem xs="12" sm="12">
+			<MudItem Class="mb-3" xs="12" sm="12">
 				<BaselineTraceabilityReadOnlyComponent BaselineItemzId="@BaselineItemzId" CalledFrom="@nameof(BaselineItemz)" />
 			</MudItem>
+
 		}
 	}
 </MudGrid>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
@@ -5,10 +5,12 @@
 *@
 
 @page "/baselineitemz/{BaselineItemzId:guid}"
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage 
 @using OpenRose.WebUI.Client.Services.BaselineHierarchy
 @using OpenRose.WebUI.Client.Services.BaselineItemz
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Pages.BaselineItemz.BaselineTraceability
 @using OpenRose.WebUI.Components.Pages.Breadcrums
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.EventServices
@@ -20,6 +22,8 @@
 @inject IFindProjectAndBaselineIdsByBaselineItemzIdService FindProjectAndBaselineIdsByBaselineItemzIdService
 @inject BaselineBreadcrumsService baselineBreadcrumsService
 @inject NavigationManager NavManager
+@inject ProtectedSessionStorage SessionStorage
+@inject ViewSettingsService ViewSettings
 @inject IDialogService DialogService
 @inject IJSRuntime JS
 
@@ -28,8 +32,29 @@
 	<BaselineBreadcrums produceBreadcrums="BreadcrumsParameter" />
 }
 
-<MudPaper Class="pa-4 mb-3 align-start d-flex" Style="width: auto" Outlined="false">
-	<MudText Typo="Typo.h6" Align="Align.Left">Baseline Itemz</MudText>
+<MudPaper Class="pa-3 mb-3 d-flex" Style="width: auto" Outlined="false">
+	<MudStack Row="true" Spacing="3" AlignItems="AlignItems.Center" Class="w-100">
+
+		<MudIcon Icon="@Icons.Material.Filled.Stream"
+				 Size="Size.Large"
+				 Color="Color.Secondary" />
+
+		<MudText Typo="Typo.h6" Align="Align.Left">
+			Baseline Itemz
+		</MudText>
+
+		<!-- This spacer pushes everything after it to the far right -->
+		<MudSpacer />
+
+		<MudSwitch T="bool"
+				   Value="@ViewSettings.ShowTraceabilityInItemzDetails"
+				   ValueChanged="ToggleShowTraces"
+				   Label="Show Traces"
+				   UncheckedColor="Color.Success"
+				   Color="Color.Success"
+				   LabelPlacement="Placement.End" />
+
+	</MudStack>
 </MudPaper>
 
 <MudGrid>
@@ -172,6 +197,12 @@
 				</Columns>
 			</MudDataGrid>
  		</MudItem>
+        @if (ViewSettings.ShowTraceabilityInItemzDetails)
+		{
+ 			<MudItem xs="12" sm="12">
+				<BaselineTraceabilityReadOnlyComponent BaselineItemzId="@BaselineItemzId" CalledFrom="@nameof(BaselineItemz)" />
+			</MudItem>
+		}
 	}
 </MudGrid>
 @code {
@@ -236,6 +267,14 @@
 	{
 		if (firstRender)
 		{
+
+			// Load view settings
+			var result = await SessionStorage.GetAsync<bool>("SHOWTRACEABILITYINITEMZDETAILS");
+			if (result.Success)
+			{
+				ViewSettings.ShowTraceabilityInItemzDetails = result.Value;
+			}
+
 			initializingPage = true;
 
 			var returnedItemzList = await baselineHierarchyService.__Get_Immediate_Children_Baseline_Hierarchy_By_GUID__Async(BaselineItemzId);
@@ -403,5 +442,15 @@
 			// await Task.Delay(1000);
 			// await JS.InvokeVoidAsync("applyMarkdownEditorFullscreenStyles");
 		}
+	}
+
+	private async Task ToggleShowTraces(bool newValue)
+	{
+
+		// Apply the new setting
+		ViewSettings.ShowTraceabilityInItemzDetails = newValue;
+		await SessionStorage.SetAsync("SHOWTRACEABILITYINITEMZDETAILS", newValue);
+
+		StateHasChanged();
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineTraceability/BaselineTraceabilityReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineTraceability/BaselineTraceabilityReadOnlyComponent.razor
@@ -291,6 +291,13 @@
 
 	public async Task openBaselineItemz(string baselineItemzId)
 	{
+
+		if (CalledFrom == nameof(BaselineItemz))
+		{
+			// If we are already in BaselineItemz, just navigate within the same page.
+			NavManager.NavigateTo($"/baselineitemz/{baselineItemzId}", true);
+			return;
+		}
 		BaselineItemzSelectionService.SelectBaselineTreeNodeItemz(Guid.Parse(baselineItemzId));
 		BaselineItemzSelectionService.ScrollToTreeViewNode(Guid.Parse(baselineItemzId));
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
@@ -28,8 +28,11 @@
 	<BaselineBreadcrums produceBreadcrums="BreadcrumsParameter" />
 }
 
-<MudPaper Class="pa-4 mb-3 align-start d-flex" Style="width: auto" Outlined="false">
-	<MudText Typo="Typo.h6" Align="Align.Left">Baseline ItemzType</MudText>
+<MudPaper Class="pa-3 mb-3 align-start d-flex" Style="width: auto " Outlined="false">
+	<MudStack Row="true" Spacing="3">
+		<MudIcon Icon="@Icons.Material.Filled.Pix" Size="Size.Large" Color="Color.Secondary" />
+		<MudText Typo="Typo.h6" Align="Align.Left">Baseline ItemzType</MudText>
+	</MudStack>
 </MudPaper>
 
 <MudGrid>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -197,9 +197,10 @@
  		</MudItem>
         @if (ViewSettings.ShowTraceabilityInItemzDetails)
 		{
- 			<MudItem xs="12" sm="12">
+			<MudItem Class="mb-3" xs="12" sm="12">
 				<TraceabilityReadOnlyComponent ItemzId="@ItemzId" CalledFrom="@nameof(Itemz)" />
 			</MudItem>
+
 		}
 		}
 	}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -5,6 +5,7 @@
 *@
 
 @page "/itemz/{ItemzId:guid}"
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.Services.ItemzTypeItemzsService
@@ -14,12 +15,15 @@
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Components.Pages.Breadcrums
 @using OpenRose.WebUI.Components.Pages.Common
+@using OpenRose.WebUI.Components.Pages.Itemz.Traceability
 @using OpenRose.WebUI.Components.Utilities
 @using OpenRose.WebUI.Services
 @using Microsoft.AspNetCore.Components.Forms
 @inject NavigationManager NavManager
 @inject IDialogService DialogService
 @inject BreadcrumsService breadcrumsService
+@inject ProtectedSessionStorage SessionStorage
+@inject ViewSettingsService ViewSettings
 @inject IJSRuntime JS
 @inject IServiceProvider serviceProvider
 
@@ -28,12 +32,31 @@
 	<ItemzBreadcrums produceBreadcrums="BreadcrumsParameter" />
 }
 
-<MudPaper Class="pa-3 mb-3 align-start d-flex" Style="width: auto " Outlined="false">
-    <MudStack Row="true" Spacing="3">
-        <MudIcon Icon="@Icons.Material.Filled.Stream" Size="Size.Large" Color="Color.Secondary" />
-		<MudText Typo="Typo.h6" Align="Align.Left">Itemz </MudText>
-    </MudStack>
+<MudPaper Class="pa-3 mb-3 d-flex" Style="width: auto" Outlined="false">
+	<MudStack Row="true" Spacing="3" AlignItems="AlignItems.Center" Class="w-100">
+
+		<MudIcon Icon="@Icons.Material.Filled.Stream"
+				 Size="Size.Large"
+				 Color="Color.Secondary" />
+
+		<MudText Typo="Typo.h6" Align="Align.Left">
+			Itemz
+		</MudText>
+
+		<!-- This spacer pushes everything after it to the far right -->
+		<MudSpacer />
+
+		<MudSwitch T="bool"
+				   Value="@ViewSettings.ShowTraceabilityInItemzDetails"
+				   ValueChanged="ToggleShowTraces"
+				   Label="Show Traces"
+				   UncheckedColor="Color.Success"
+				   Color="Color.Success"
+				   LabelPlacement="Placement.End" />
+
+	</MudStack>
 </MudPaper>
+
 
 <MudGrid>
 	@if (initializingPage)
@@ -172,6 +195,12 @@
 				</Columns>
 			</MudDataGrid>
  		</MudItem>
+        @if (ViewSettings.ShowTraceabilityInItemzDetails)
+		{
+ 			<MudItem xs="12" sm="12">
+				<TraceabilityReadOnlyComponent ItemzId="@ItemzId" CalledFrom="@nameof(Itemz)" />
+			</MudItem>
+		}
 		}
 	}
 	}
@@ -256,6 +285,14 @@
 	{
 		if (firstRender)
 		{
+
+			// Load view settings
+			var result = await SessionStorage.GetAsync<bool>("SHOWTRACEABILITYINITEMZDETAILS");
+			if (result.Success)
+			{
+				ViewSettings.ShowTraceabilityInItemzDetails = result.Value;
+			}
+
 			initializingPage = true;
 			await Task.Delay(200); // Wanted Breadcrums to load so that decision about displaying Child Itemz can be taken properly.
 		}
@@ -465,6 +502,16 @@
 			// await Task.Delay(1000);
 			// await JS.InvokeVoidAsync("applyMarkdownEditorFullscreenStyles");
 		}
+	}
+
+	private async Task ToggleShowTraces(bool newValue)
+	{
+
+		// Apply the new setting
+		ViewSettings.ShowTraceabilityInItemzDetails = newValue;
+		await SessionStorage.SetAsync("SHOWTRACEABILITYINITEMZDETAILS", newValue);
+
+		StateHasChanged();
 	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponent.razor
@@ -296,6 +296,13 @@
 
 	public async Task openItemz(string itemzId)
 	{
+		if (CalledFrom == nameof(Itemz))
+		{
+			// If we are already in ItemzDetails, just navigate within the same page without forcing a reload
+			NavManager.NavigateTo($"/itemz/{itemzId}", true);
+			return;
+        }
+
 		ItemzSelectionService.SelectTreeNodeItemz(Guid.Parse(itemzId));
 		ItemzSelectionService.ScrollToTreeViewNode(Guid.Parse(itemzId));
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponent.razor
@@ -298,7 +298,7 @@
 	{
 		if (CalledFrom == nameof(Itemz))
 		{
-			// If we are already in ItemzDetails, just navigate within the same page without forcing a reload
+			// If we are already in ItemzDetails, just navigate within the same page.
 			NavManager.NavigateTo($"/itemz/{itemzId}", true);
 			return;
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
@@ -35,10 +35,6 @@
     </MudStack>
 </MudPaper>
 
-@* <MudPaper Class="pa-4 mb-5 align-start d-flex" Style="width: auto" Outlined="false">
-	<MudText Typo="Typo.h6" Align="Align.Left">ItemzType</MudText>
-</MudPaper> *@
-
 <MudGrid>
 	@if (initializingPage)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -53,8 +53,7 @@
 						</MudItem>
 					</MudGrid>
 				</MudItem>
-@* 				<MudDivider Style="color: darkgray background-color: white; border-width: 2px; border-color: black; height: 2px; " /> *@
-					</MudCardContent>
+				</MudCardContent>
 				</MudCard>
 				<MudCard >
 					<MudCardContent>
@@ -128,8 +127,6 @@
 	<MudPaper Height="calc(100vh - 100px);" Width="100%">
 		<MudOverlay Visible="@_showOverlay" DarkBackground="true" Absolute="true">
 			<MudContainer Class="d-flex flex-column justify-center align-center" Style="height: 100%;">
-				@* <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Moving ... </MudText>
-			<br /> *@
 				<MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
 			</MudContainer>
 		</MudOverlay>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -23,11 +23,6 @@
     </MudStack>
 </MudPaper>
 
-
-@* <MudPaper Class="pa-3 mb-5 align-start d-flex" Style="width: auto " Outlined="false">
-	<MudText Typo="Typo.h6" Align="Align.Left">Project</MudText>
-</MudPaper>
- *@
 <MudGrid>
 	@if (initializingPage)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Services/ViewSettingsService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/ViewSettingsService.cs
@@ -78,6 +78,15 @@ namespace OpenRose.WebUI.Services
 		/// </summary>
 		public bool ShowDataSourceSwitchControl { get; set; } = true;
 
+
+		/// <summary>
+		/// Indicates whether traceability information is displayed in Itemz details view.
+		/// This is a user preference stored per session using local storage.
+		/// This setting will cover both, Itemz and Baseline Itemz 
+		/// as user preference will be same for both!
+		/// </summary>
+		public bool ShowTraceabilityInItemzDetails { get; set; } = true;
+
 		public bool IsKioskMode { get; private set; } = false;
 
 		public event Action? OnKioskModeChanged;


### PR DESCRIPTION
In Details View, now we show Traceability Data in the base view for both, 

- Requirement Items
- Baseline Requirement Items

We also added Icons in the title for following record types

- Baseline
- Baseline Requirement Item Types
- Baseline Requirement Item

Open Rose Requirements Management Tools team is excited to roll-out this feature that will make it easier for users to navigate traceability data for Requirements that are managed in the repository. 

Open Rose Team has performed their own manual testing to verify that features are working as expected. 

