### PR TITLE
Improved UI for Server Data Files view to support Mobile Users

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DataSourceSwitchServerJsonDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DataSourceSwitchServerJsonDialog.razor
@@ -1,4 +1,4 @@
-﻿@using OpenRose.WebUI.Client.Services.JsonFile
+﻿@* @using OpenRose.WebUI.Client.Services.JsonFile
 @using OpenRose.WebUI.Client.SharedModels.ClientSideUIOnlyModel
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Services
@@ -59,9 +59,9 @@
             Cancel
         </MudButton>
     </DialogActions>
-</MudDialog>
+</MudDialog> *@
 
-@code {
+@* @code {
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; }
 
@@ -205,3 +205,4 @@
         public string jsonContent { get; set; }
     }
 }
+ *@

--- a/OpenRose.Web/OpenRose.WebUI/Components/EventServices/DataSourceStateService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Components/EventServices/DataSourceStateService.cs
@@ -311,6 +311,20 @@ namespace OpenRose.WebUI.Components.EventServices
 			NotifyStateChanged();
 		}
 
+		//public void SwitchToNone()
+		//{
+		//	_currentDataSourceState = new DataSourceState
+		//	{
+		//		CurrentDataSourceType = DataSourceType.None,
+		//		IsReadOnlyMode = false,
+		//		//JsonFilePathForDataSource = null,
+		//		JsonFileNameForDisplay = null,
+		//		LastErrorMessage = null,
+		//		LastErrorDetails = null
+		//	};
+
+		//	NotifyStateChanged();
+		//}
 
 		/// <summary>
 		/// Switches the data source back to API Server mode.

--- a/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
@@ -442,24 +442,24 @@
 
 	}
 
-	private async Task ShowDataSourceSwitchDialogForSelectingServerJsonFileAsync()
-	{
-		var dialogOptions = new DialogOptions
-		{
-			CloseOnEscapeKey = true,
-			BackdropClick = true,
-			MaxWidth = MaxWidth.Small,
-			FullWidth = true
-		};
+	// private async Task ShowDataSourceSwitchDialogForSelectingServerJsonFileAsync()
+	// {
+	// 	var dialogOptions = new DialogOptions
+	// 	{
+	// 		CloseOnEscapeKey = true,
+	// 		BackdropClick = true,
+	// 		MaxWidth = MaxWidth.Small,
+	// 		FullWidth = true
+	// 	};
 
-		var dialog = await DialogServiceForShowingDialogs.ShowAsync<DataSourceSwitchServerJsonDialog>(
-			"Select Server JSON File",
-			new DialogParameters(),
-			dialogOptions
-		);
+	// 	var dialog = await DialogServiceForShowingDialogs.ShowAsync<DataSourceSwitchServerJsonDialog>(
+	// 		"Select Server JSON File",
+	// 		new DialogParameters(),
+	// 		dialogOptions
+	// 	);
 
-		await dialog.Result;
-	}
+	// 	await dialog.Result;
+	// }
 
 
 	/// <summary>
@@ -646,8 +646,8 @@
 		bool canProceed = await FormStateService.ConfirmDiscardAllChangesAsync();
 		if (!canProceed)
 			return;
-
-		await ShowDataSourceSwitchDialogForSelectingServerJsonFileAsync();
+        NavManager.NavigateTo("/serverdatafiles", true);
+		//await ShowDataSourceSwitchDialogForSelectingServerJsonFileAsync();
 	}
 
 	private async Task SwitchToClientJsonModeAsync()

--- a/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
@@ -138,41 +138,30 @@
 		</span>
 		} *@
 
