### PR TITLE
Introduced setting for show properties toggle button for Read Only views

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -84,7 +84,10 @@
 									@onclick="async _ => await gotoBaselineProjectRecord(singleBaseline.Id.ToString())" />
 								</MudTooltip>
 							</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineId" /></div>
+							@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+							{
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineId" /></div>
+							}
 						</div>
 					</MudBreakpointProvider>
 					}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -70,13 +70,16 @@
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
                         </div>
-                        @if (!string.IsNullOrEmpty(_baseline.EstimationUnit))
+                        @if (ViewSettings.ShowPropertiesInReadOnlyViews)
                         {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_baseline.EstimationUnit] : </strong> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </div>
-                        }
-                        else
-                        {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </div>
+                            @if (!string.IsNullOrEmpty(_baseline.EstimationUnit))
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_baseline.EstimationUnit] : </strong> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </div>
+                            }
+                            else
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_baseline.OwnEstimation <b>|| Roll-Up</b> :@_baseline.RolledUpEstimation </div>
+                            }
                         }
                     </div>
                 </MudBreakpointProvider>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
@@ -525,12 +525,24 @@
     {
         if (firstRender)
         {
-
-            // Load view settings
+            // Load view settings for ReadOnlyView
             var result = await SessionStorage.GetAsync<bool>("READONLYVIEW");
             if (result.Success)
             {
                 ViewSettings.ReadOnlyView = result.Value;
+            }
+
+            // Load view settings for ShowPropertiesInReadOnlyViews
+            var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
+            if (resultShowProperties.Success)
+            {
+                ViewSettings.ShowPropertiesInReadOnlyViews = resultShowProperties.Value;
+            }
+            else
+            {
+                // If not set in session, default to false and save it
+                ViewSettings.ShowPropertiesInReadOnlyViews = false;
+                await SessionStorage.SetAsync("SHOWPROPERTIESINREADONLYVIEWS", false);
             }
 
             // Load initial data
@@ -540,8 +552,8 @@
             await Task.Delay(300);
             // Load Entire Baseline Hierarchy data
             InitialTreeItems = await LoadAllBaselineHierarchyData(BaselineId);
-            
-            // Hide Parking Lot in read-only mode if empty 
+
+            // Hide Parking Lot in read-only mode if empty
             RemoveParkingLotIfEmpty(InitialTreeItems);
 
             _linearIds = InitialTreeItems.Flatten()
@@ -561,7 +573,7 @@
             }
 
 
-            showLoadingMessage = false; 
+            showLoadingMessage = false;
 
             StateHasChanged();
 
@@ -961,6 +973,12 @@
         // PHASE 5: Add estimation info only if in Read-Only view
         if (ViewSettings.ReadOnlyView)
         {
+            // If ShowPropertiesInReadOnlyViews is false, we skip showing estimation info
+            if (ViewSettings.ShowPropertiesInReadOnlyViews == false)
+            {
+                return string.Empty;
+            }
+
             // I want to return empty string if estimation unit is null or whitespace to avoid showing [N/A 0] for items without estimation
             if (string.IsNullOrWhiteSpace(presenter.EstimationUnit) && presenter.RolledUpEstimation == 0)
             {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -4,6 +4,7 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 *@
 
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using OpenRose.WebUI.Client.Services.JsonFile
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Components.EventServices
@@ -19,6 +20,7 @@
 @inject ViewSettingsService ViewSettings
 @inject BaselineTreeNodeItemzSelectionServiceForJson BaselineItemzSelectionServiceForJson
 @inject IJSRuntime JS
+@inject ProtectedSessionStorage SessionStorage
 @implements IDisposable
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
@@ -334,6 +336,22 @@
         await ReloadTreeAsync();
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // Load view settings for ShowPropertiesInReadOnlyViews
+        var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
+        if (resultShowProperties.Success)
+        {
+            ViewSettings.ShowPropertiesInReadOnlyViews = resultShowProperties.Value;
+        }
+        else
+        {
+            // If not set in session, default to false and save it
+            ViewSettings.ShowPropertiesInReadOnlyViews = false;
+            await SessionStorage.SetAsync("SHOWPROPERTIESINREADONLYVIEWS", false);
+        }
+    }
+
     private async Task HandleStateChangedAsync()
     {
 
@@ -537,6 +555,12 @@
             return string.Empty;
 
         if (ViewSettings.IsKioskMode)
+        {
+            return string.Empty;
+        }
+
+        // If ShowPropertiesInReadOnlyViews is false, we skip showing estimation info
+        if (ViewSettings.ShowPropertiesInReadOnlyViews == false)
         {
             return string.Empty;
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -112,10 +112,13 @@
 							<GoToOriginalItemzButton BaselineItemzId="@singleBaselineItemz.Id" UseTreeView="true" />
 							<ShowHierarchyTreeButton RecordId="@singleBaselineItemz.Id" />
 							</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemz.Status</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @singleBaselineItemz.Priority</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @singleBaselineItemz.Severity</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzId" /></div>
+							@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+							{
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemz.Status</div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @singleBaselineItemz.Priority</div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @singleBaselineItemz.Severity</div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzId" /></div>
+							}
 						</div>
 					</MudBreakpointProvider>
 					}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -100,16 +100,19 @@
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
                         </div>
-                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      :</strong> @_baselineItemz.Status</div>
-                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @_baselineItemz.Priority</div>
-                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @_baselineItemz.Severity</div>
-                        @if (!string.IsNullOrEmpty(_baselineItemz.EstimationUnit))
+                        @if (ViewSettings.ShowPropertiesInReadOnlyViews)
                         {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_baselineItemz.EstimationUnit] : </strong> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </div>
-                        }
-                        else
-                        {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      :</strong> @_baselineItemz.Status</div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority    : </strong> @_baselineItemz.Priority</div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity    : </strong> @_baselineItemz.Severity</div>
+                            @if (!string.IsNullOrEmpty(_baselineItemz.EstimationUnit))
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_baselineItemz.EstimationUnit] : </strong> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </div>
+                            }
+                            else
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>> @_baselineItemz.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemz.RolledUpEstimation </div>
+                            }
                         }
                         </div>
                     </MudBreakpointProvider>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -92,11 +92,15 @@
 														 UseTreeView="true" />
 							<ShowHierarchyTreeButton RecordId="@singleBaselineItemzType.Id" />
 							</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemzType.Status</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" /></div>
