### PR TITLE
UI Improvements for Title Block and Properties for Mobile Users

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
@@ -46,21 +46,36 @@
  		<MudItem xs="12" sm="12">
 			<MudPaper Class="pa-2 mb-2">
 			<MudCard style="background-color : #FABBBB;" >
-				<MudCardContent>
-				<MudItem Class="align-start d-flex" Style="width: auto" Outlined="false">
-					<MudGrid>
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleBaseline.Name </strong></MudText>
-						</MudItem>
-						<MudItem xs="12" sm="12" md="5" lg="5">
-							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Justify="Justify.FlexEnd" Class="w-100">
-								<MudButton OnClick="async _ => await editBaselineDetails(BaselineId.ToString())" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Success"> Edit Baseline </MudButton>
-								<MudButton OnClick="async _ => await openBaselineTreeView(BaselineId.ToString())" Variant="@Variant.Filled" Size="@Size.Medium" Color="@Color.Success" Target="_blank"> TreeView </MudButton>
-								<MudButton OnClick="goBackToParentProject" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning" style="gap: 10px; margin-left : 10px"> Go Back </MudButton>
-							</MudStack>
-						</MudItem>
-					</MudGrid>
-				</MudItem>
+				<MudCardContent Style="padding:6px">
+ 				<div class="d-flex align-start justify-space-between" style="gap:8px;">
+					<MudText Typo="Typo.inherit"
+								Class="flex-grow-1 text-responsive-title"
+								Align="Align.Left">
+						<strong>@singleBaseline.Name </strong>
+					</MudText>
+					<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
+					<MudButton OnClick="async _ => await editBaselineDetails(BaselineId.ToString())" 
+						Variant="Variant.Filled"
+						Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+						Color="Color.Success">
+							@(bp >= Breakpoint.Sm ? "Edit Baseline" : "E")
+					</MudButton>
+					<MudButton OnClick="async _ => await openBaselineTreeView(BaselineId.ToString())" 
+						Variant="@Variant.Filled"
+						Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+						Color="@Color.Success" 
+						Target="_blank">
+							@(bp >= Breakpoint.Sm ? "Tree View" : "T")
+					</MudButton>
+					<MudButton OnClick="goBackToParentProject" 
+						Variant="Variant.Filled"
+						Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+						Color="Color.Warning" 
+						style="gap: 10px; margin-left : 10px">
+							@(bp >= Breakpoint.Sm ? "Go Back" : "<-")
+					</MudButton>
+					</div>
+				</div>
 				</MudCardContent>
 			</MudCard>
 			<MudCard>
@@ -89,7 +104,7 @@
 					<MudText><strong>Description : </strong></MudText>
 					<br />
 					<div class="custom-markdown-editor">
-							<MudPaper Class="pa-2" Elevation="0" Outlined="false">
+						<MudPaper Class="pa-2" Elevation="0" Outlined="false">
 							@if (!string.IsNullOrEmpty(singleBaseline.Description))
 							{
 								<div class="markdown-body">@((MarkupString)convertedMarkdown)</div>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
@@ -65,17 +65,27 @@
 			</MudCard>
 			<MudCard>
 				<MudCardContent>
-					<MudStack Row="true" Spacing="2">
-					<MudText><strong>ID          : </strong></MudText>
-					<CopyableText TextToCopy="@singleBaseline.Id.ToString()" DisplayLength="8"/>
-					<MudTooltip Text="GoTo Project" Placement="Placement.Top">
-						<MudIcon Icon="@Icons.Material.Filled.SportsBaseball"
-									Size="Size.Small"
-									Class="mouse-pointer-icon"
-									@onclick="async _ => await gotoBaselineProjectRecord(singleBaseline.Id.ToString())" />
-					</MudTooltip>
-					|| <BaselineEstimationReadOnlyComponent RecordId="BaselineId" />
-					</MudStack>
+                <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                    <div style="
+                                display:flex;
+                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                align-items:flex-start;
+                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                ">
+                        <div style="display:flex; align-items:center; gap:6px;">
+						<strong>ID : </strong>
+						<CopyableText TextToCopy="@singleBaseline.Id.ToString()" DisplayLength="8"/>
+						<MudTooltip Text="GoTo Project" Placement="Placement.Top">
+							<MudIcon Icon="@Icons.Material.Filled.SportsBaseball"
+										Size="Size.Small"
+										Class="mouse-pointer-icon"
+										@onclick="async _ => await gotoBaselineProjectRecord(singleBaseline.Id.ToString())" />
+						</MudTooltip>
+						</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineId" /></div>
+					</div>
+				</MudBreakpointProvider>
 					<MudText><strong>Description : </strong></MudText>
 					<br />
 					<div class="custom-markdown-editor">
@@ -147,6 +157,8 @@
 	public bool initializingPage { get; set; } = true;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -37,11 +37,12 @@
 				<MudCardContent>
 					<div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<!-- Left side: Title -->
-							<MudText Typo="Typo.h5" Align="Align.Left"
-							 Class="flex-grow-1"
-							 Style="white-space:normal; overflow-wrap:break-word;">
-								<strong>@singleBaseline.Name</strong>
-							</MudText>
+						<MudText Typo="Typo.inherit"
+								 Class="flex-grow-1 text-responsive-title"
+								 Align="Align.Left"
+								 Style="white-space:normal; overflow-wrap:break-word;">
+							<strong>@singleBaseline.Name</strong>
+						</MudText>
 					<div class="d-flex align-top flex-shrink-0">
 						<!-- Right side: Only Down button -->
 							<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -58,34 +58,35 @@
 			</MudCard>
 			<MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
 				<MudCardContent>
-@* 					<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-						<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
-							<MudText><strong>ID :</strong></MudText>
-							<CopyableText TextToCopy="@singleBaseline.Id.ToString()" />
-						</MudStack>
-						<MudText><strong>Status :</strong> @singleBaseline.Status</MudText>
-					</MudStack> *@
 					@if (!ViewSettings.IsKioskMode)
 					{
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudStack Row="true" Spacing="2">
-							<MudText><strong>ID          : </strong></MudText>
-							<CopyableText TextToCopy="@singleBaseline.Id.ToString()" DisplayLength="8" />
-							<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
-								<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small"
-											Class="mouse-pointer-icon"
-											Style="cursor:pointer"
-											@onclick="findAndShowInTreeView" />
-							</MudTooltip>
-							<MudTooltip Text="GoTo Project" Placement="Placement.Top">
-								<MudIcon Icon="@Icons.Material.Filled.SportsBaseball"
-								Size="Size.Small"
-								Class="mouse-pointer-icon"
-								@onclick="async _ => await gotoBaselineProjectRecord(singleBaseline.Id.ToString())" />
-							</MudTooltip>
-							|| <BaselineEstimationReadOnlyComponent RecordId="BaselineId" />
-						</MudStack>
-					</MudStack>
+					<MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+						<div style="
+									display:flex;
+									gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+									align-items:flex-start;
+									flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+									flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+									">
+							<div style="display:flex; align-items:center; gap:6px;">
+								<strong>ID : </strong>
+								<CopyableText TextToCopy="@singleBaseline.Id.ToString()" DisplayLength="8" />
+								<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
+									<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small"
+												Class="mouse-pointer-icon"
+												Style="cursor:pointer"
+												@onclick="findAndShowInTreeView" />
+								</MudTooltip>
+								<MudTooltip Text="GoTo Project" Placement="Placement.Top">
+									<MudIcon Icon="@Icons.Material.Filled.SportsBaseball"
+									Size="Size.Small"
+									Class="mouse-pointer-icon"
+									@onclick="async _ => await gotoBaselineProjectRecord(singleBaseline.Id.ToString())" />
+								</MudTooltip>
+							</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineId" /></div>
+						</div>
+					</MudBreakpointProvider>
 					}
 
 					<br />
@@ -127,6 +128,8 @@
 	public bool _showOverlay { get; set; } = false;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -35,16 +35,15 @@
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent>
-					<MudGrid>
+					<div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<!-- Left side: Title -->
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left">
+							<MudText Typo="Typo.h5" Align="Align.Left"
+							 Class="flex-grow-1"
+							 Style="white-space:normal; overflow-wrap:break-word;">
 								<strong>@singleBaseline.Name</strong>
 							</MudText>
-						</MudItem>
-
+					<div class="d-flex align-top flex-shrink-0">
 						<!-- Right side: Only Down button -->
-						<MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
 							<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
 										   Color="Color.Success"
 										   Size="Size.Medium"
@@ -52,8 +51,8 @@
 										   Variant="Variant.Filled"
 										   Class="mud-rounded-circle"
 										   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineId); })" />