-		@if (tempCustomDataSourceState.IsServerJsonMode)
+@* 		@if (tempCustomDataSourceState.IsServerJsonMode)
 		{
-			@* <MudChip T="string" Color="Color.Warning" Variant="Variant.Filled">SERVER JSON MODE</MudChip> *@
-
 				<MudButton Variant="Variant.Text" Color="Color.Primary"
 						   OnClick="ShowJsonFileDetailsAsync">
 					<MudChip T="string" Color="Color.Warning" Variant="Variant.Filled">SERVER JSON MODE</MudChip>
 				</MudButton>
-
-
-@* 			<MudTooltip Text="Click to view full file path" Placement="Placement.Top">
-				<span class="file-path-footer-button" @onclick="ShowJsonFileDetailsAsync">
-					📁 @tempCustomDataSourceState.JsonFileNameForDisplay
-				</span>
-			</MudTooltip>
- *@		}
+		}
 		else if (tempCustomDataSourceState.IsClientJsonMode)
 		{
-			@* <MudChip T="string" Color="Color.Info" Variant="Variant.Filled">CLIENT JSON MODE</MudChip> *@
 
 				<MudButton Variant="Variant.Text" Color="Color.Primary"
 						   OnClick="ShowJsonFileDetailsAsync">
 					<MudChip T="string" Color="Color.Info" Variant="Variant.Filled">CLIENT JSON MODE</MudChip>
 				</MudButton>
-
-@* 			<MudTooltip Text="This file is loaded from your browser memory" Placement="Placement.Top"> 				
-			</MudTooltip>*@
 		}
+*@
 
 @* 		@if (DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.IsAnyJsonMode)
 		{
 			<span class="file-path-footer-button" @onclick="ShowJsonFileDetailsAsync">
 				📄 @tempCustomDataSourceState.JsonFileNameForDisplay
 			</span>
-		} *@
+		} 
+*@
 
 		<MudSpacer />
 