+							@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+							{
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemzType.Status</div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" /></div>
+							}
 						</div>
-					</MudBreakpointProvider>					}				
+					</MudBreakpointProvider>					
+					}				
 					<br />
 					<div class="custom-markdown-editor">
 						@if (!string.IsNullOrEmpty(singleBaselineItemzType.Description))

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -77,15 +77,18 @@
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
                         </div>
-                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status:</strong> @_baselineItemzType.Status</div>
-                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(_baselineItemzType.IsSystem ? "Yes" : "No")</div>
-                        @if (!string.IsNullOrEmpty(_baselineItemzType.EstimationUnit))
+                        @if (ViewSettings.ShowPropertiesInReadOnlyViews)
                         {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "")Estimation [@_baselineItemzType.EstimationUnit] : </strong> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </div>
-                        }
-                        else
-                        {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status:</strong> @_baselineItemzType.Status</div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(_baselineItemzType.IsSystem ? "Yes" : "No")</div>
+                            @if (!string.IsNullOrEmpty(_baselineItemzType.EstimationUnit))
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "")Estimation [@_baselineItemzType.EstimationUnit] : </strong> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </div>
+                            }
+                            else
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_baselineItemzType.OwnEstimation <b>|| Roll-Up</b> :@_baselineItemzType.RolledUpEstimation </div>
+                            }
                         }
                         </div>
                     </MudBreakpointProvider>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -117,10 +117,13 @@
                                     </MudTooltip>
                                     <ShowHierarchyTreeButton RecordId="@singleItemz.Id" />
                                 </div>