-						</MudItem>
-					</MudGrid>
+                        </div>
+                    </div>
 				</MudCardContent>
 			</MudCard>
 			<MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -57,23 +57,30 @@
                 <MudCardContent>
                 @if (!ViewSettings.IsKioskMode)
                 {
-                    <MudStack Row="true" Spacing="2">
-                        <MudText><strong>ID:</strong></MudText>
+                <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                    <div style=" display:flex;
+                            gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                            align-items:flex-start;
+                            flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                            flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                        <div style="display:flex; align-items:center; gap:6px;">
+                        <strong>ID:</strong>
                         <CopyableText TextToCopy="@_baseline.Id.ToString()" DisplayLength="8" />
                         <MudTooltip Text="Show in Tree View">
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
+                        </div>
                         @if (!string.IsNullOrEmpty(_baseline.EstimationUnit))
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation [@_baseline.EstimationUnit] : </b> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_baseline.EstimationUnit] : </strong> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </div>
                         }
                         else
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation : </b> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </div>
                         }
-                    </MudStack>
-
-                    <br />
+                    </div>
+                </MudBreakpointProvider>
+                <br />
                 }
                 @if (!string.IsNullOrEmpty(_baseline.Description))
                 {
@@ -93,6 +100,8 @@
     private GetBaselineExportDTO _baseline = new();
     private MarkupString _convertedMarkdown;
     private bool _needsRender = false;
+
+    private Breakpoint bp;
 
     protected override async Task OnParametersSetAsync()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -33,24 +33,22 @@
             @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
-                    <MudGrid>
-                        <MudItem xs="12" sm="12" md="7" lg="7">
-                            <MudText Typo="Typo.h5" Align="Align.Left">
-                                <strong>@_baseline.Name</strong>
-                            </MudText>
-                        </MudItem>
-
-                        <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
-                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle"
-                                           OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineId); })" />
-                        </MudItem>
-                    </MudGrid>
-
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                        <MudText Typo="Typo.h5" Align="Align.Left"
+                                Class="flex-grow-1"
+                                Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@_baseline.Name</strong>
+                        </MudText>
+                    <div class="d-flex align-top flex-shrink-0">
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+                                        Color="Color.Success"
+                                        Size="Size.Medium"
+                                        IconSize="Size.Large"
+                                        Variant="Variant.Filled"
+                                        Class="mud-rounded-circle"
+                                        OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineId); })" />
+                        </div>
+                    </div>
                 </MudCardContent>
             </MudCard>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -34,9 +34,10 @@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
-                        <MudText Typo="Typo.h5" Align="Align.Left"
-                                Class="flex-grow-1"
-                                Style="white-space:normal; overflow-wrap:break-word;">
+                        <MudText Typo="Typo.inherit"
+                                 Class="flex-grow-1 text-responsive-title"
+                                 Align="Align.Left"
+                                 Style="white-space:normal; overflow-wrap:break-word;">
                             <strong>@_baseline.Name</strong>
                         </MudText>
                     <div class="d-flex align-top flex-shrink-0">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
@@ -73,22 +73,36 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
-				<MudCardContent>
-				<MudItem Class="align-start d-flex" Style="width: auto" Outlined="false">
-					<MudGrid>
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleBaselineItemz.Name </strong></MudText>
-						</MudItem>
-						<MudItem xs="12" sm="12" md="5" lg="5">
-							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Justify="Justify.FlexEnd" Class="w-100">
-								<MudButton OnClick="async _ => await openBaselineItemzDetails(BaselineItemzId.ToString())" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Success"> Open </MudButton>
-								<MudButton OnClick="async _ => await openBaselineTreeView(BaselineItemzId)" Variant="@Variant.Filled" Size="@Size.Medium" Color="@Color.Success" Target="_blank"> TreeView </MudButton>
-								<MudButton OnClick="goBackToParent" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning"> Go Back </MudButton>
-							</MudStack>
-						</MudItem>
-					</MudGrid>
-				</MudItem>
-				</MudCardContent>
+			<MudCardContent Style="padding:6px">
+				<div class="d-flex align-start justify-space-between" style="gap:8px;">
+					<MudText Typo="Typo.inherit"
+								Class="flex-grow-1 text-responsive-title"
+								Align="Align.Left">
+						<strong>@singleBaselineItemz.Name </strong>
+					</MudText>
+					<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
+						<MudButton OnClick="async _ => await openBaselineItemzDetails(BaselineItemzId.ToString())" 
+							Variant="Variant.Filled"
+							Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+							Color="Color.Success"> 
+							@(bp >= Breakpoint.Sm ? "Open" : "O")
+						</MudButton>
+						<MudButton OnClick="async _ => await openBaselineTreeView(BaselineItemzId)" 
+							Variant="@Variant.Filled"
+							Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+							Color="@Color.Success" 
+							Target="_blank"> 
+							@(bp >= Breakpoint.Sm ? "Tree View" : "T")
+						</MudButton>
+						<MudButton OnClick="goBackToParent" 
+							Variant="Variant.Filled"
+							Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+							Color="Color.Warning"> 
+							@(bp >= Breakpoint.Sm ? "Go Back" : "<-")
+						</MudButton>
+					</div>
+				</div>
+			</MudCardContent>
 			</MudCard>
 			<MudCard>
 				<MudCardContent>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
@@ -106,18 +106,26 @@
 						</MudChipSet>
 					</MudStack>
 
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudStack Row="true" Spacing="2">
-							<MudText><strong>ID          : </strong></MudText>
+					<MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+						<div style="
+	                                display:flex;
+	                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+	                                align-items:flex-start;
+	                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+	                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+	                                ">
+							<div style="display:flex; align-items:center; gap:6px;">
+							<strong>ID : </strong>
 							<CopyableText TextToCopy="@singleBaselineItemz.Id.ToString()" DisplayLength="8" />
 							<GoToOriginalItemzButton BaselineItemzId="@singleBaselineItemz.Id" UseTreeView="false" />
 							<ShowHierarchyTreeButton RecordId="@singleBaselineItemz.Id" />
-						</MudStack>
-						<MudText><strong> || Status      : </strong> @singleBaselineItemz.Status</MudText>
-						<MudText><strong> || Priority    : </strong> @singleBaselineItemz.Priority</MudText>
-						<MudText><strong> || Severity    : </strong> @singleBaselineItemz.Severity</MudText>
-						|| <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzId" />
-					</MudStack>
+						</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemz.Status</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @singleBaselineItemz.Priority</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @singleBaselineItemz.Severity</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzId" /></div>
+						</div>
+					</MudBreakpointProvider>
 
 					<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
 					<MudSwitch T="bool" 
@@ -231,6 +239,8 @@
 	private MarkupString convertedMarkdown;
 
 	private List<string>? tagsList = new List<string>();
+
+	private Breakpoint bp;
 
 	protected override async Task OnInitializedAsync()
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -92,9 +92,16 @@
 
 					@if (!ViewSettings.IsKioskMode)
 					{
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudStack Row="true" Spacing="2">
-							<MudText><strong>ID          : </strong></MudText>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style="
+                                    display:flex;
+                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                    align-items:flex-start;
+                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                    ">
+							<div style="display:flex; align-items:center; gap:6px;">
+							<strong>ID : </strong>
 							<CopyableText TextToCopy="@singleBaselineItemz.Id.ToString()" DisplayLength="8" />
 							<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
 								<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small"
@@ -104,12 +111,13 @@
 							</MudTooltip>
 							<GoToOriginalItemzButton BaselineItemzId="@singleBaselineItemz.Id" UseTreeView="true" />
 							<ShowHierarchyTreeButton RecordId="@singleBaselineItemz.Id" />
-						</MudStack>
-						<MudText><strong> || Status      : </strong> @singleBaselineItemz.Status</MudText>
-						<MudText><strong> || Priority    : </strong> @singleBaselineItemz.Priority</MudText>
-						<MudText><strong> || Severity    : </strong> @singleBaselineItemz.Severity</MudText>
-						|| <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzId" />
-					</MudStack>
+							</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemz.Status</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @singleBaselineItemz.Priority</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @singleBaselineItemz.Severity</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzId" /></div>
+						</div>
+					</MudBreakpointProvider>
 					}
 					
 					<br />
@@ -158,6 +166,8 @@
 	private MarkupString convertedMarkdown;
 
 	private List<string>? tagsList = new List<string>();
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -36,16 +36,17 @@
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent>
-					<MudGrid>
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+
 						<!-- Left side: Title -->
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left">
+							<MudText Typo="Typo.h5" Align="Align.Left"
+									 Class="flex-grow-1"
+									 Style="white-space:normal; overflow-wrap:break-word;">
 								<strong>@singleBaselineItemz.Name</strong>
 							</MudText>
-						</MudItem>
+                        <div class="d-flex align-top flex-shrink-0">
 
 						<!-- Right side: Up + Down buttons -->
-						<MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
 							@if (!IsIncluded)
 							{
 								<MudTooltip Text="Excluded from Baseline">
@@ -67,8 +68,8 @@
 										   Variant="Variant.Filled"
 										   Class="mud-rounded-circle"
 										   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineItemzId); })" />