@@ -305,7 +294,7 @@
 			{
 				<!-- RESTRICTED MENU (SERVER JSON OR CLIENT JSON) -->
 				<MudNavLink Href="/jsonviewer" Icon="@Icons.Material.Filled.FolderOpen">
-					JSON Data View
+					Data File View
 				</MudNavLink>
 				<MudNavLink Href="/settings" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Settings">
 					Settings
@@ -600,29 +589,29 @@
 	// 	NavManager.NavigateTo("/", forceLoad: true);
 	// }
 
-	/// <summary>
-	/// Shows a dialog displaying the full file path of the JSON file.
-	/// User can copy the path from the dialog.
-	/// </summary>
-	private async Task ShowJsonFileDetailsAsync()
-	{
-		//string fullJsonFilePathToDisplay = DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.JsonFilePathForDataSource ?? "Unknown";
+// 	/// <summary>
+// 	/// Shows a dialog displaying the full file path of the JSON file.
+// 	/// User can copy the path from the dialog.
+// 	/// </summary>
+// 	private async Task ShowJsonFileDetailsAsync()
+// 	{
+// 		//string fullJsonFilePathToDisplay = DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.JsonFilePathForDataSource ?? "Unknown";
 
-		string fileName = DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.JsonFileNameForDisplay ?? "Unknown";
+// 		string fileName = DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.JsonFileNameForDisplay ?? "Unknown";
 
 
-		var dialogParameters = new DialogParameters();
-//		dialogParameters.Add("JsonFilePathToShow", fullJsonFilePathToDisplay);
-		dialogParameters.Add("JsonFileNameToShow", fileName);
+// 		var dialogParameters = new DialogParameters();
+// //		dialogParameters.Add("JsonFilePathToShow", fullJsonFilePathToDisplay);
+// 		dialogParameters.Add("JsonFileNameToShow", fileName);
 
-		var dialogOptions = new DialogOptions { CloseOnEscapeKey = true, BackdropClick = true };
+// 		var dialogOptions = new DialogOptions { CloseOnEscapeKey = true, BackdropClick = true };
 
-		await DialogServiceForShowingDialogs.ShowAsync<JsonFileDialog>(
-			"JSON File Details",
-			dialogParameters,
-			dialogOptions
-		);
-	}
+// 		await DialogServiceForShowingDialogs.ShowAsync<JsonFileDialog>(
+// 			"JSON File Details",
+// 			dialogParameters,
+// 			dialogOptions
+// 		);
+// 	}
 
 	private async Task SwitchToApiModeAsync()
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Home.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Home.razor
@@ -5,6 +5,7 @@
 *@
 
 @page "/"
+@using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Configuration
 @using OpenRose.WebUI.Services
 
@@ -58,6 +59,9 @@
     [Inject] private AssemblyInfoService AssemblyInfo { get; set; } = default!;
     [Inject] private ApiVersionChecker VersionChecker { get; set; } = default!;
     [Inject] private StartupCapabilitiesService StartupCapabilities { get; set; } = default!;
+    [Inject] private DataSourceStateService DataSourceStateService { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+
     //[Inject] private IServiceProvider Services { get; set; } = default!;
 
 
@@ -65,6 +69,8 @@
     private string version = string.Empty;
     private bool _isReconnectDisabled = false;
     //private ApiVersionChecker? VersionChecker;
+
+    private static bool _redirectedOnce = false;
 
     protected override void OnInitialized()
     {
@@ -74,6 +80,25 @@
         // }
 
         // Only show API configuration error if API is expected to exist
+
+        // Redirect ONLY on first visit AND ONLY if startup mode is Server JSON
+        // if (!_redirectedOnce && DataSourceStateService.CurrentDataSourceState.IsServerJsonMode)
+        // {
+        //     _redirectedOnce = true;
+        //     Navigation.NavigateTo("/serverdatafiles", replace: true);
+        //     return;
+        // }
+
+
+        // Redirect ONLY when the application starts in Server JSON mode
+        if (DataSourceStateService.CurrentDataSourceState.IsServerJsonMode)
+        {
+            Navigation.NavigateTo("/serverdatafiles", replace: true);
+            return; // Prevent further initialization
+        }
+
+
+
         if (StartupCapabilities.ApiAvailable)
         {
             if (!apiConfigService.IsOpenRoseAPIConfigured)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
@@ -1,0 +1,205 @@
+﻿@page "/serverdatafiles"
+
+@using OpenRose.WebUI.Client.Services.JsonFile
+@using OpenRose.WebUI.Client.SharedModels.ClientSideUIOnlyModel
+@using OpenRose.WebUI.Components.EventServices
+@using OpenRose.WebUI.Services
+@inject IHttpClientFactory ClientFactory
+@inject NavigationManager NavManager
+@inject JsonFileDataSourceService JsonDataSource
+@inject DataSourceStateService DataSourceStateService
+@inject ViewSettingsService ViewSettingsService
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
+
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Justify="Justify.Center" >
+        <MudImage Src="icons/OpenRose_01.png" Width="45" Height="45" />
+        <MudText Typo="Typo.h4" Align="Align.Left">
+            Welcome to <b>OpenRose</b>
+        </MudText>
+    </MudStack>
+
+    <br />
+
+    @if (isLoading)
+    {
+        <MudProgressCircular Indeterminate="true" Color="Color.Primary" />
+    }
+    else if (folderUnavailable)
+    {
+        <MudAlert Severity="Severity.Warning">
+            The server's offline storage folder is unavailable.
+        </MudAlert>
+    }
+    else if (loadError != null)
+    {
+        <MudAlert Severity="Severity.Error">@loadError</MudAlert>
+    }
+    else
+    {
+        <MudGrid Gutter="9px">
+            @foreach (var file in availableFiles)
+            {
+                <MudItem xs="12">
+                    <MudCard Class="server-file-card clickable-card" @onclick="() => LoadFileAsync(file)">
+                        <MudCardContent>
+                            <MudText Typo="Typo.subtitle1" Class="card-text-wrap">
+                                @ToFriendlyName(file)
+                            </MudText>
+                        </MudCardContent>
+                    </MudCard>
+
+                </MudItem>
+            }
+        </MudGrid>
+
+    }
+</MudContainer>
+<style>
+.server-file-card {
+    background: var(--server-card-bg);
+    border-radius: 10px;
+    padding: 14px;
+    border: 1px solid var(--server-card-border);
+    color: var(--server-card-text);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+    .server-file-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 6px 18px rgba(0,0,0,0.12);
+    }
+
+.card-text-wrap {
+    white-space: normal;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+</style>
+
+
+@code {
+    private bool isLoading = true;
+    private bool folderUnavailable = false;
+    private string? loadError;
+    private List<string> availableFiles = new();
+    private HttpClient? httpClient;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            httpClient = ClientFactory.CreateClient("WebUIInternal");
+            httpClient.BaseAddress = new Uri(NavManager.BaseUri);
+
+            var result = await httpClient.GetFromJsonAsync<ServerFilesResponse>("offline/files");
+
+            if (result is null)
+                loadError = "Unexpected server response.";
+            else if (!result.folderAvailable)
+                folderUnavailable = true;
+            else if (result.files is null || result.files.Count == 0)
+                loadError = "No JSON files found on the server.";
+            else
+                availableFiles = result.files;
+
+        }
+        catch (Exception ex)
+        {
+            loadError = $"Failed to load server JSON files: {ex.Message}";
+        }
+
+        isLoading = false;
+    }
+
+    private async Task LoadFileAsync(string fileName)
+    {
+        try
+        {
+            if (httpClient == null)
+            {
+                httpClient = ClientFactory.CreateClient("WebUIInternal");
+                httpClient.BaseAddress = new Uri(NavManager.BaseUri);
+            }
+
+            var response = await httpClient.PostAsJsonAsync("offline/select", new { fileName });
+
+            if (!response.IsSuccessStatusCode)
+            {
+                loadError = $"Server rejected selection: {response.StatusCode}";
+                return;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<ServerSelectResponse>();
+
+            if (result is null || !result.success)
+            {
+                loadError = "Failed to activate JSON file.";
+                return;
+            }
+
+            await JsonDataSource.LoadJsonFileDataFromStringAsync(result.jsonContent);
+
+            DataSourceStateService.SwitchToServerSideJsonFile(result.fileName);
+
+            JsonDataSource.SetJsonViewerMetadata(new JsonViewerMetadata
+            {
+                FileName = result.fileName,
+                FullPath = null,
+                FileSizeBytes = result.jsonContent.Length,
+                LoadedAt = DateTime.Now,
+                IsServerSide = true
+            });
+
+            ViewSettingsService.IsOperatingInJsonFileDataSourceMode = true;
+
+            NavManager.NavigateTo("/jsonviewer");
+        }
+        catch (Exception ex)
+        {
+            loadError = $"Failed to activate JSON file: {ex.Message}";
+        }
+    }
+
+    private class ServerFilesResponse
+    {
+        public bool folderAvailable { get; set; }
+        public List<string>? files { get; set; }
+    }
+
+    private class ServerSelectResponse
+    {
+        public bool success { get; set; }
+        public string fileName { get; set; }
+        public string jsonContent { get; set; }
+    }
+
+    private string ToFriendlyName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return fileName;
+
+        // 1. Remove extension
+        var name = fileName.Replace(".json", "", StringComparison.OrdinalIgnoreCase);
+
+        // 2. Replace underscores and hyphens with spaces
+        name = name.Replace("_", " ").Replace("-", " ");
+
+        // 3. Insert spaces between:
+        //    - lower → upper (camelCase)
+        //    - acronym → normal word (ACCCompany → ACC Company)
+        //    - normal word → acronym (WorkWithACC → Work With ACC)
+        name = System.Text.RegularExpressions.Regex.Replace(
+            name,
+            "(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])",
+            " "
+        );
+
+        // 4. Remove double spaces
+        while (name.Contains("  "))
+            name = name.Replace("  ", " ");
+
+        return name.Trim();
+    }
+
+}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
@@ -43,7 +43,7 @@
                 <MudItem xs="12">
                     <MudCard Class="server-file-card clickable-card" @onclick="() => LoadFileAsync(file)">
                         <MudCardContent>
-                            <MudText Typo="Typo.subtitle1" Class="card-text-wrap">
+                            <MudText Typo="Typo.subtitle1" Class="card-text-wrap" Align="Align.Center">
                                 @ToFriendlyName(file)
                             </MudText>
                         </MudCardContent>
@@ -58,26 +58,29 @@
 <style>
     .server-file-card {
         background: var(--card-bg);
-        border-radius: 14px;
+        border-radius: 20px;
         padding: 18px;
         border: 1px solid var(--card-border);
         color: var(--card-text);
-        font-family: "Segoe UI", sans-serif;
-        font-size: 1.05rem;
-        letter-spacing: 0.3px;
+        letter-spacing: 0.5px;
         transition: transform .18s ease, box-shadow .18s ease;
     }
 
-        .server-file-card:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 8px 22px rgba(0,0,0,0.12);
-        }
+    .server-file-card .mud-typography-subtitle1 {
+        font-size: 1.15rem !important;
+        font-weight: 700 !important;
+    }
+
+
+    .server-file-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 8px 22px rgba(0,0,0,0.12);
+    }
 
     .card-text-wrap {
         white-space: normal;
         overflow-wrap: break-word;
     }
-
 
 </style>
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
@@ -56,25 +56,29 @@
     }
 </MudContainer>
 <style>
