### PR TITLE
Better handler for obtaining Hosted Server Side JSON Data in Cloud Deployment Scenarios

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DataSourceSwitchServerJsonDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DataSourceSwitchServerJsonDialog.razor
@@ -70,17 +70,29 @@
     private string? loadError;
     private List<string> availableFiles = new();
     private string? selectedFile;
+    private HttpClient? httpClient;
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
-            var http = ClientFactory.CreateClient("WebUIInternal");
+            httpClient = ClientFactory.CreateClient("WebUIInternal");
+
+            // EXPLANATION: Setting BaseAddress here ensures we dynamically
+            // set this value as we decided not to initiate BaseAddress in Program.cs.
+            // This was an important decision we had to take because otherwise
+            // host like Azure App Services would have issues with the API calls
+            // as the Context lifecycle is different depending on the hosting environment.
+            // We noticed that hosting application in IIS would work as context is created
+            // early on while it would not work for Azure App Services as context 
+            // is created later on in the lifecycle, which would cause the 
+            // BaseAddress to be null when HttpClient is created in Program.cs.
+
+            httpClient.BaseAddress = new Uri(NavManager.BaseUri);  
 
             // NEW: Expect structured response
             // var result = await http.GetFromJsonAsync<ServerFilesResponse>("offline/files");
-            var result = await http.GetFromJsonAsync<ServerFilesResponse>("offline/files");
-
+            var result = await httpClient.GetFromJsonAsync<ServerFilesResponse>("offline/files");
 
             if (result is null)
             {
@@ -124,11 +136,15 @@
             return;
 
         try
-        {
-            var http = ClientFactory.CreateClient("WebUIInternal");
+        {   
+            if (httpClient == null)
+            {
+                httpClient = ClientFactory.CreateClient("WebUIInternal");
+                httpClient.BaseAddress = new Uri(NavManager.BaseUri);
+            }
 
             // NEW: Expect file CONTENT instead of file PATH
-            var response = await http.PostAsJsonAsync("offline/select", new
+            var response = await httpClient.PostAsJsonAsync("offline/select", new
             {
                 fileName = selectedFile
             });

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -34,7 +34,7 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-				<MudCardContent>
+				<MudCardContent Style="padding:6px">
 					<div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<!-- Left side: Title -->
 						<MudText Typo="Typo.inherit"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -32,7 +32,7 @@
         <MudItem xs="12">
             @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
-                <MudCardContent>
+                <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -35,7 +35,7 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-				<MudCardContent>
+				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
 						<!-- Left side: Title -->

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -33,7 +33,7 @@
         <MudItem xs="12">
             @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
-                <MudCardContent>
+                <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -34,7 +34,7 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-				<MudCardContent>
+				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
 						<!-- Left side: Title -->

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -32,7 +32,7 @@
         <MudItem xs="12">
             @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
-                <MudCardContent>
+                <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -33,7 +33,7 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-				<MudCardContent Style="padding : 6px">
+				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<!-- Left side: Title -->
 						<MudText Typo="Typo.inherit"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -30,7 +30,7 @@
     {
         <MudItem xs="12" sm="12">
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
-                <MudCardContent>
+                <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                     <MudText Typo="Typo.inherit"
                                 Class="flex-grow-1 text-responsive-title"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -33,7 +33,7 @@
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-				<MudCardContent>
+				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
 						<!-- Left side: Title -->

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -31,7 +31,7 @@
     {
         <MudItem xs="12" sm="12">
             <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
-                <MudCardContent>
+                <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"

--- a/OpenRose.Web/OpenRose.WebUI/Program.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Program.cs
@@ -94,16 +94,26 @@ if (startupCapabilities.ServerOfflineAvailable)
 	// This config controls where server-side JSON files are stored and how offline mode behaves.
 	builder.Services.Configure<OfflineContentSettings>(builder.Configuration.GetSection("OfflineContent"));
 
-	builder.Services.AddHttpClient("WebUIInternal", (sp, client) =>
-	{
-		var context = sp.GetRequiredService<IHttpContextAccessor>().HttpContext;
-		if (context is not null)
-		{
-			var request = context.Request;
-			var baseUri = $"{request.Scheme}://{request.Host}";
-			client.BaseAddress = new Uri(baseUri);
-		}
-	});
+	// EXPLANATION: Register HttpClient for internal API calls.
+	// Don't configure BaseAddress here - it's null at startup
+	// The actual BaseAddress will be determined dynamically in the services that use this client,
+	// WebUIInternal is a named client that services can use when they need to
+	// make internal API calls to the same server,
+	// regardless of whether we're in API mode or Offline JSON mode.
+	// Just register the client
+
+	builder.Services.AddHttpClient("WebUIInternal");
+
+	//builder.Services.AddHttpClient("WebUIInternal", (sp, client) =>
+	//{
+	//	var context = sp.GetRequiredService<IHttpContextAccessor>().HttpContext;
+	//	if (context is not null)
+	//	{
+	//		var request = context.Request;
+	//		var baseUri = $"{request.Scheme}://{request.Host}";
+	//		client.BaseAddress = new Uri(baseUri);
+	//	}
+	//});
 }
 
 builder.Services.Configure<OpenRoseOptions>(


### PR DESCRIPTION
When Hosting in the Cloud environment, we now obtain Base URL from the injected NavManager. This way we call into HttpContext client just in time post it being establish fully.