-						</MudItem>
-					</MudGrid>
+						</div>
+					</div>
 				</MudCardContent>
 			</MudCard>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -39,11 +39,12 @@
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
 						<!-- Left side: Title -->
-							<MudText Typo="Typo.h5" Align="Align.Left"
-									 Class="flex-grow-1"
-									 Style="white-space:normal; overflow-wrap:break-word;">
-								<strong>@singleBaselineItemz.Name</strong>
-							</MudText>
+						<MudText Typo="Typo.inherit"
+								 Class="flex-grow-1 text-responsive-title"
+								 Align="Align.Left"
+								 Style="white-space:normal; overflow-wrap:break-word;">
+							<strong>@singleBaselineItemz.Name</strong>
+						</MudText>
                         <div class="d-flex align-top flex-shrink-0">
 
 						<!-- Right side: Up + Down buttons -->

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -86,25 +86,33 @@
                     </MudStack>
                     @if (!ViewSettings.IsKioskMode)
                     {
-                    <MudStack Row="true" Spacing="2">
-                        <MudText><strong>ID:</strong></MudText>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style=" display:flex;
+                            gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                            align-items:flex-start;
+                            flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                            flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                        <div style="display:flex; align-items:center; gap:6px;">
+
+                        <strong>ID:</strong>
                         <CopyableText TextToCopy="@_baselineItemz.Id.ToString()" DisplayLength="8" />
                         <MudTooltip Text="Show in Tree View">
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
-                        <MudText><strong> || Status      :</strong> @_baselineItemz.Status</MudText>
-                        <MudText><strong> || Priority    : </strong> @_baselineItemz.Priority</MudText>
-                        <MudText><strong> || Severity    : </strong> @_baselineItemz.Severity</MudText>
+                        </div>
+                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      :</strong> @_baselineItemz.Status</div>
+                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @_baselineItemz.Priority</div>
+                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @_baselineItemz.Severity</div>
                         @if (!string.IsNullOrEmpty(_baselineItemz.EstimationUnit))
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation [@_baselineItemz.EstimationUnit] : </b> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_baselineItemz.EstimationUnit] : </strong> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </div>
                         }
                         else
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation : </b> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </div>
                         }
-                    </MudStack>
-
+                        </div>
+                    </MudBreakpointProvider>
                     <br />
                     }
 
@@ -137,6 +145,8 @@
     private bool _needsRender = false;
 
     private List<string>? tagsList = new List<string>();
+    
+    private Breakpoint bp;
 
     protected override async Task OnParametersSetAsync()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -35,9 +35,9 @@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
-
-                        <MudText Typo="Typo.h5" Align="Align.Left"
-                                 Class="flex-grow-1"
+                        <MudText Typo="Typo.inherit"
+                                 Class="flex-grow-1 text-responsive-title"
+                                 Align="Align.Left"
                                  Style="white-space:normal; overflow-wrap:break-word;">
                             <strong>@_baselineItemz.Name</strong>
                         </MudText>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -34,14 +34,15 @@
             @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
-                    <MudGrid>
-                        <MudItem xs="12" sm="12" md="7" lg="7">
-                            <MudText Typo="Typo.h5" Align="Align.Left">
-                                <strong>@_baselineItemz.Name</strong>
-                            </MudText>
-                        </MudItem>
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
-                        <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                        <MudText Typo="Typo.h5" Align="Align.Left"
+                                 Class="flex-grow-1"
+                                 Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@_baselineItemz.Name</strong>
+                        </MudText>
+
+                        <div class="d-flex align-top flex-shrink-0">
                             @if (!IsIncluded)
                             {
                                 <MudTooltip Text="Excluded from Baseline">
@@ -49,22 +50,22 @@
                                 </MudTooltip>
                             }
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle me-2"
-                                           OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(BaselineItemzId); })" />
+                                            Color="Color.Success"
+                                            Size="Size.Medium"
+                                            IconSize="Size.Large"
+                                            Variant="Variant.Filled"
+                                            Class="mud-rounded-circle me-2"
+                                            OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(BaselineItemzId); })" />
 
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle"
-                                           OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineItemzId); })" />
-                        </MudItem>
-                    </MudGrid>
+                                            Color="Color.Success"
+                                            Size="Size.Medium"
+                                            IconSize="Size.Large"
+                                            Variant="Variant.Filled"
+                                            Class="mud-rounded-circle"
+                                            OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineItemzId); })" />
+                        </div>
+                    </div>
                 </MudCardContent>
             </MudCard>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
@@ -51,21 +51,31 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
-				<MudCardContent>
-				<MudItem Class="align-start d-flex" Style="width: auto" Outlined="false">
-					<MudGrid>
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleIBaselineItemzType.Name </strong></MudText>
-						</MudItem>
-						<MudItem xs="12" sm="12" md="5" lg="5">
-							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Justify="Justify.FlexEnd" Class="w-100">
-								<MudButton OnClick="async _ => await openBaselineTreeView(BaselineItemzTypeId)" Variant="@Variant.Filled" Size="@Size.Medium" Color="@Color.Success" Target="_blank"> TreeView </MudButton>
-								<MudButton OnClick="goBackToBaseline" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning" style="gap: 10px; margin-left : 10px"> Go Back </MudButton>
-							</MudStack>
-						</MudItem>
-					</MudGrid>
-				</MudItem>
-					</MudCardContent>
+				<MudCardContent Style="padding:6px">
+				 <div class="d-flex align-start justify-space-between" style="gap:8px;">
+					<MudText Typo="Typo.inherit"
+							Class="flex-grow-1 text-responsive-title"
+							Align="Align.Left">
+						<strong>@singleIBaselineItemzType.Name </strong>
+					</MudText>
+					<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
+					<MudButton OnClick="async _ => await openBaselineTreeView(BaselineItemzTypeId)" 
+						Variant="@Variant.Filled"
+						Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+						Color="@Color.Success" 
+						Target="_blank">
+						@(bp >= Breakpoint.Sm ? "Tree View" : "T")
+					</MudButton>
+					<MudButton OnClick="goBackToBaseline" 
+						Variant="Variant.Filled"
+						Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+						Color="Color.Warning" 
+						style="gap: 10px; margin-left : 10px">
+						@(bp >= Breakpoint.Sm ? "Go Back" : "<-")
+					</MudButton>
+					</div>
+				</div>
+				</MudCardContent>
 				</MudCard>
 				<MudCard>
 					<MudCardContent>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
@@ -70,17 +70,25 @@
 				<MudCard>
 					<MudCardContent>
 
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudStack Row="true" Spacing="2">
-							<MudText><strong>ID          : </strong></MudText>
+					<MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+						<div style="
+	                                display:flex;
+	                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+	                                align-items:flex-start;
+	                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+	                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+	                                ">
+							<div style="display:flex; align-items:center; gap:6px;">
+							<strong>ID : </strong>
 							<CopyableText TextToCopy="@singleIBaselineItemzType.Id.ToString()" DisplayLength="8" />
 							<GoToOriginalItemzTypeButton BaselineItemzTypeId="@singleIBaselineItemzType.Id" />
 							<ShowHierarchyTreeButton RecordId="@singleIBaselineItemzType.Id" />
-						</MudStack>
-						<MudText><strong> || Status      : </strong> @singleIBaselineItemzType.Status</MudText>
-						<MudText><strong> || Is System?  : </strong> @(singleIBaselineItemzType.IsSystem ? "Yes" : "No")</MudText>
-						|| <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" />
-					</MudStack>
+							</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleIBaselineItemzType.Status</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(singleIBaselineItemzType.IsSystem ? "Yes" : "No")</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" /></div>
+						</div>
+					</MudBreakpointProvider>
 
 @* 					<MudStack Row="true" Spacing="2">
 						<MudText><strong>ID           : </strong></MudText>
@@ -174,6 +182,8 @@
 	public bool initializingPage { get; set; } = true;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -92,8 +92,8 @@
 														 UseTreeView="true" />
 							<ShowHierarchyTreeButton RecordId="@singleBaselineItemzType.Id" />
 							</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Status      : </strong> @singleBaselineItemzType.Status</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemzType.Status</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</div>
 							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" /></div>
 						</div>
 					</MudBreakpointProvider>					}				

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -35,16 +35,18 @@
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent>
-					<MudGrid>
-						<!-- Left side: Title -->
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left">
-								<strong>@singleBaselineItemzType.Name</strong>
-							</MudText>
-						</MudItem>
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
+						<!-- Left side: Title -->
+
+						<MudText Typo="Typo.h5" Align="Align.Left"
+									Class="flex-grow-1"
+									Style="white-space:normal; overflow-wrap:break-word;">
+							<strong>@singleBaselineItemzType.Name</strong>
+						</MudText>
+
+                        <div class="d-flex align-top flex-shrink-0">
 						<!-- Right side: Up + Down buttons -->