-.server-file-card {
-    background: var(--server-card-bg);
-    border-radius: 10px;
-    padding: 14px;
-    border: 1px solid var(--server-card-border);
-    color: var(--server-card-text);
-    transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-    .server-file-card:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 6px 18px rgba(0,0,0,0.12);
+    .server-file-card {
+        background: var(--card-bg);
+        border-radius: 14px;
+        padding: 18px;
+        border: 1px solid var(--card-border);
+        color: var(--card-text);
+        font-family: "Segoe UI", sans-serif;
+        font-size: 1.05rem;
+        letter-spacing: 0.3px;
+        transition: transform .18s ease, box-shadow .18s ease;
     }
 
-.card-text-wrap {
-    white-space: normal;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-}
+        .server-file-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 8px 22px rgba(0,0,0,0.12);
+        }
+
+    .card-text-wrap {
+        white-space: normal;
+        overflow-wrap: break-word;
+    }
+
+
 </style>
 
 
@@ -85,8 +89,11 @@
     private List<string> availableFiles = new();
     private HttpClient? httpClient;
 
+    private static bool _redirectedOnce = false;
+
     protected override async Task OnInitializedAsync()
     {
+
         try
         {
             httpClient = ClientFactory.CreateClient("WebUIInternal");

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Settings/Settings.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Settings/Settings.razor
@@ -7,6 +7,7 @@
 @page "/settings/"
 @using OpenRose.WebUI.Client.Services.JsonFile
 @using OpenRose.WebUI.Components.EventServices
+@using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.Orphan.DeleteAllOrphan
 @using OpenRose.WebUI.Services
 @inject DataSourceStateService DataSourceState
@@ -60,15 +61,25 @@
         }
         else if (DataSourceState.CurrentDataSourceState.IsServerJsonMode)
         {
-            <MudChip T="string" Color="Color.Warning" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
+@*             <MudChip T="string" Color="Color.Warning" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
                 Server JSON Mode
-            </MudChip>
+            </MudChip> *@
+
+            <MudButton Variant="Variant.Text" Color="Color.Primary"
+                       OnClick="ShowJsonFileDetailsAsync">
+                <MudChip T="string" Color="Color.Warning" Variant="Variant.Filled">SERVER JSON MODE</MudChip>
+            </MudButton>
         }
         else if (DataSourceState.CurrentDataSourceState.IsClientJsonMode)
         {
-            <MudChip T="string" Color="Color.Info" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
+@*             <MudChip T="string" Color="Color.Info" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
                 Client JSON Mode
-            </MudChip>
+            </MudChip> *@
+
+            <MudButton Variant="Variant.Text" Color="Color.Primary"
+                       OnClick="ShowJsonFileDetailsAsync">
+                <MudChip T="string" Color="Color.Info" Variant="Variant.Filled">CLIENT JSON MODE</MudChip>
+            </MudButton>
         }
         else 
         {
@@ -171,6 +182,30 @@
     protected override async Task OnInitializedAsync()
     {
         version = AssemblyInfo.GetAssemblyVersion();
+    }
+
+    /// <summary>
+    /// Shows a dialog displaying the full file path of the JSON file.
+    /// User can copy the path from the dialog.
+    /// </summary>
+    private async Task ShowJsonFileDetailsAsync()
+    {
+        //string fullJsonFilePathToDisplay = DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.JsonFilePathForDataSource ?? "Unknown";
+
+        string fileName = DataSourceState.CurrentDataSourceState.JsonFileNameForDisplay ?? "Unknown";
+
+
+        var dialogParameters = new DialogParameters();
+        //		dialogParameters.Add("JsonFilePathToShow", fullJsonFilePathToDisplay);
+        dialogParameters.Add("JsonFileNameToShow", fileName);
+
+        var dialogOptions = new DialogOptions { CloseOnEscapeKey = true, BackdropClick = true };
+
+        await Dialogs.ShowAsync<JsonFileDialog>(
+            "JSON File Details",
+            dialogParameters,
+            dialogOptions
+        );
     }
 
     // ============================================================

--- a/OpenRose.Web/OpenRose.WebUI/Components/Routes.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Routes.razor
@@ -142,6 +142,7 @@
             bool isAllowed =
                 path == "" ||
                 path == "jsonviewer" ||
+                path == "serverdatafiles" ||
                 path == "settings";
 
             // Console.WriteLine($"[Guard] IsAnyJsonMode: true");

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
@@ -1,4 +1,4 @@
-html, body {
+﻿html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
@@ -162,19 +162,22 @@ h1:focus {
         box-shadow: 0 6px 18px rgba(0,0,0,0.15);
 }
 
-/* Light mode defaults */
+/* Light mode */
 :root {
-    --server-card-bg: #f3f6ff; /* pastel blue */
-    --server-card-border: #d9e2ff;
-    --server-card-text: #1a1a1a;
+    --card-bg: #f3f6ff; /* very light blue */
+    --card-border: #d9e2ff; /* soft blue border */
+    --card-text: #1a1a1a; /* dark readable text */
 }
 
-/* Dark mode overrides */
+
+/* Dark mode */
 .mud-theme-dark {
-    --server-card-bg: #1e1f26; /* soft dark slate */
-    --server-card-border: #3a3d4d;
-    --server-card-text: #e6e6e6;
+    --card-bg: #1f2129; /* dark slate */
+    --card-border: #3a3d4d;
+    --card-text: #e8e8e8;
 }
+
+
 
 /* END - Server Card Styles used in ServerDataFiles.razor */
 

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
@@ -147,7 +147,38 @@ h1:focus {
     }
 }
 
+
 /* END - Responsive Text for Titles */
+
+/* START - Server Card Styles used in ServerDataFiles.razor */
+
+.clickable-card {
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+    .clickable-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 6px 18px rgba(0,0,0,0.15);
+}
+
+/* Light mode defaults */
+:root {
+    --server-card-bg: #f3f6ff; /* pastel blue */
+    --server-card-border: #d9e2ff;
+    --server-card-text: #1a1a1a;
+}
+
+/* Dark mode overrides */
+.mud-theme-dark {
+    --server-card-bg: #1e1f26; /* soft dark slate */
+    --server-card-border: #3a3d4d;
+    --server-card-text: #e6e6e6;
+}
+
+/* END - Server Card Styles used in ServerDataFiles.razor */
+
+
 
 /* Scroll bar for MudPaper mainly for displaying Description Content in Read-Only mode */
 /*.fixed-height-scroll {

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
@@ -164,7 +164,7 @@ h1:focus {
 
 /* Light mode */
 :root {
-    --card-bg: #f3f6ff; /* very light blue */
+    --card-bg: linear-gradient(135deg, #e6faff, #00ccff); /* very light blue */
     --card-border: #d9e2ff; /* soft blue border */
     --card-text: #1a1a1a; /* dark readable text */
 }
@@ -172,7 +172,7 @@ h1:focus {
 
 /* Dark mode */
 .mud-theme-dark {
-    --card-bg: #1f2129; /* dark slate */
+    --card-bg: linear-gradient(135deg, #1f2129, #7c839c); /* dark slate */
     --card-border: #3a3d4d;
     --card-text: #e8e8e8;
 }


### PR DESCRIPTION
Now we have implemented Cards view to support Mobile users to see cards layout for choosing and opening server Data files. When API layer turned off via configuration then users will land on 'Server Data Files' view if that option is available.

