### PR TITLE
Alpha resolve null parent id scenario while Navigating to Parent Record

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/BaselineHierarchy/BaselineHierarchyService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/BaselineHierarchy/BaselineHierarchyService.cs
@@ -49,7 +49,7 @@ namespace OpenRose.WebUI.Client.Services.BaselineHierarchy
 			}
 			catch (Exception)
 			{
-				throw new NotImplementedException();
+				return null;
 			}
 			return default;
 		}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
@@ -10,6 +10,7 @@
 @using OpenRose.WebUI.Client.Services.BaselineItemz
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.Pages.BaselineItemz.BaselineTraceability
 @using OpenRose.WebUI.Components.Pages.Breadcrums
 @using OpenRose.WebUI.Components.Pages.Common
@@ -272,7 +273,7 @@
 			BreadcrumsParameter.RecordType = "baselineitemz"; // TODO :: USE CONSTANT
 			BreadcrumsParameter.isIncluded = singleBaselineItemz.isIncluded;
 
-            // Obtain tags list from the singleBaselineItemz.
+			// Obtain tags list from the singleBaselineItemz.
 			if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
 			{
 				// Normalize incoming tags (removes duplicates, trims, preserves order)
@@ -346,20 +347,31 @@
 
 	public async Task goBackToParent()
 	{
-		// TODO: IT COULD BE BASELINE ITEMZ OR BASELINE ITEMZTYPE AS PARENT OF A GIVEN BASELINE ITEMZ.
-
 		// EXPLANATION : At the start of initialization process we capture parent record ID.
 		// Now even if user decides to Delete this Itemz Record then also we can go back to it's
 		// Parent ItemzType post completing deletion operation.
+		initializingPage = true;
+        // StateHasChanged();
 		var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzId);
-
-		if (httpResponse.ParentRecordType.ToLower() == "baselineitemztype") // TODO :: USE GLOBAL CONSTANTS
+		if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty)  // If for some reason API call fails then also we can avoid exception by this null check.
 		{
-			NavManager.NavigateTo($"/baselineitemztype/{httpResponse.ParentRecordId.ToString()}",true);
+			if (httpResponse.ParentRecordType.ToLower() == "baselineitemztype") // TODO :: USE GLOBAL CONSTANTS
+			{
+				NavManager.NavigateTo($"/baselineitemztype/{httpResponse.ParentRecordId.ToString()}", true);
+			}
+			else if (httpResponse.ParentRecordType.ToLower() == "baselineitemz") // TODO :: USE GLOBAL CONSTANTS
+			{
+				NavManager.NavigateTo($"/baselineitemz/{httpResponse.ParentRecordId.ToString()}", true);
+			}
 		}
-		else if (httpResponse.ParentRecordType.ToLower() == "baselineitemz") // TODO :: USE GLOBAL CONSTANTS
+		else
 		{
-			NavManager.NavigateTo($"/baselineitemz/{httpResponse.ParentRecordId.ToString()}",true);
+			var parameters = new DialogParameters { ["Message"] = "Parent record not found. Please refresh and try again!" };
+			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
+			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
+			await dialogRef.Result;
+			initializingPage = false;
+			// StateHasChanged();
 		}
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
@@ -7,6 +7,7 @@
 @page "/baselineItemzDetails/{BaselineItemzId:guid}"
 @using OpenRose.WebUI.Client.Services.BaselineHierarchy
 @using OpenRose.WebUI.Client.Services.BaselineItemz
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Components.Pages.Breadcrums
 @using OpenRose.WebUI.Components.Pages.BaselineItemz.BaselineTraceability
@@ -50,17 +51,17 @@
 		<MudTabs Outlined="true" Position="Position.Top" Rounded="true" Border="true" 
 					 IconColor="Color.Secondary" ScrollIconColor="Color.Secondary" SliderColor = "Color.Secondary"
 					 ApplyEffectsToContainer="true" PanelClass="pa-2" MinimumTabWidth="200px" >
-			<MudTabPanel Text="Details" Icon="@Icons.Material.Filled.EditNote" >
-				@if (errors.Length > 0)
-				{
-					<MudPaper Class="pa-4 mud-height-full mud-width-full">
-						<MudText Typo="Typo.subtitle2" Color="@Color.Error">@($"Validation Errors ({errors.Length})")</MudText>
-						@foreach (var error in errors)
-						{
-							<MudText Color="@Color.Error">@error</MudText>
-						}
-					</MudPaper>
-				}
+		<MudTabPanel Text="Details" Icon="@Icons.Material.Filled.EditNote" >
+			@if (errors.Length > 0)
+			{
+				<MudPaper Class="pa-4 mud-height-full mud-width-full">
+					<MudText Typo="Typo.subtitle2" Color="@Color.Error">@($"Validation Errors ({errors.Length})")</MudText>
+					@foreach (var error in errors)
+					{
+						<MudText Color="@Color.Error">@error</MudText>
+					}
+				</MudPaper>
+			}
 		<MudPaper Class="pa-4 mud-height-full" Width="100%">
 		<MudForm Model="@singleBaselineItemz" ReadOnly=true @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
 			<MudCardActions>