-						<MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
 							<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
 										   Color="Color.Success"
 										   Size="Size.Medium"
@@ -60,8 +62,8 @@
 										   Variant="Variant.Filled"
 										   Class="mud-rounded-circle"
 										   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineItemzTypeId); })" />
-						</MudItem>
-					</MudGrid>
+						</div>
+					</div>
 				</MudCardContent>
 			</MudCard>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -38,10 +38,10 @@
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
 						<!-- Left side: Title -->
-
-						<MudText Typo="Typo.h5" Align="Align.Left"
-									Class="flex-grow-1"
-									Style="white-space:normal; overflow-wrap:break-word;">
+						<MudText Typo="Typo.inherit"
+								 Class="flex-grow-1 text-responsive-title"
+								 Align="Align.Left"
+								 Style="white-space:normal; overflow-wrap:break-word;">
 							<strong>@singleBaselineItemzType.Name</strong>
 						</MudText>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -71,9 +71,16 @@
 				<MudCardContent>
 					@if (!ViewSettings.IsKioskMode)
 					{
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudStack Row="true" Spacing="2">
-							<MudText><strong>ID          : </strong></MudText>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style="
+                                    display:flex;
+                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                    align-items:flex-start;
+                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                    ">
+							<div style="display:flex; align-items:center; gap:6px;">
+							<strong>ID :</strong>
 							<CopyableText TextToCopy="@singleBaselineItemzType.Id.ToString()" DisplayLength="8" />
 							<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
 								<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small"
@@ -84,12 +91,12 @@
 							<GoToOriginalItemzTypeButton BaselineItemzTypeId="@singleBaselineItemzType.Id"
 														 UseTreeView="true" />
 							<ShowHierarchyTreeButton RecordId="@singleBaselineItemzType.Id" />
-						</MudStack>
-						<MudText><strong> || Status      : </strong> @singleBaselineItemzType.Status</MudText>
-						<MudText><strong> || Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</MudText>
-						|| <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" />
-					</MudStack>
-					}				
+							</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Status      : </strong> @singleBaselineItemzType.Status</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" /></div>
+						</div>
+					</MudBreakpointProvider>					}				
 					<br />
 					<div class="custom-markdown-editor">
 						@if (!string.IsNullOrEmpty(singleBaselineItemzType.Description))
@@ -132,6 +139,8 @@
 	public bool _showOverlay { get; set; } = false;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -64,27 +64,33 @@
                 <MudCardContent>
                     @if (!ViewSettings.IsKioskMode)
                     {
-                    <MudStack Row="true" Spacing="2">
-                        <MudText><strong>ID:</strong></MudText>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style=" display:flex;
+                            gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                            align-items:flex-start;
+                            flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                            flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                        <div style="display:flex; align-items:center; gap:6px;">
+                        <strong>ID:</strong>
                         <CopyableText TextToCopy="@_baselineItemzType.Id.ToString()" DisplayLength="8" />
                         <MudTooltip Text="Show in Tree View">
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
-                        <MudText><strong> || Status:</strong> @_baselineItemzType.Status</MudText>
-                        <MudText><strong> || Is System?  : </strong> @(_baselineItemzType.IsSystem ? "Yes" : "No")</MudText>
+                        </div>
+                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status:</strong> @_baselineItemzType.Status</div>
+                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(_baselineItemzType.IsSystem ? "Yes" : "No")</div>
                         @if (!string.IsNullOrEmpty(_baselineItemzType.EstimationUnit))
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation [@_baselineItemzType.EstimationUnit] : </b> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "")Estimation [@_baselineItemzType.EstimationUnit] : </strong> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </div>
                         }
                         else
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation : </b> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </div>
                         }
-                    </MudStack>
+                        </div>
+                    </MudBreakpointProvider>
                     }
-
                     <br />
-
                     @if (!string.IsNullOrEmpty(_baselineItemzType.Description))
                     {
                         <div class="markdown-body">@((MarkupString)_convertedMarkdown)</div>
@@ -104,6 +110,8 @@
     private GetBaselineItemzTypeExportDTO _baselineItemzType = new();
     private MarkupString _convertedMarkdown;
     private bool _needsRender = false;
+
+    private Breakpoint bp;
 
     protected override async Task OnParametersSetAsync()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -34,12 +34,12 @@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
-
-                            <MudText Typo="Typo.h5" Align="Align.Left"
-                                     Class="flex-grow-1"
-                                     Style="white-space:normal; overflow-wrap:break-word;">
-                                <strong>@_baselineItemzType.Name</strong>
-                            </MudText>
+                        <MudText Typo="Typo.inherit"
+                                 Class="flex-grow-1 text-responsive-title"
+                                 Align="Align.Left"
+                                 Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@_baselineItemzType.Name</strong>
+                        </MudText>
                         <div class="d-flex align-top flex-shrink-0">
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
                                            Color="Color.Success"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -33,13 +33,14 @@
             @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
-                    <MudGrid>
-                        <MudItem xs="12" sm="12" md="7" lg="7">
-                            <MudText Typo="Typo.h5" Align="Align.Left">
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+
+                            <MudText Typo="Typo.h5" Align="Align.Left"
+                                     Class="flex-grow-1"
+                                     Style="white-space:normal; overflow-wrap:break-word;">
                                 <strong>@_baselineItemzType.Name</strong>
                             </MudText>
-                        </MudItem>
-                        <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                        <div class="d-flex align-top flex-shrink-0">
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
                                            Color="Color.Success"
                                            Size="Size.Medium"
@@ -55,8 +56,8 @@
                                            Variant="Variant.Filled"
                                            Class="mud-rounded-circle"
                                            OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(BaselineItemzTypeId); })" />
-                        </MudItem>
-                    </MudGrid>
+                        </div>
+                    </div>
                 </MudCardContent>
             </MudCard>
             <MudCard Elevation="0" Style="background-color:transparent;">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -77,33 +77,27 @@
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
 				<MudCardContent>
-				<MudItem Class="align-start d-flex" Style="width: auto" Outlined="false">
-					<MudGrid>
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleItemz.Name </strong></MudText>
-						</MudItem>
-						<MudItem xs="12" sm="12" md="5" lg="5">
-							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Justify="Justify.FlexEnd" Class="w-100">
-								<MudButton OnClick="async _ => await editItemzDetails(ItemzId.ToString())"
-											Variant="Variant.Filled"
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+						<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleItemz.Name </strong></MudText>
+							<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
+							<MudButton OnClick="async _ => await editItemzDetails(ItemzId.ToString())"
+										Variant="Variant.Filled"
+										Size="Size.Medium"
+										Color="Color.Success">
+								Edit Itemz
+							</MudButton>
+							@if (!(breadcrumsService.RequestIsOrphanStatus()))
+							{
+								<MudButton Variant="Variant.Filled"
 											Size="Size.Medium"
-											Color="Color.Success">
-									Edit Itemz
+											Color="Color.Success"
+											OnClick="(() => HandleGoToTreeView())">
+									TREE VIEW
 								</MudButton>
-								@if (!(breadcrumsService.RequestIsOrphanStatus()))
-								{
-									<MudButton Variant="Variant.Filled"
-												Size="Size.Medium"
-												Color="Color.Success"
-												OnClick="(() => HandleGoToTreeView())">
-										TREE VIEW
-									</MudButton>
-								}
-								<MudButton OnClick="goBackToParent" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning"> Go Back </MudButton>
-							</MudStack>
-						</MudItem>
-					</MudGrid>
-				</MudItem>
+							}
+							<MudButton OnClick="goBackToParent" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning"> Go Back </MudButton>
+						</div>
+					</div>
 					@*<MudDivider Style="color: darkgray background-color: white; border-width: 2px; border-color: black; height: 2px; " /> *@
 				</MudCardContent>
 			</MudCard>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -76,29 +76,37 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
-				<MudCardContent>
+				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
-						<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleItemz.Name </strong></MudText>
-							<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
-							<MudButton OnClick="async _ => await editItemzDetails(ItemzId.ToString())"
-										Variant="Variant.Filled"
-										Size="Size.Medium"
-										Color="Color.Success">
-								Edit Itemz
+						<MudText Typo="Typo.inherit"
+								Class="flex-grow-1 text-responsive-title"
+								Align="Align.Left">
+							<strong>@singleItemz.Name </strong>
+						</MudText>
+						<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
+						<MudButton OnClick="async _ => await editItemzDetails(ItemzId.ToString())"
+							Variant="Variant.Filled"
+							Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+							Color="Color.Success">
+							@(bp >= Breakpoint.Sm ? "Edit Itemz" : "E")
+						</MudButton>
+						@if (!(breadcrumsService.RequestIsOrphanStatus()))
+						{
+							<MudButton Variant="Variant.Filled"
+								Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+								Color="Color.Success"
+								OnClick="(() => HandleGoToTreeView())">
+								@(bp >= Breakpoint.Sm ? "Tree View" : "T")
 							</MudButton>
-							@if (!(breadcrumsService.RequestIsOrphanStatus()))
-							{
-								<MudButton Variant="Variant.Filled"
-											Size="Size.Medium"
-											Color="Color.Success"
-											OnClick="(() => HandleGoToTreeView())">
-									TREE VIEW
-								</MudButton>
-							}
-							<MudButton OnClick="goBackToParent" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning"> Go Back </MudButton>
+						}
+						<MudButton OnClick="goBackToParent" 
+							Variant="Variant.Filled"
+							Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+							Color="Color.Warning">
+							@(bp >= Breakpoint.Sm ? "Go Back" : "<-")
+						</MudButton>
 						</div>
 					</div>