-                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status :</strong> @singleItemz.Status</div>
-                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority :</strong> @singleItemz.Priority</div>
-                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity :</strong> @singleItemz.Severity</div>
-                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzId" /></div>
+                                @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                                {
+                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status :</strong> @singleItemz.Status</div>
+                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Priority :</strong> @singleItemz.Priority</div>
+                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Severity :</strong> @singleItemz.Severity</div>
+                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzId" /></div>
+                                }
                             </div>
                         </MudBreakpointProvider>
                     }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -99,16 +99,19 @@
                                     <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                                 </MudTooltip>
                             </div>
-                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_itemz.Status</div>
-                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Priority    : </strong> @_itemz.Priority</div>
-                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Severity    : </strong> @_itemz.Severity</div>
-                            @if (!string.IsNullOrEmpty(_itemz.EstimationUnit))
+                            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
                             {
-                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemz.EstimationUnit] : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
-                            }
-                            else
-                            {
-                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
+                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_itemz.Status</div>
+                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Priority    : </strong> @_itemz.Priority</div>
+                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Severity    : </strong> @_itemz.Severity</div>
+                                @if (!string.IsNullOrEmpty(_itemz.EstimationUnit))
+                                {
+                                    <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemz.EstimationUnit] : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
+                                }
+                                else
+                                {
+                                    <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
+                                }
                             }
                         </div>
                     </MudBreakpointProvider>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -86,8 +86,11 @@
 							</MudTooltip>
 							<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
 							</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Status : </strong> @singleItemzType.Status</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzTypeId" /> </div>
+							@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+							{
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Status : </strong> @singleItemzType.Status</div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzTypeId" /> </div>
+							}
 						</div>
 					</MudBreakpointProvider>
 					}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -76,14 +76,18 @@
                             <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                         </MudTooltip>
                         </div>
-                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status : </strong> @_itemzType.Status</div>
-                    @if (!string.IsNullOrEmpty(_itemzType.EstimationUnit))
+
+                    @if (ViewSettings.ShowPropertiesInReadOnlyViews)
                     {
-                        <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemzType.EstimationUnit] : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
-                    }
-                    else
-                    {
-                        <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
+                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status : </strong> @_itemzType.Status</div>
+                        @if (!string.IsNullOrEmpty(_itemzType.EstimationUnit))
+                        {
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemzType.EstimationUnit] : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
+                        }
+                        else
+                        {
+                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
+                        }
                     }
                     </div>
                 </MudBreakpointProvider>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -80,16 +80,19 @@
                                     flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
                                     flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
                                     ">
-                            <div style="display:flex; align-items:center; gap:6px;">
+							<div style="display:flex; align-items:center; gap:6px;">
 								<strong>ID : </strong>
 								<CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
 								<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
 									<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
 								</MudTooltip>
 							</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleProject.Status </div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong>  <EstimationReadOnlyComponent RecordId="@ProjectId" /> </div>
-						</div>
+							@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+							{
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleProject.Status </div>
+								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong>  <EstimationReadOnlyComponent RecordId="@ProjectId" /> </div>
+							}
+							</div>
 					</MudBreakpointProvider>
 					}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -74,14 +74,17 @@
                                     <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
                                 </MudTooltip>
                             </div>
-                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_project.Status</div>
-                        @if (!string.IsNullOrEmpty(_project.EstimationUnit))
+                        @if (ViewSettings.ShowPropertiesInReadOnlyViews)
                         {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_project.EstimationUnit] : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
