### PR TITLE
Removed extra large white space from the Page Layout for ItemzReadOnly views

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -77,7 +77,7 @@
 
 
             <!-- Scrollable Content -->
-            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 200px);">
+            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);">
                 <MudCardContent Style="padding : 6px">
                     @if (tagsList is { Count: > 0 })
                     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -66,7 +66,7 @@
                 </MudCardContent>
             </MudCard>
 
-            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 200px);">
+            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);">
                 <MudCardContent Style="padding : 6px">
                     @if (tagsList is { Count: > 0 })
                     {


### PR DESCRIPTION
When user were viewing Itemz ReadOnly Views especially in the smaller devices then they were identifying a large white space at the bottom of the Itemz Details component. It took a while to identify the location where we had specified the white space to appear in the view and now it's resolved. 