-					@*<MudDivider Style="color: darkgray background-color: white; border-width: 2px; border-color: black; height: 2px; " /> *@
 				</MudCardContent>
 			</MudCard>
 			<MudCard>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -122,18 +122,24 @@
 							}
 						</MudChipSet>
 					</MudStack>
-
-				<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-					<MudStack Row="true" Spacing="2">
-						<MudText><strong>ID          : </strong></MudText>
-						<CopyableText TextToCopy="@singleItemz.Id.ToString()" DisplayLength="8" />
-						<ShowHierarchyTreeButton RecordId="@singleItemz.Id" />
-					</MudStack>
-					<MudText><strong> || Status      : </strong> @singleItemz.Status</MudText>
-					<MudText><strong> || Priority    : </strong> @singleItemz.Priority</MudText>
-					<MudText><strong> || Severity    : </strong> @singleItemz.Severity</MudText>
-					|| <EstimationReadOnlyComponent RecordId="@ItemzId" />
-				</MudStack>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style="
+                                    display:flex;
+                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                    align-items:flex-start;
+                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                    ">
+                            <div style="display:flex; align-items:center; gap:6px;">						<strong>ID : </strong>
+								<CopyableText TextToCopy="@singleItemz.Id.ToString()" DisplayLength="8" />
+								<ShowHierarchyTreeButton RecordId="@singleItemz.Id" />
+							</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleItemz.Status</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @singleItemz.Priority</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @singleItemz.Severity</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzId" /> </div>
+						</div>
+					</MudBreakpointProvider>
 					<MudText><strong>Description : </strong></MudText>
 					<br />
 					<div class="custom-markdown-editor">
@@ -247,6 +253,7 @@
 
 	private List<string>? tagsList = new List<string>();
 
+	private Breakpoint bp;
 
 	protected override async Task OnInitializedAsync()
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -49,7 +49,7 @@
                         </MudText>
 
                         <!-- Buttons -->
-                        <div class="d-flex align-center flex-shrink-0">
+                        <div class="d-flex align-top flex-shrink-0">
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
                                            Color="Color.Success"
                                            Size="Size.Medium"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -36,17 +36,20 @@
         <MudItem xs="12" sm="12">
             <!-- Title Card made sticky -->
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-                <MudCardContent Style="padding : 6px">
-                    <MudGrid>
-                        <!-- Left side: Title -->
-                        <MudItem xs="12" sm="12" md="7" lg="7">
-                            <MudText Typo="Typo.h5" Align="Align.Left">
-                                <strong>@singleItemz.Name</strong>
-                            </MudText>
-                        </MudItem>
+                <MudCardContent Style="padding:6px">
 
-                        <!-- Right side: Circular Icon Buttons -->
-                        <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+
+                        <!-- Title -->
+                        <MudText Typo="Typo.h5"
+                                 Align="Align.Left"
+                                 Class="flex-grow-1"
+                                 Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@singleItemz.Name</strong>
+                        </MudText>
+
+                        <!-- Buttons -->
+                        <div class="d-flex align-center flex-shrink-0">
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
                                            Color="Color.Success"
                                            Size="Size.Medium"
@@ -62,11 +65,16 @@
                                            Variant="Variant.Filled"
                                            Class="mud-rounded-circle"
                                            OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzId); })" />
+                        </div>
 
-                        </MudItem>
-                    </MudGrid>
+                    </div>
+
                 </MudCardContent>
             </MudCard>
+
+
+
+
 
             <!-- Scrollable Content -->
             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 200px);">
@@ -131,6 +139,11 @@
 		</MudOverlay>
 	</MudPaper>
 }
+<script>
+    .no-wrap-grid {
+        flex-wrap: nowrap;
+    }
+</script>
 @code {
 	[Parameter]
 	public Guid ItemzId { get; set; }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -41,9 +41,9 @@
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
                         <!-- Title -->
-                        <MudText Typo="Typo.h5"
+                        <MudText Typo="Typo.inherit"
+                                 Class="flex-grow-1 text-responsive-title"
                                  Align="Align.Left"
-                                 Class="flex-grow-1"
                                  Style="white-space:normal; overflow-wrap:break-word;">
                             <strong>@singleItemz.Name</strong>
                         </MudText>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -97,20 +97,32 @@
                     }
                     @if (!ViewSettings.IsKioskMode)
                     {
-                        <MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-                            <MudStack Row="true" Spacing="2">
-                            <MudText><strong>ID          : </strong></MudText>
-                            <CopyableText TextToCopy="@singleItemz.Id.ToString()" DisplayLength="8" />
-                            <MudTooltip Text="Show in Tree View" Placement="Placement.Top">
-                                <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
-                            </MudTooltip>
-                            <ShowHierarchyTreeButton RecordId="@singleItemz.Id" />
-                        </MudStack>
-                        <MudText><strong> || Status      : </strong> @singleItemz.Status</MudText>
-                        <MudText><strong> || Priority    : </strong> @singleItemz.Priority</MudText>
-                        <MudText><strong> || Severity    : </strong> @singleItemz.Severity</MudText>
-						|| <EstimationReadOnlyComponent RecordId="@ItemzId" />
-                    </MudStack>
+                        <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                            <div style="
+                                        display:flex;
+                                        gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                        align-items:flex-start;
+                                        flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                        flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                        ">
+                                <div style="display:flex; align-items:center; gap:6px;">
+                                    <strong>ID :</strong>
+                                    <CopyableText TextToCopy="@singleItemz.Id.ToString()" DisplayLength="8" />
+
+                                    <MudTooltip Text="Show in Tree View" Placement="Placement.Top">
+                                        <MudIcon Icon="@Icons.Material.Filled.Park"
+                                                 Size="Size.Small"
+                                                 Class="mouse-pointer-icon"
+                                                 @onclick="findAndShowInTreeView" />
+                                    </MudTooltip>
+                                    <ShowHierarchyTreeButton RecordId="@singleItemz.Id" />
+                                </div>
+                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status :</strong> @singleItemz.Status</div>
+                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority :</strong> @singleItemz.Priority</div>
+                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity :</strong> @singleItemz.Severity</div>
+                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzId" /></div>
+                            </div>
+                        </MudBreakpointProvider>
                     }
                     <br />
                     <div class="custom-markdown-editor">
@@ -161,6 +173,8 @@
 	private MarkupString convertedMarkdown;
 
     private List<string>? tagsList = new List<string>();
+
+    private Breakpoint bp;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -86,26 +86,32 @@
                     }
                     @if (!ViewSettings.IsKioskMode)
                     {
-                        <MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-                            <MudStack Row="true" Spacing="2">
-                            <MudText><strong>ID          : </strong></MudText>
-                            <CopyableText TextToCopy="@_itemz.Id.ToString()" DisplayLength="8" />
-                            <MudTooltip Text="Show in Tree View">
-                                <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
-                            </MudTooltip>
-                        </MudStack>
-                        <MudText><strong> || Status      : </strong> @_itemz.Status</MudText>
-                        <MudText><strong> || Priority    : </strong> @_itemz.Priority</MudText>
-                        <MudText><strong> || Severity    : </strong> @_itemz.Severity</MudText>
-                        @if (!string.IsNullOrEmpty(_itemz.EstimationUnit))
-                        {
-                            <MudText Variant="Variant.H6">|| <b>Estimation [@_itemz.EstimationUnit] : </b> @_itemz.OwnEstimation <b>|| Roll-Up</b> :@_itemz.RolledUpEstimation </MudText>
-                        }
-                        else
-                        {
-                            <MudText Variant="Variant.H6">|| <b>Estimation : </b> @_itemz.OwnEstimation <b>|| Roll-Up</b> :@_itemz.RolledUpEstimation </MudText>
-                        }
-                    </MudStack>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style=" display:flex;
+                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                align-items:flex-start;
+                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                            <div style="display:flex; align-items:center; gap:6px;">
+                                <strong>ID : </strong>
+                                <CopyableText TextToCopy="@_itemz.Id.ToString()" DisplayLength="8" />
+                                <MudTooltip Text="Show in Tree View">
+                                    <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
+                                </MudTooltip>
+                            </div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_itemz.Status</div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Priority    : </strong> @_itemz.Priority</div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Severity    : </strong> @_itemz.Severity</div>
+                            @if (!string.IsNullOrEmpty(_itemz.EstimationUnit))
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemz.EstimationUnit] : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
+                            }
+                            else
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
+                            }
+                        </div>
+                    </MudBreakpointProvider>
                     <br />
                      }
                     <div class="custom-markdown-editor">