-                        }
-                        else
-                        {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
+                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_project.Status</div>
+                            @if (!string.IsNullOrEmpty(_project.EstimationUnit))
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_project.EstimationUnit] : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
+                            }
+                            else
+                            {
+                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
+                            }
                         }
                         </div>
                     </MudBreakpointProvider>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -536,11 +536,24 @@
     {
         if (firstRender)
         {
-            // Load view settings
+            // Load view settings for ReadOnlyView
             var result = await SessionStorage.GetAsync<bool>("READONLYVIEW");
             if (result.Success)
             {
                 ViewSettings.ReadOnlyView = result.Value;
+            }
+
+            // Load view settings for ShowPropertiesInReadOnlyViews
+            var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
+            if (resultShowProperties.Success)
+            {
+                ViewSettings.ShowPropertiesInReadOnlyViews = resultShowProperties.Value;
+            }
+            else
+            {
+                // If not set in session, default to false and save it
+                ViewSettings.ShowPropertiesInReadOnlyViews = false;
+                await SessionStorage.SetAsync("SHOWPROPERTIESINREADONLYVIEWS", false);
             }
 
             // Load initial data
@@ -552,7 +565,7 @@
 
             if (ViewSettings.ReadOnlyView)
             {
-                // Apply Parking Lot hiding logic 
+                // Apply Parking Lot hiding logic
                 RemoveParkingLotIfEmpty(InitialTreeItems);
             }
 
@@ -582,9 +595,9 @@
 
             if (AutoSelectedRecordId.HasValue)
             {
-                // Select the node after the first render 
+                // Select the node after the first render
 
-                // This Task.Delay is important to allow full 
+                // This Task.Delay is important to allow full
                 // rendering which could take some time for large project.
                 // await Task.Delay(500);
 
@@ -909,6 +922,11 @@
         // PHASE 5: Add estimation info only if in Read-Only view
         if (ViewSettings.ReadOnlyView)
         {
+            // If ShowPropertiesInReadOnlyViews is false, we skip showing estimation info
+            if(ViewSettings.ShowPropertiesInReadOnlyViews == false)
+            {
+                return string.Empty;
+            }
             // I want to return empty string if estimation unit is null or whitespace to avoid showing [N/A 0] for items without estimation
             if (string.IsNullOrWhiteSpace(presenter.EstimationUnit) && presenter.RolledUpEstimation == 0)
             {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -5,6 +5,7 @@
 *@
 
 
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using OpenRose.WebUI.Client.Services.JsonFile
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Components.EventServices
@@ -19,6 +20,7 @@
 @inject ViewSettingsService ViewSettings
 @inject TreeNodeItemzSelectionServiceForJson ItemzSelectionServiceForJson
 @inject IJSRuntime JS
+@inject ProtectedSessionStorage SessionStorage
 @implements IDisposable
 
 
@@ -224,10 +226,27 @@
 
     }
 
+
     protected override async Task OnParametersSetAsync()
     {
         await ReloadTreeAsync();
     }   
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // Load view settings for ShowPropertiesInReadOnlyViews
+        var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
+        if (resultShowProperties.Success)
+        {
+            ViewSettings.ShowPropertiesInReadOnlyViews = resultShowProperties.Value;
+        }
+        else
+        {
+            // If not set in session, default to false and save it
+            ViewSettings.ShowPropertiesInReadOnlyViews = false;
+            await SessionStorage.SetAsync("SHOWPROPERTIESINREADONLYVIEWS", false);
+        }
+    }
 
 
     private async Task HandleStateChangedAsync()
@@ -423,7 +442,13 @@
         {
             return string.Empty;
         }
-
+        
+        // If ShowPropertiesInReadOnlyViews is false, we skip showing estimation info
+        if (ViewSettings.ShowPropertiesInReadOnlyViews == false)
+        {
+            return string.Empty;
+        }
+        
         // NEW: Show estimation in read-only view if available
         if (showEstimation )
         {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Settings/Settings.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Settings/Settings.razor
@@ -10,10 +10,13 @@
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.Orphan.DeleteAllOrphan
 @using OpenRose.WebUI.Services
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @inject DataSourceStateService DataSourceState
 @inject AssemblyInfoService AssemblyInfo
 @inject NavigationManager Nav
 @inject IDialogService Dialogs
+@inject ViewSettingsService ViewSettings
+@inject ProtectedSessionStorage SessionStorage
 
 <MudPaper Class="pa-3 mb-3 align-start d-flex" Outlined="false">
     <MudStack Row="true" Spacing="3">
@@ -44,10 +47,53 @@
 </MudPaper>
 
 <!-- ============================================================
+     VIEW PREFERENCES SECTION - NEW
+     Always displayed regardless of data source configuration
+     ============================================================ -->
+<MudPaper Class="pa-3 mb-3" Outlined="false">
+    <MudStack Row="true" Spacing="3">
+        <MudIcon Icon="@Icons.Material.Filled.Visibility" Size="Size.Large" />
+        <MudText Typo="Typo.h6" Class="mb-2">View Preferences</MudText>
+    </MudStack>
+
+    <MudDivider Class="my-3" />
+
+    <!-- Show Properties in Read-Only Views Toggle -->
+    <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Center" Class="mt-3">
+
+        <MudTooltip Text="Properties like Stauts, Estimation, Priority, Severity" Placement="Placement.Top">
+            <MudText Typo="Typo.body2" Class="ms-5" >
+                Show Properties in Read-Only Views
+            </MudText>
+        </MudTooltip>
+
+@*         <MudSwitch T="bool"
+                   Value="@ViewSettings.ReadOnlyView"
+                   ValueChanged="ToggleReadOnly"
+                   Label="Read-Only"
+                   Color="Color.Secondary"
+                   LabelPlacement="Placement.End" /> *@
+
+        <MudSwitch T="bool"
+                   Value="@ViewSettings.ShowPropertiesInReadOnlyViews"
+                   ValueChanged="ToggleShowPropertiesInReadOnlyViews"
+                   Color="Color.Primary"
+                   Class="ma-0" />
+
+@*         <MudSwitch T="bool"
+                   @bind-Checked="ViewSettings.ShowPropertiesInReadOnlyViews"
+                   ValueChanged="ToggleShowPropertiesInReadOnlyViews"
+                   Color="Color.Primary"
+                   Class="ma-0" />
+ *@
+    </MudStack>
+</MudPaper>
+
+<!-- ============================================================
      DATA SOURCE MODE SECTION
      ============================================================ -->
 <MudPaper Class="pa-3 mb-3" Outlined="false">
-    
+
     <MudStack Row="true" Spacing="3">
         <MudIcon Icon="@Icons.Material.Filled.Cable" Size="Size.Large" />
         <MudText Typo="Typo.h6" Class="mb-2">Data Source Mode</MudText>
@@ -61,7 +107,7 @@
         }
         else if (DataSourceState.CurrentDataSourceState.IsServerJsonMode)
         {
-@*             <MudChip T="string" Color="Color.Warning" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
+            @*             <MudChip T="string" Color="Color.Warning" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
                 Server JSON Mode
             </MudChip> *@
 
@@ -72,7 +118,7 @@
         }
         else if (DataSourceState.CurrentDataSourceState.IsClientJsonMode)
         {
-@*             <MudChip T="string" Color="Color.Info" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
+            @*             <MudChip T="string" Color="Color.Info" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
                 Client JSON Mode
             </MudChip> *@
 
@@ -81,7 +127,7 @@
                 <MudChip T="string" Color="Color.Info" Variant="Variant.Filled">CLIENT JSON MODE</MudChip>
             </MudButton>
         }
-        else 
+        else
         {
             <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Filled" Class="mb-2">
                 NONE
@@ -167,7 +213,7 @@
     }
 
     @if (ConfigService.IsOpenRoseAPIConfigured ||
-        string.IsNullOrEmpty(ConfigService.ApiVersionMismatchMessage))
+            string.IsNullOrEmpty(ConfigService.ApiVersionMismatchMessage))
     {
         <DeleteAllOrphanComponent />
     }
@@ -182,6 +228,18 @@
     protected override async Task OnInitializedAsync()
     {
         version = AssemblyInfo.GetAssemblyVersion();
+
+        // Load the ShowPropertiesInReadOnlyViews setting from session storage on page load
+        var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
+        if (resultShowProperties.Success)
+        {
+            ViewSettings.ShowPropertiesInReadOnlyViews = resultShowProperties.Value;
+        }
+        else
+        {
+            // If not set in session, default to false
+            ViewSettings.ShowPropertiesInReadOnlyViews = false;
+        }
     }
 
     /// <summary>
@@ -206,6 +264,30 @@
             dialogParameters,
             dialogOptions
         );
+    }
+
+    /// <summary>
+    /// Handles toggling of ShowPropertiesInReadOnlyViews preference.
+    ///
+    /// EXPLANATION: This method is called whenever the user changes the toggle switch
+    /// for showing properties in read-only views. It updates the ViewSettingsService
+    /// property and persists the user preference to browser session storage so that
+    /// the setting is retained during the user's session.
+    ///
+    /// The session storage key "SHOWPROPERTIESINREADONLYVIEWS" is used consistently
+    /// across all components that need to access this setting (ProjectTreeView.razor,
+    /// BaselineTreeView.razor, and all read-only component files).
+    /// </summary>
+    private async Task ToggleShowPropertiesInReadOnlyViews(bool newValue)
+    {
+        // Update the service property
+        ViewSettings.ShowPropertiesInReadOnlyViews = newValue;
+
+        // Persist the setting to browser session storage
+        await SessionStorage.SetAsync("SHOWPROPERTIESINREADONLYVIEWS", newValue);
+
+        // Force a state refresh so the UI updates
+        StateHasChanged();
     }
 
     // ============================================================

