### PR TITLE
Improved Guide rules for Serve JSON Data file as default when available

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Routes.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Routes.razor
@@ -150,11 +150,18 @@
 
             if (!isAllowed)
             {
+                // EXCPLANATION:
                 // Block navigation to any route that requires API access or write access.
-                // Redirect to the JSON viewer, which is the only safe place.
-                // Nav.NavigateTo("/jsonviewer", forceLoad: true);
-                Nav.NavigateTo("/jsonviewer");
-                return Task.CompletedTask;
+                // Check if Server JSON Mode is active → if so, we can allow access to the server data files page, 
+                // which is safe and relevant for this mode.
+                // Otherwise, Lets redirect to the home page which is "/".
+
+                if (state.IsServerJsonMode)
+                {
+                    Nav.NavigateTo("/serverdatafiles");
+                    return Task.CompletedTask;
+                }
+                Nav.NavigateTo("/");
             }
 
             // Allowed route → proceed

--- a/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
+++ b/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
@@ -15,5 +15,11 @@
     //"StorageFolder": "C:\\OpenRoseData\\OfflineFiles",
     "StorageFolder": "OpenRose/OfflineFiles",
     "DefaultJsonFile": "OpenRoseData.json"
+  },
+  "OpenRose": {
+    "UserFilesStorage": {
+      "Enabled": true,
+      "RootPath": "./user-files"
+	}
   }
 }


### PR DESCRIPTION
Now when the deployment of Open Rose Requirements Management Tool is set as Server Data file view mode then user will be redirected to that mode via Guard Rules. So if the user tries to go to any of the pages which are related to API actions then they will be re-directed to the landing page of the server data files rule. 

This will help improve user experience working with Open Rose.