@@ -138,6 +144,7 @@
 
     private bool _needsRender = false;
 
+    private Breakpoint bp;
 
     protected override async Task OnParametersSetAsync()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -34,14 +34,16 @@
         <MudItem xs="12" sm="12">
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent Style="padding : 6px">
-                    <MudGrid>
-                        <MudItem xs="12" sm="12" md="7" lg="7">
-                            <MudText Typo="Typo.h5" Align="Align.Left">
-                                <strong>@_itemz.Name</strong>
-                            </MudText>
-                        </MudItem>
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
-                        <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                        <MudText Typo="Typo.h5" Align="Align.Left" 
+                                 Class="flex-grow-1"
+                                 Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@_itemz.Name</strong>
+                        </MudText>
+
+                        <div class="d-flex align-top flex-shrink-0">
+
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
                                            Color="Color.Success"
                                            Size="Size.Medium"
@@ -57,8 +59,8 @@
                                            Variant="Variant.Filled"
                                            Class="mud-rounded-circle"
                                            OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzId); })" />
-                        </MudItem>
-                    </MudGrid>
+                        </div>
+                    </div>
                 </MudCardContent>
             </MudCard>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -36,11 +36,13 @@
                 <MudCardContent Style="padding : 6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
-                        <MudText Typo="Typo.h5" Align="Align.Left" 
-                                 Class="flex-grow-1"
+                        <MudText Typo="Typo.inherit"
+                                 Class="flex-grow-1 text-responsive-title"
+                                 Align="Align.Left"
                                  Style="white-space:normal; overflow-wrap:break-word;">
                             <strong>@_itemz.Name</strong>
                         </MudText>
+
 
                         <div class="d-flex align-top flex-shrink-0">
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
@@ -51,30 +51,37 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
-				<MudCardContent>
-				<MudItem Class="align-start d-flex" Style="width: auto" Outlined="false">
-					<MudGrid>
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleItemzType.Name </strong></MudText>
-						</MudItem>
-						<MudItem xs="12" sm="12" md="5" lg="5">
-							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Justify="Justify.FlexEnd" Class="w-100">
-								<MudButton OnClick="async _ => await editItemzTypeDetails(ItemzTypeId.ToString())" Variant="Variant.Filled" Disabled="singleItemzType.IsSystem" Size="Size.Medium" Color="Color.Success"> Edit ItemzType </MudButton>
+				<MudCardContent Style="padding:6px">
+					<div class="d-flex align-start justify-space-between" style="gap:8px;">
+						<MudText Typo="Typo.inherit"
+								 Class="flex-grow-1 text-responsive-title"
+								 Align="Align.Left">
+							<strong>@singleItemzType.Name </strong>
+						</MudText>
+						<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
+							<MudButton OnClick="async _ => await editItemzTypeDetails(ItemzTypeId.ToString())" 
+								Variant="Variant.Filled" 
+								Disabled="singleItemzType.IsSystem"
+								Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+								Color="Color.Success">
+								@(bp >= Breakpoint.Sm ? "Edit ItemzType" : "E")
+							</MudButton>
 								@if (!(breadcrumsService.RequestIsOrphanStatus()))
 								{
 									<MudButton Variant="Variant.Filled"
-												Size="Size.Medium"
-												Color="Color.Success"
-												OnClick="(() => HandleGoToTreeView())">
-										TREE VIEW
+										Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+										Color="Color.Success"
+										OnClick="(() => HandleGoToTreeView())">
+										@(bp >= Breakpoint.Sm ? "Tree View" : "T")
 									</MudButton>
 								}
-								<MudButton OnClick="goBackToProject" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning"> Go Back </MudButton>
-							</MudStack>
-						</MudItem>
-					</MudGrid>
-				</MudItem>
-			@*<MudDivider Style="color: darkgray background-color: white; border-width: 2px; border-color: black; height: 2px; " /> *@
+								<MudButton OnClick="goBackToProject" Variant="Variant.Filled"
+									Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+									Color="Color.Warning">
+									@(bp >= Breakpoint.Sm ? "Go Back" : "<-")
+								</MudButton>
+						</div>
+					</div>
 				</MudCardContent>
 			</MudCard>
 			<MudCard>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
@@ -79,12 +79,23 @@
 			</MudCard>
 			<MudCard>
 				<MudCardContent>
-				<MudStack Row="true" Spacing="2">
-					<MudText><strong>ID          : </strong></MudText>
-					<CopyableText TextToCopy="@singleItemzType.Id.ToString()" DisplayLength="8" />
-					<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
-					|| <EstimationReadOnlyComponent RecordId="@ItemzTypeId" />
-				</MudStack>
+                <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                    <div style="
+                                display:flex;
+                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                align-items:flex-start;
+                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                ">
+                        <div style="display:flex; align-items:center; gap:6px;">
+							<strong>ID : </strong>
+							<CopyableText TextToCopy="@singleItemzType.Id.ToString()" DisplayLength="8" />
+							<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
+						</div>
+						<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzTypeId" /> </div>
+                    </div>
+                </MudBreakpointProvider>
+
 				<MudText><strong>Status      : </strong> @singleItemzType.Status</MudText>
 				<MudText><strong>Description : </strong> </MudText>
 					<br />
@@ -185,6 +196,8 @@
 	public bool _showOverlay { get; set; } = false;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnInitializedAsync()
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -78,20 +78,27 @@
 
 					@if (!ViewSettings.IsKioskMode)
 					{
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudStack Row="true" Spacing="2">
-							<MudText><strong>ID          : </strong></MudText>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style="
+                                    display:flex;
+                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                    align-items:flex-start;
+                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                    ">
+							<div style="display:flex; align-items:center; gap:6px;">
+							<strong>ID : </strong>
 							<CopyableText TextToCopy="@singleItemzType.Id.ToString()" DisplayLength="8" />
 							<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
 								<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
 							</MudTooltip>
 							<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
-						</MudStack>
-						<MudText><strong> || Status      : </strong> @singleItemzType.Status</MudText>
-						|| <EstimationReadOnlyComponent RecordId="@ItemzTypeId" />
-					</MudStack>
+							</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Status : </strong> @singleItemzType.Status</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzTypeId" /> </div>
+						</div>
+					</MudBreakpointProvider>
 					}
-
 					<br />
 					<div class="custom-markdown-editor">
 						@if (!string.IsNullOrEmpty(singleItemzType.Description))
@@ -132,6 +139,8 @@
 	public bool _showOverlay { get; set; } = false;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -34,16 +34,18 @@
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent Style="padding : 6px">
-					<MudGrid>
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<!-- Left side: Title -->
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left">
+							<MudText Typo="Typo.h5" Align="Align.Left"
+								 Class="flex-grow-1"
+								 Style="white-space:normal; overflow-wrap:break-word;">
 								<strong>@singleItemzType.Name</strong>
 							</MudText>
-						</MudItem>
+						
 
 						<!-- Right side: Circular Icon Buttons -->
-						<MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                        <div class="d-flex align-top flex-shrink-0">
+
 							<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
 										   Color="Color.Success"
 										   Size="Size.Medium"
@@ -59,8 +61,8 @@
 										   Variant="Variant.Filled"
 										   Class="mud-rounded-circle"
 										   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzTypeId); })" />
-						</MudItem>
-					</MudGrid>
+						</div>
+					</div>
 				</MudCardContent>
 			</MudCard>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -36,12 +36,12 @@
 				<MudCardContent Style="padding : 6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<!-- Left side: Title -->
-							<MudText Typo="Typo.h5" Align="Align.Left"
-								 Class="flex-grow-1"
+						<MudText Typo="Typo.inherit"
+								 Class="flex-grow-1 text-responsive-title"
+								 Align="Align.Left"
 								 Style="white-space:normal; overflow-wrap:break-word;">
-								<strong>@singleItemzType.Name</strong>
-							</MudText>
-						
+							<strong>@singleItemzType.Name</strong>
+						</MudText>
 
 						<!-- Right side: Circular Icon Buttons -->
                         <div class="d-flex align-top flex-shrink-0">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -68,14 +68,6 @@
 
 			<MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
 				<MudCardContent Style="padding : 6px">