@@ -144,22 +145,22 @@
 					</div>
 				</MudCardContent>
 		</MudForm>
-	</MudPaper>
-			</MudTabPanel>
+		</MudPaper>
+		</MudTabPanel>
 
-			<MudTabPanel Icon="@Icons.Material.Filled.Money" Text="Estimation">
-				<MudPaper Class="pa-0 mud-height-full"
-							Width="100%"
-							Outlined="false"
-							Elevation="0">
-                    <BaselineEstimationComponent @ref="baselineEstimationComponent"
-                                                    RecordId="@BaselineItemzId"
-                                                    RecordType="BaselineItemz" />
-				</MudPaper>
-			</MudTabPanel>
-			<MudTabPanel Icon="@Icons.Material.Filled.Hub" Text="Treaceability">
-				<BaselineTraceabilityComponent BaselineItemzId="@BaselineItemzId" />
-			</MudTabPanel>
+		<MudTabPanel Icon="@Icons.Material.Filled.Money" Text="Estimation">
+			<MudPaper Class="pa-0 mud-height-full"
+						Width="100%"
+						Outlined="false"
+						Elevation="0">
+                <BaselineEstimationComponent @ref="baselineEstimationComponent"
+                                                RecordId="@BaselineItemzId"
+                                                RecordType="BaselineItemz" />
+			</MudPaper>
+		</MudTabPanel>
+		<MudTabPanel Icon="@Icons.Material.Filled.Hub" Text="Treaceability">
+			<BaselineTraceabilityComponent BaselineItemzId="@BaselineItemzId" />
+		</MudTabPanel>
 		</MudTabs>
 		
 		</MudPaper>
@@ -178,11 +179,11 @@
 	private Guid ParentId { get; set; }
 	private string ParentRecordType { get; set; }
 
-	
+
 	public GetBaselineItemzDTO singleBaselineItemz { get; set; } = new();
 	private ParameterForBaselineBreadcrums BreadcrumsParameter;
 	public bool initializingPage { get; set; } = false;
-	
+
 	//MudForm related fields
 	bool success = true;
 	string[] errors = { };
@@ -212,7 +213,7 @@
 				BreadcrumsParameter.Name = singleBaselineItemz.Name;
 				BreadcrumsParameter.RecordType = "baselineitemz"; // TODO :: USE CONSTANT
 				BreadcrumsParameter.isIncluded = singleBaselineItemz.isIncluded;
-				
+
 				// Obtain tags list from the singleBaselineItemz.
 				if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
 				{
@@ -240,30 +241,50 @@
 			// Now even if user decides to Delete this Itemz Record then also we can go back to it's 
 			// Parent ItemzType post completing deletion operation. 
 			var httpResponse = await BaselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzId);
-			ParentId = httpResponse.ParentRecordId;
-			ParentRecordType = httpResponse.ParentRecordType;
 
-
+			if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // If for some reason API call fails then also we can avoid exception by this null check.
+			{
+				ParentId = httpResponse.ParentRecordId;
+				ParentRecordType = httpResponse.ParentRecordType;
+			}
 		}
 	}
 
 	public async Task goBackToBaselineItemz()
 	{
-
 		NavManager.NavigateTo($"/baselineitemz/{BaselineItemzId.ToString()}");
 	}
-	public async Task goBackToParent()
-	{
 
-		if (ParentRecordType.ToLower() == "baselineitemztype")
-		{
-			NavManager.NavigateTo($"/baselineitemztype/{ParentId.ToString()}");
-		}
-		else if (ParentRecordType.ToLower() == "baselineitemz")
-		{
-			NavManager.NavigateTo($"/baselineitemz/{ParentId.ToString()}");
-		}
-	}
+	// TODO ::
+	// goBackToParent() METHOD is not used ever in the component so 
+	// we decided to mark it as commented out. We can safely remove it away in the future.
+	// public async Task goBackToParent()
+	// {
+	// 	initializingPage = true;
+
+	// 	var httpResponse = await BaselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzId);
+	// 	if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty)  // If for some reason API call fails then also we can avoid exception by this null check.
+	// 	{
+	// 		if (ParentRecordType.ToLower() == "baselineitemztype")
+	// 		{
+	// 			NavManager.NavigateTo($"/baselineitemztype/{ParentId.ToString()}");
+	// 		}
+	// 		else if (ParentRecordType.ToLower() == "baselineitemz")
+	// 		{
+	// 			NavManager.NavigateTo($"/baselineitemz/{ParentId.ToString()}");
+	// 		}
+	// 	}
+	// 	else
+	// 	{
+
+	// 		var parameters = new DialogParameters { ["Message"] = "Parent record not found. Please refresh and try again!" };
+	// 		var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
+	// 		var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
+	// 		await dialogRef.Result;
+
+	// 		initializingPage = false;
+	// 	}
+	// }
 
 	public async Task openBaselineTreeView()
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
@@ -228,7 +228,11 @@
 			// Now even if user decides to Delete this Itemz Record then also we can go back to it's
 			// Parent post completing deletion operation.
 			var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzTypeId);