--- a/OpenRose.Web/OpenRose.WebUI/Services/ViewSettingsService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/ViewSettingsService.cs
@@ -87,6 +87,28 @@ namespace OpenRose.WebUI.Services
 		/// </summary>
 		public bool ShowTraceabilityInItemzDetails { get; set; } = true;
 
+		/// <summary>
+		/// NEW PROPERTY: Controls whether to display properties (Status, Priority, Severity, Estimation)
+		/// in Read-Only views for Project, ItemzType, Itemz, and their Baseline equivalents.
+		/// 
+		/// EXPLANATION: When user is in Read-Only mode and has enabled this setting,
+		/// property details will be displayed in the read-only components. When false,
+		/// only the item name and description are shown, making the UI cleaner.
+		/// 
+		/// Example, When ShowPropertiesInReadOnlyViews is true:
+		/// - Status, Priority, Severity, and Estimation information is displayed
+		/// - EndText in TreeView nodes shows property information
+		/// 
+		/// Example, When ShowPropertiesInReadOnlyViews is false:
+		/// - Property sections are hidden from view
+		/// - EndText in TreeView nodes is empty
+		/// - Cleaner, minimal UI for viewing
+		/// 
+		/// This setting is stored in browser session storage using key "SHOWPROPERTIESINREADONLYVIEWS"
+		/// and defaults to false (properties hidden by default).
+		/// </summary>
+		public bool ShowPropertiesInReadOnlyViews { get; set; } = false;
+
 		public bool IsKioskMode { get; private set; } = false;
 
 		public event Action? OnKioskModeChanged;


### PR DESCRIPTION
By default in each read only view we now use Session based 'ShowPropertiesInReadOnlyViews' settings for deciding on set of properties to be visualized or shall remain hidden for following views within ReadOnly TreeViews

ProjectReadOnlyView & ProjectReadOnlyViewForJSON
ItemzTypeReadOnlyView &  ItemzTypeReadOnlyViewForJSON
ItemzReadOnlyView &  ItemzReadOnlyViewForJSON

BaselineReadOnlyView & BaselineReadOnlyViewForJSON
BaselineItemzTypeReadOnlyView &  BaselineItemzTypeReadOnlyViewForJSON
BaselineItemzReadOnlyView &  BaselineItemzReadOnlyViewForJSON

This means now user can control using Settings page if they would like to see properties like Status, Estimation, Priority, Severity, etc. when they load Read Only views from LIVE Project or from JSON data files. 

By default such properties will be hidden and user can make it visible by going into Settings option page.