-@* 					<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-						<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
-							<MudText><strong>ID :</strong></MudText>
-							<CopyableText TextToCopy="@singleItemzType.Id.ToString()" />
-						</MudStack>
-						<MudText><strong>Status :</strong> @singleItemzType.Status</MudText>
-					</MudStack> *@
-
 					@if (!ViewSettings.IsKioskMode)
 					{
                     <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
@@ -117,8 +109,6 @@
 	<MudPaper Height="calc(100vh - 100px);" Width="100%">
 		<MudOverlay Visible="@_showOverlay" DarkBackground="true" Absolute="true">
 			<MudContainer Class="d-flex flex-column justify-center align-center" Style="height: 100%;">
-				@* <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Moving ... </MudText>
-			<br /> *@
 				<MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
 			</MudContainer>
 		</MudOverlay>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -31,32 +31,32 @@
         <MudItem xs="12" sm="12">
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
-                    <MudGrid>
-                        <MudItem xs="12" sm="12" md="7" lg="7">
-                            <MudText Typo="Typo.h5" Align="Align.Left">
-                                <strong>@_itemzType.Name</strong>
-                            </MudText>
-                        </MudItem>
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                    <MudText Typo="Typo.h5" Align="Align.Left"
+                            Class="flex-grow-1"
+                            Style="white-space:normal; overflow-wrap:break-word;">
+                        <strong>@_itemzType.Name</strong>
+                    </MudText>
 
-                        <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
-                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle me-2"
-                                           OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzTypeId); })" />
+                    <div class="d-flex align-top flex-shrink-0">
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
+                                        Color="Color.Success"
+                                        Size="Size.Medium"
+                                        IconSize="Size.Large"
+                                        Variant="Variant.Filled"
+                                        Class="mud-rounded-circle me-2"
+                                        OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzTypeId); })" />
 
-                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle"
-                                           OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzTypeId); })" />
-                        </MudItem>
-                    </MudGrid>
-                </MudCardContent>
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+                                        Color="Color.Success"
+                                        Size="Size.Medium"
+                                        IconSize="Size.Large"
+                                        Variant="Variant.Filled"
+                                        Class="mud-rounded-circle"
+                                        OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzTypeId); })" />
+                        </div>
+                    </div>                
+                 </MudCardContent>
             </MudCard>
 
             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -63,24 +63,30 @@
                 <MudCardContent>
                 @if (!ViewSettings.IsKioskMode)
                 {
-                    <MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-                        <MudStack Row="true" Spacing="2">
-                        <MudText><strong>ID          : </strong></MudText>
+                <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                    <div style=" display:flex;
+                            gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                            align-items:flex-start;
+                            flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                            flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                        <div style="display:flex; align-items:center; gap:6px;">
+                        <strong>ID : </strong>
                         <CopyableText TextToCopy="@_itemzType.Id.ToString()" DisplayLength="8" />
                         <MudTooltip Text="Show in Tree View">
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
-                    </MudStack>
-                    <MudText><strong> || Status      : </strong> @_itemzType.Status</MudText> 
+                        </div>
+                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status : </strong> @_itemzType.Status</div>
                     @if (!string.IsNullOrEmpty(_itemzType.EstimationUnit))
                     {
-                        <MudText Variant="Variant.H6">|| <b>Estimation [@_itemzType.EstimationUnit] : </b> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </MudText>
+                        <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemzType.EstimationUnit] : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
                     }
                     else
                     {
-                        <MudText Variant="Variant.H6">|| <b>Estimation : </b> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </MudText>
+                        <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
                     }
-                </MudStack>
+                    </div>
+                </MudBreakpointProvider>
                 <br />
                     }
                     <div class="custom-markdown-editor">
@@ -106,6 +112,7 @@
     private MarkupString _convertedMarkdown;
     private bool _needsRender = false;
 
+    private Breakpoint bp;
 
     protected override async Task OnParametersSetAsync()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -32,12 +32,12 @@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
-                    <MudText Typo="Typo.h5" Align="Align.Left"
-                            Class="flex-grow-1"
-                            Style="white-space:normal; overflow-wrap:break-word;">
+                    <MudText Typo="Typo.inherit"
+                                Class="flex-grow-1 text-responsive-title"
+                                Align="Align.Left"
+                                Style="white-space:normal; overflow-wrap:break-word;">
                         <strong>@_itemzType.Name</strong>
                     </MudText>
-
                     <div class="d-flex align-top flex-shrink-0">
                         <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
                                         Color="Color.Success"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -39,21 +39,37 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
-				<MudCardContent>
-				<MudItem Class="align-start d-flex" Style="width: auto" Outlined="false">
-					<MudGrid>
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleProject.Name </strong></MudText>
-						</MudItem>
-						<MudItem xs="12" sm="12" md="5" lg="5">
-							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Justify="Justify.FlexEnd" Class="w-100">
-								<MudButton OnClick="async _ => await editProjectDetails(ProjectId.ToString())" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Success"> Edit Project </MudButton>
-								<MudButton OnClick="async _ => await openProjectTreeView(singleProject.Id.ToString())" Variant="@Variant.Filled" Size="@Size.Medium" Color="@Color.Success" Target="_blank" style="gap: 10px; margin-left : 10px"> TreeView </MudButton>
-								<MudButton OnClick="goBackToProjects" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Warning" style="gap: 10px; margin-left : 10px"> Go Back </MudButton>
-							</MudStack>
-						</MudItem>
-					</MudGrid>
-				</MudItem>
+				<MudCardContent Style="padding:6px">
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+						<MudText Typo="Typo.inherit"
+								 Class="flex-grow-1 text-responsive-title"
+								 Align="Align.Left">
+								<strong>@singleProject.Name </strong>
+						</MudText>
+						<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
+							<MudButton OnClick="async _ => await editProjectDetails(ProjectId.ToString())" 
+								Variant="Variant.Filled"
+								Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+								Color="Color.Success"> 
+								@(bp >= Breakpoint.Sm ? "Edit Project" : "E")
+							</MudButton>
+							<MudButton OnClick="async _ => await openProjectTreeView(singleProject.Id.ToString())" 
+								Variant="@Variant.Filled"
+								Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+								Color="@Color.Success" 
+								Target="_blank" 
+								style="gap: 10px; margin-left : 10px">
+								@(bp >= Breakpoint.Sm ? "Tree View" : "T")
+							</MudButton>
+							<MudButton OnClick="goBackToProjects" 
+								Variant="Variant.Filled"
+								Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
+								Color="Color.Warning" 
+								style="gap: 10px; margin-left : 10px">
+								@(bp >= Breakpoint.Sm ? "Go Back" : "<-")
+							</MudButton>
+						</div>
+					</div>
 				</MudCardContent>
 				</MudCard>
 				<MudCard >

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -59,11 +59,21 @@
 				<MudCard >
 					<MudCardContent>
 						<MudText><strong> </strong> </MudText>
-						<MudStack Row="true" Spacing="2">
-						<MudText><strong>ID          : </strong></MudText>
-						<CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
-						|| <EstimationReadOnlyComponent RecordId="@ProjectId" />
-						</MudStack>
+                        <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                            <div style="
+                                        display:flex;
+                                        gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                        align-items:flex-start;
+                                        flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                        flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                        ">
+                                <div style="display:flex; align-items:center; gap:6px;">
+									<strong>ID : </strong>
+									<CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
+								</div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ProjectId" /></div>
+                            </div>
+                        </MudBreakpointProvider>
 						<MudText><strong>Status      : </strong> @singleProject.Status 	</MudText>
 						<MudText><strong>Description : </strong> </MudText> 
 						<br />
@@ -153,6 +163,8 @@
 	public bool _showOverlay { get; set; } = false;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -72,17 +72,25 @@
 					</MudStack> *@
 					@if (!ViewSettings.IsKioskMode)
 					{
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudStack Row="true" Spacing="2">
-							<MudText><strong>ID          : </strong></MudText>
-							<CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
-							<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
-								<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
-							</MudTooltip>
-						</MudStack>
-						<MudText><strong> || Status      : </strong> @singleProject.Status </MudText>
-						|| <EstimationReadOnlyComponent RecordId="@ProjectId" />
-					</MudStack>
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style="
+                                    display:flex;
+                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                    align-items:flex-start;
+                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                    ">
+                            <div style="display:flex; align-items:center; gap:6px;">
+								<strong>ID : </strong>
+								<CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
+								<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
+									<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
+								</MudTooltip>
+							</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleProject.Status </div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong>  <EstimationReadOnlyComponent RecordId="@ProjectId" /> </div>
+						</div>
+					</MudBreakpointProvider>
 					}
 
 					<br />
@@ -124,6 +132,8 @@
 	public bool _showOverlay { get; set; } = false;
 
 	private MarkupString convertedMarkdown;
+
+	private Breakpoint bp;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -34,13 +34,16 @@
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent>
-					<MudGrid>
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+
 						<!-- Left side: Title -->
-						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left">
-								<strong>@singleProject.Name</strong>
+							<MudText Typo="Typo.h5" Align="Align.Left"
+								 Class="flex-grow-1"
+								 Style="white-space:normal; overflow-wrap:break-word;">
+							<strong>@singleProject.Name</strong>
 							</MudText>