-			ParentId = httpResponse.ParentRecordId;
+			if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check.
+			{
+				ParentId = httpResponse.ParentRecordId;
+			}
+
 
 			await ConvertMarkdownToHtml(singleIBaselineItemzType.Description);
 			StateHasChanged();
@@ -243,6 +247,17 @@
 
 	public void goBackToBaseline()
 	{
+		if (ParentId == Guid.Empty)
+		{
+			// EXPLANATION ::
+			// This means we are at the top of the hierarchy and there is no parent to go back to.
+			// In this case, we can decide to navigate to a default page, such as the Projects list page.
+            // We don't expect this anyways but this could happen only when there is some issue with API response 
+			// for fetching parent record details and we end up with default value of Guid.Empty for ParentId variable.
+
+			NavManager.NavigateTo("/projects");
+			return;
+		}
 		NavManager.NavigateTo($"/baseline/{ParentId.ToString()}");
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -349,7 +349,7 @@
 		// Parent ItemzType post completing deletion operation.
 		var httpResponse = await HierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzId);
 
-		if (httpResponse != null) // Orphand Itemz does not have Hierarchy Record
+		if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // Orphand Itemz does not have Hierarchy Record
 		{
 			if (httpResponse.ParentRecordType.ToLower() == "itemztype")
 			{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -11,6 +11,7 @@
 @using OpenRose.WebUI.Client.Services.ItemzTypeItemzsService
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Components.Pages.Breadcrums
@@ -342,11 +343,19 @@
 
 	public async Task goBackToParent()
 	{
-		// TODO: IT COULD BE ITEMZ OR ITEMZTYPE AS PARENT OF A GIVEN ITEMZ.
+		if (breadcrumsService.RequestIsOrphanStatus())
+		{
+			// Orphand Itemz when deleted then go back to Project's list.
+			NavManager.NavigateTo($"/projects/");
+			return;
+		}
 
-		// EXPLANATION : At the start of initialization process we capture parent record ID.
-		// Now even if user decides to Delete this Itemz Record then also we can go back to it's
-		// Parent ItemzType post completing deletion operation.
+		// TODO :: The initializingPage didn't really work for 
+        // showing overlay when connection to API layer was dropped
+
+		initializingPage = true;
+        StateHasChanged();
+
 		var httpResponse = await HierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzId);
 
 		if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // Orphand Itemz does not have Hierarchy Record
@@ -362,8 +371,20 @@
 		}
 		else
 		{
-			// Orphand Itemz when deleted then go back to Project's list.
-			NavManager.NavigateTo($"/projects/");
+
+			// TODO :: Because we capture parent record ID in the initialization code
+			// it will be ideal to try and go back to that parent record
+			// by checking if that parent record is still present. 
+			// If parent record is not present then we can assume that
+			// API Layer connection is not working any more. This is where
+			// we can then show an error dialog box to the user. 
+
+			var parameters = new DialogParameters { ["Message"] = "Parent record not found. Please refresh and try again!" };
+			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
+			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
+			await dialogRef.Result;
+			initializingPage = false;
+            StateHasChanged();
 		}
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -559,7 +559,7 @@
 		// Now even if user decides to Delete this Itemz Record then also we can go back to it's
 		// Parent ItemzType post completing deletion operation.
 		var httpResponse = await hierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzId);
-		if (httpResponse != null) // Orphaned Itemz will not have any Hierarchy records.
+		if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // Orphaned Itemz will not have any Hierarchy records.
 		{
 			ParentId = httpResponse.ParentRecordId;
 			ParentRecordType = httpResponse.ParentRecordType;

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -112,8 +112,8 @@
 									<MudText>Tree View</MudText>
 								</MudButton>
 							}
-
 						}
+
 						<MudButton Variant="Variant.Filled" Color="Color.Warning"
 									Disabled="!FormStateService.IsDirty(ItemzTypeId)"
 									Size="Size.Large" style="gap: 10px; margin : 1px"
@@ -413,7 +413,10 @@
 		// Now even if user decides to Delete this Itemz Record then also we can go back to it's
 		// Parent ItemzType post completing deletion operation.
 		var httpResponse = await hierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzTypeId);
-		ParentId = httpResponse.ParentRecordId;
+        if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check. 
+		{
+			ParentId = httpResponse.ParentRecordId;
+		}
 
 		await ConvertMarkdownToHtml(singleItemzType.Description);
 
@@ -494,7 +497,17 @@
             await OpenExceptionDialogAsync("Problem Deleting ItemzType : " + ex.Message);
             return;
         }
-		NavManager.NavigateTo($"/project/{ParentId.ToString()}");
+
+		if (ParentId != Guid.Empty)
+		{
+			NavManager.NavigateTo($"/project/{ParentId}");
+		}
+		else
+		{
+			// Fallback: go to a safe default
+			NavManager.NavigateTo("/projects");
+		}
+
 	}
 	private async Task OpenDeleteConfirmationDialogAsync()
 	{


### PR DESCRIPTION
If the API connection is lost from the WebUI then users who click on GoBack button within given records details view then it would throw null pointer exception. Now with this change it should show a dialog box indicating that parent record is not accessible and does not leave users view frozen.