-						</MudItem>
+
+                        <div class="d-flex align-top flex-shrink-0">
 
 						<!-- Right side: Only Down button -->
 						<MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
@@ -52,7 +55,8 @@
 										   Class="mud-rounded-circle"
 										   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
 						</MudItem>
-					</MudGrid>
+						</div>
+					</div>
 				</MudCardContent>
 			</MudCard>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -38,7 +38,6 @@
 
 						<!-- Left side: Title -->
 						<MudText Typo="Typo.inherit"
-						<MudText Typo="Typo.inherit"
 								 Class="flex-grow-1 text-responsive-title"
 								 Align="Align.Left"
 								 Style="white-space:normal; overflow-wrap:break-word;">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -37,13 +37,15 @@
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
 						<!-- Left side: Title -->
-							<MudText Typo="Typo.h5" Align="Align.Left"
-								 Class="flex-grow-1"
+						<MudText Typo="Typo.inherit"
+						<MudText Typo="Typo.inherit"
+								 Class="flex-grow-1 text-responsive-title"
+								 Align="Align.Left"
 								 Style="white-space:normal; overflow-wrap:break-word;">
 							<strong>@singleProject.Name</strong>
-							</MudText>
+						</MudText>
 
-                        <div class="d-flex align-top flex-shrink-0">
+						<div class="d-flex align-top flex-shrink-0">
 
 						<!-- Right side: Only Down button -->
 						<MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -33,11 +33,12 @@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
-                            <MudText Typo="Typo.h5" Align="Align.Left"
-                                 Class="flex-grow-1"
-                                 Style="white-space:normal; overflow-wrap:break-word;"> 
-                                <strong>@_project.Name</strong>
-                            </MudText>
+                        <MudText Typo="Typo.inherit"
+                                 Class="flex-grow-1 text-responsive-title"
+                                 Align="Align.Left"
+                                 Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@_project.Name</strong>
+                        </MudText>
                         <div class="d-flex align-top flex-shrink-0">
 
                         <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -59,24 +59,34 @@
                 <MudCardContent>
                     @if (!ViewSettings.IsKioskMode)
                     {
-                    <MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-                        <MudStack Row="true" Spacing="2">
-                        <MudText><strong>ID          : </strong></MudText>
-                        <CopyableText TextToCopy="@_project.Id.ToString()" DisplayLength="8" />
-                        <MudTooltip Text="Show in Tree View">
-                            <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
-                        </MudTooltip>
-                        </MudStack>
-                        <MudText><strong> || Status      : </strong> @_project.Status</MudText>
+                    
+                        
+                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                        <div style=" display:flex;
+                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                align-items:flex-start;
+                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                            <div style="display:flex; align-items:center; gap:6px;">
+                                <strong>ID : </strong>
+                                <CopyableText TextToCopy="@_project.Id.ToString()" DisplayLength="8" />
+                                <MudTooltip Text="Show in Tree View">
+                                    <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
+                                </MudTooltip>
+                            </div>
+                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_project.Status</div>
                         @if (!string.IsNullOrEmpty(_project.EstimationUnit))
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation [@_project.EstimationUnit] : </b> @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_project.EstimationUnit] : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
                         }
                         else
                         {
-                            <MudText Variant="Variant.H6">|| <b>Estimation : </b> @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </MudText>
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
                         }
-                    </MudStack>
+                        </div>
+                    </MudBreakpointProvider>
+
+
                     <br />
                     }
                     <div class="custom-markdown-editor">
@@ -100,6 +110,8 @@
     private GetProjectExportDTO _project = new();
     private MarkupString _convertedMarkdown;
     private bool _needsRender = false;
+
+    private Breakpoint bp;
 
     protected override async Task OnParametersSetAsync()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -32,12 +32,13 @@
         <MudItem xs="12" sm="12">
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
                 <MudCardContent>
-                    <MudGrid>
-                        <MudItem xs="12" sm="12" md="7" lg="7">
-                            <MudText Typo="Typo.h5" Align="Align.Left">
+                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                            <MudText Typo="Typo.h5" Align="Align.Left"
+                                 Class="flex-grow-1"
+                                 Style="white-space:normal; overflow-wrap:break-word;"> 
                                 <strong>@_project.Name</strong>
                             </MudText>
-                        </MudItem>
+                        <div class="d-flex align-top flex-shrink-0">
 
                         <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
@@ -48,7 +49,9 @@
                                            Class="mud-rounded-circle"
                                            OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
                         </MudItem>
-                    </MudGrid>
+                        </div>
+                    </div>
+
                 </MudCardContent>
             </MudCard>
             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/SharedComponents/BaselineEstimationReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/SharedComponents/BaselineEstimationReadOnlyComponent.razor
@@ -15,11 +15,11 @@
 {
     @if (!string.IsNullOrEmpty(BaselineHierarchyData.EstimationUnit))
     { 
-        <MudText Variant="Variant.H6"><b>Estimation [@BaselineHierarchyData.EstimationUnit] : </b> @BaselineHierarchyData.OwnEstimation <b>|| Roll-Up</b> :@BaselineHierarchyData.RolledUpEstimation </MudText>
+        <MudText Inline="true" Variant="Variant.H6"><b>Estimation [@BaselineHierarchyData.EstimationUnit] : </b> @BaselineHierarchyData.OwnEstimation <b>|| Roll-Up</b> :@BaselineHierarchyData.RolledUpEstimation </MudText>
     }
         else
     {
-        <MudText Variant="Variant.H6"><b>Estimation : </b> @BaselineHierarchyData.OwnEstimation <b>|| Roll-Up</b> :@BaselineHierarchyData.RolledUpEstimation </MudText>
+        <MudText Inline="true" Variant="Variant.H6"><b>Estimation : </b> @BaselineHierarchyData.OwnEstimation <b>|| Roll-Up</b> :@BaselineHierarchyData.RolledUpEstimation </MudText>
     }
 }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/SharedComponents/EstimationReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/SharedComponents/EstimationReadOnlyComponent.razor
@@ -14,12 +14,12 @@
 @if (HierarchyData != null)
 {
     @if (!string.IsNullOrEmpty(HierarchyData.EstimationUnit))
-    { 
-        <MudText Variant="Variant.H6"><b>Estimation [@HierarchyData.EstimationUnit] : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
+    {
+        <MudText Inline="true" Variant="Variant.H6"><b>Estimation [@HierarchyData.EstimationUnit] : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
     }
         else
     {
-        <MudText Variant="Variant.H6"><b>Estimation : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
+        <MudText Inline="true" Variant="Variant.H6"><b>Estimation : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
     }
 }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/SharedComponents/EstimationReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/SharedComponents/EstimationReadOnlyComponent.razor
@@ -15,11 +15,11 @@
 {
     @if (!string.IsNullOrEmpty(HierarchyData.EstimationUnit))
     {
-        <MudText Inline="true" Variant="Variant.H6"><b>Estimation [@HierarchyData.EstimationUnit] : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
+        <MudText Inline="true" ><b>Estimation [@HierarchyData.EstimationUnit] : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
     }
         else
     {
-        <MudText Inline="true" Variant="Variant.H6"><b>Estimation : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
+        <MudText Inline="true" ><b>Estimation : </b> @HierarchyData.OwnEstimation <b>|| Roll-Up</b> :@HierarchyData.RolledUpEstimation </MudText>
     }
 }
 

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
@@ -129,6 +129,25 @@ h1:focus {
             color: black !important; /* Set the color of the bullet markers */
         }
 
+/* START - Responsive Text for Titles */
+
+.text-responsive-title {
+    font-size: 1.75rem !important; /* default = h5 */
+}
+
+@media (max-width: 900px) { /* tablet */
+    .text-responsive-title {
+        font-size: 1.5rem !important;
+    }
+}
+
+@media (max-width: 600px) { /* mobile */
+    .text-responsive-title {
+        font-size: 1rem !important;
+    }
+}
+
+/* END - Responsive Text for Titles */
 
 /* Scroll bar for MudPaper mainly for displaying Description Content in Read-Only mode */
 /*.fixed-height-scroll {


### PR DESCRIPTION
Now, Mobile users who connect to OpenRose will have much better views that covers Title Block and Properties that are enhanced for better visibility and reading via layout changes based on user screen size. Now Mobile users will be able to see most of the content stacked one after the other in a linear fashion. Following record type's UI was improved during this change

Project
Requirement Item Types
Requirement Items
Baseline 
Baseline Requirement Item Types
Baseline Requirement Items

We covered following views to have this Mobile UI improvements

Details View
Read Only Tree Views
Read Only Tree Views for JSON

So in total we made improvements to several UI components to make sure that Mobile users have better experience using OpenRose Requirements Management Tool especially when they are reviewing data on their Phone.

