### PR TITLE
Show warning about data count impacted due to delete opration

### DIFF
--- a/OpenRose.API/Controllers/BaselinesController.cs
+++ b/OpenRose.API/Controllers/BaselinesController.cs
@@ -591,15 +591,46 @@ namespace ItemzApp.API.Controllers
         }
 
 
+		/// <summary>
+		/// Get total number of BaselineItemz by Project
+		/// </summary>
+		/// <param name="projectId">Provide ProjectID representated in GUID form</param>
+		/// <returns>Number of BaselineItemz found for the given ProjectID. Zero if none found.</returns>
+		/// <response code="200">Returns number of BaselineItemz count that were associated with a given Project</response>
+		/// <response code="404">Project based on projectId was not found</response>
+		[HttpGet("GetBaselineItemzCountByProject/{projectId:Guid}", Name = "__GET_BaselineItemz_Count_By_Project__")]
+		[HttpHead("GetBaselineItemzCountByProject/{projectId:Guid}", Name = "__HEAD_BaselineItemz_Count_By_Project__")]
+		[ProducesResponseType(StatusCodes.Status200OK, Type = typeof(int))]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		[ProducesDefaultResponseType]
+		public async Task<ActionResult<int>> GetBaselineItemzCountByProjectAsync(Guid projectId)
+		{
+			if (!(await _baselineRepository.ProjectExistsAsync(projectId)))
+			{
+				_logger.LogDebug("{FormattedControllerAndActionNames}Cannot find count of BaselineItemz as Project with ID {ProjectId} could not be found",
+					ControllerAndActionNames.GetFormattedControllerAndActionNames(ControllerContext),
+					projectId);
+				return NotFound();
+			}
 
-        /// <summary>
-        /// Get total number of BaselineItemz Traces by Baseline
-        /// </summary>
-        /// <param name="BaselineId">Provide BaselineID representated in GUID form</param>
-        /// <returns>Number of BaselineItemz Traces found for the given BaselineID. Zero if none found.</returns>
-        /// <response code="200">Returns number of BaselineItemz Traces count that are associated with a given Baseline</response>
-        /// <response code="404">Baseline based on baselineId was not found</response>
-        [HttpGet("GetBaselineItemzTraceCount/{BaselineId:Guid}", Name = "__GET_BaselineItemz_Trace_Count_By_Baseline__")]
+			var foundBaselineItemzCountByProjectId = await _baselineRepository.GetBaselineItemzCountByProjectAsync(projectId);
+			_logger.LogDebug("{FormattedControllerAndActionNames} Found {foundBaselineItemzCountByProjectId} BaselineItemz records for Project with ID {projectId}",
+				ControllerAndActionNames.GetFormattedControllerAndActionNames(ControllerContext),
+				foundBaselineItemzCountByProjectId,
+				projectId);
+			return foundBaselineItemzCountByProjectId;
+		}
+
+
+
+		/// <summary>
+		/// Get total number of BaselineItemz Traces by Baseline
+		/// </summary>
+		/// <param name="BaselineId">Provide BaselineID representated in GUID form</param>
+		/// <returns>Number of BaselineItemz Traces found for the given BaselineID. Zero if none found.</returns>
+		/// <response code="200">Returns number of BaselineItemz Traces count that are associated with a given Baseline</response>
+		/// <response code="404">Baseline based on baselineId was not found</response>
+		[HttpGet("GetBaselineItemzTraceCount/{BaselineId:Guid}", Name = "__GET_BaselineItemz_Trace_Count_By_Baseline__")]
         [HttpHead("GetBaselineItemzTraceCount/{BaselineId:Guid}", Name = "__HEAD_BaselineItemz_Trace_Count_By_Baseline__")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(int))]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/OpenRose.API/DbContexts/SQLHelper/SQLStatements.cs
+++ b/OpenRose.API/DbContexts/SQLHelper/SQLStatements.cs
@@ -156,7 +156,15 @@ namespace ItemzApp.API.DbContexts.SQLHelper
             "AND RecordType = 'BaselineItemz' " +
             "AND BaselineItemzHierarchyId.GetLevel() > 3 ";
 
-        public static readonly string SQLStatementFor_GetBaselineItemzByItemzId =
+		public static readonly string SQLStatementFor_GetBaselineItemzCountByProject =
+			"select count(Id) from BaselineItemzHierarchy " +
+			"where BaselineItemzHierarchyId.IsDescendantOf( " +
+				"(SELECT BaselineItemzHierarchyId FROM BaselineItemzHierarchy WHERE id = @__ProjectID__)" +
+			") = 1 " +
+			"AND RecordType = 'BaselineItemz' " +
+			"AND BaselineItemzHierarchyId.GetLevel() > 3 ";
+
+		public static readonly string SQLStatementFor_GetBaselineItemzByItemzId =
             "select count(Id) from [dbo].[BaselineItemz] as bi " +
             "where bi.ItemzId = @__ItemzId__";
 

--- a/OpenRose.API/Services/BaselineRepository.cs
+++ b/OpenRose.API/Services/BaselineRepository.cs
@@ -404,7 +404,24 @@ namespace ItemzApp.API.Services
             return foundItemzByBaseline;
         }
 
-        public async Task<int> GetBaselineItemzTraceCountByBaselineAsync(Guid BaselineId)
+		public async Task<int> GetBaselineItemzCountByProjectAsync(Guid ProjectId)
+		{
+			if (ProjectId == Guid.Empty)
+			{
+				throw new ArgumentNullException(nameof(ProjectId));
+			}
+			KeyValuePair<string, object>[] sqlArgs = new KeyValuePair<string, object>[]
+			{
+				new KeyValuePair<string, object>("@__ProjectID__", ProjectId.ToString()),
+			};
+			var foundItemzByProject = await _baselineContext.CountByRawSqlAsync(SQLStatements.SQLStatementFor_GetBaselineItemzCountByProject, sqlArgs);
+
+			return foundItemzByProject;
+		}
+
+
+
+		public async Task<int> GetBaselineItemzTraceCountByBaselineAsync(Guid BaselineId)
         {
             if (BaselineId == Guid.Empty)
             {

--- a/OpenRose.API/Services/IBaselineRepository.cs
+++ b/OpenRose.API/Services/IBaselineRepository.cs
@@ -39,7 +39,10 @@ namespace ItemzApp.API.Services
 
         Task<int> GetBaselineItemzCountByBaselineAsync(Guid BaselineId);
 
-        Task<int> GetBaselineItemzTraceCountByBaselineAsync(Guid BaselineId);
+        Task<int> GetBaselineItemzCountByProjectAsync(Guid ProjectId);
+
+
+		Task<int> GetBaselineItemzTraceCountByBaselineAsync(Guid BaselineId);
 
         Task<int> GetIncludedBaselineItemzCountByBaselineAsync(Guid BaselineId);
 

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Baselines/BaselinesService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Baselines/BaselinesService.cs
@@ -359,6 +359,40 @@ namespace OpenRose.WebUI.Client.Services.Baselines
 
 		#endregion
 
+		#region __GET_BaselineItemz_Count_By_Project__Async
+		public async Task<int> __GET_BaselineItemz_Count_By_Project__Async(Guid projectId)
+		{
+			return await __GET_BaselineItemz_Count_By_Project__Async(projectId, CancellationToken.None);
+		}
+		public async Task<int> __GET_BaselineItemz_Count_By_Project__Async(Guid projectId, CancellationToken cancellationToken)
+		{
+			try
+			{
+				if (projectId == Guid.Empty)
+				{
+					throw new ArgumentNullException(nameof(projectId) + "is required for which value is not provided");
+				}
+
+				// TODO :: Utilize urlBuilder which is commented below.
+				//var urlBuilder_ = new System.Text.StringBuilder();
+				//urlBuilder_.Append($"/api/Baselines/GetBaselineItemzCountByProject/{projectId.ToString()}");
+				//urlBuilder_.Append('?');
+
+				//urlBuilder_.Length--;
+
+				var response = await _httpClient.GetFromJsonAsync<int>($"/api/Baselines/GetBaselineItemzCountByProject/{projectId.ToString()}", cancellationToken);
+
+				return response!;
+			}
+			catch (Exception)
+			{
+
+			}
+			return default;
+		}
+
+		#endregion
+
 		#region __GET_BaselineItemz_Trace_Count_By_Baseline__Async
 		public async Task<int> __GET_BaselineItemz_Trace_Count_By_Baseline__Async(Guid baselineId)
 		{

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Baselines/DummyBaselinesService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Baselines/DummyBaselinesService.cs
@@ -23,7 +23,12 @@ namespace OpenRose.WebUI.Client.Services.Baselines
             throw new NotImplementedException();
         }
 
-        public Task<int> __GET_BaselineItemz_Trace_Count_By_Baseline__Async(Guid baselineId)
+		public Task<int> __GET_BaselineItemz_Count_By_Project__Async(Guid projectId)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task<int> __GET_BaselineItemz_Trace_Count_By_Baseline__Async(Guid baselineId)
         {
             throw new NotImplementedException();
         }

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Baselines/IBaselinesService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Baselines/IBaselinesService.cs
@@ -23,6 +23,8 @@ namespace OpenRose.WebUI.Client.Services.Baselines
 
 		public Task<int> __GET_BaselineItemz_Count_By_Baseline__Async(Guid baselineId);
 
+		public Task<int> __GET_BaselineItemz_Count_By_Project__Async(Guid projectId);
+
 		public Task<int> __GET_BaselineItemz_Trace_Count_By_Baseline__Async(Guid baselineId);
 
 		public Task<int> __GET_Included_BaselineItemz_Count_By_Baseline__Async(Guid baselineId);

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDeletionConfirmDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDeletionConfirmDialog.razor
@@ -9,7 +9,7 @@
         <MudText Color="Color.Error">CONFIRM</MudText>
     </TitleContent>
     <DialogContent>
-        <p style="color:red;">
+@*         <p style="color:red;">
         <MudIcon Icon="@Icons.Material.Filled.Dangerous" Size="Size.Large" Color="Color.Error" Title="Delete Baseline" />
             THIS IS IRREVERSABLE OPERATION!
         </p>
@@ -18,7 +18,22 @@
         </p>
         <p style="color:red; align-content:center">
            <b> @deletingBaselineName.ToString() </b>
+        </p> *@
+
+        <p style="color:red;">
+            <MudIcon Icon="@Icons.Material.Filled.Dangerous" Size="Size.Large" Color="Color.Error" Title="Delete Baseline" />
+            THIS IS IRREVERSABLE OPERATION!
         </p>
+        <p style="color:red; align-content:center">
+            Are you sure you want to delete following Baseline?
+        </p>
+        <p style="color:red; align-content:center">
+            <b> @deletingBaselineName.ToString() </b>
+        </p>
+        <MudPaper Class="pa-4" Elevation="2" Style="background-color:#FFF3F3;">
+            <MudText Color="Color.Error"><b>Deletion Impact Summary</b></MudText>
+            <MudText Color="Color.Error">Baseline Itemz:<b> @baselineItemzCount </b></MudText>
+        </MudPaper>
     </DialogContent>
     <DialogActions>
         <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="Submit">Yes</MudButton>
@@ -32,6 +47,8 @@
 
     [Parameter]
     public string deletingBaselineName { get; set; }
+    [Parameter]
+    public int baselineItemzCount { get; set; }
 
     private void Submit() => MudDialog.Close(DialogResult.Ok(true));
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
@@ -469,9 +469,13 @@
 
 	private async Task OpenDeleteConfirmationDialogAsync(string baselineName)
 	{
+		var baselineItemzCount = await baselinesService.__GET_BaselineItemz_Count_By_Baseline__Async(BaselineId);
+
 		var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, Position = DialogPosition.Center };
 		var dialogPara = new DialogParameters();
 		dialogPara.Add("deletingBaselineName", baselineName);
+		dialogPara.Add("baselineItemzCount", baselineItemzCount);
+
 		var dialogref = await DialogService.ShowAsync<BaselineDeletionConfirmDialog>("CONFIRM", parameters: dialogPara, options);
 		var dialogresult = await dialogref.Result;
 		if (!(dialogresult!.Canceled))

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/ProjectBaselineComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/ProjectBaselineComponent.razor
@@ -685,9 +685,12 @@ else
 
 	public async Task deleteBaseline(Guid baselineId, string? baselineName = "")
 	{
+		var baselineItemzCount = await baselinesService.__GET_BaselineItemz_Count_By_Baseline__Async(baselineId);
 		var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, Position = DialogPosition.Center };
 		var dialogPara = new DialogParameters();
 		dialogPara.Add("deletingBaselineName", baselineName);
+		dialogPara.Add("baselineItemzCount", baselineItemzCount);
+
 		var dialogref = await DialogService.ShowAsync<BaselineDeletionConfirmDialog>("CONFIRM", parameters: dialogPara, options);
 		var dialogresult = await dialogref.Result;
 		if (!(dialogresult!.Canceled))

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDeletionConfirmDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDeletionConfirmDialog.razor
@@ -9,7 +9,7 @@
         <MudText Color="Color.Error">CONFIRM</MudText>
     </TitleContent>
     <DialogContent>
-        <p style="color:red;">
+@*         <p style="color:red;">
         <MudIcon Icon="@Icons.Material.Filled.Dangerous" Size="Size.Medium" Color="Color.Error" Title="Delete Itemz" />
             @if (AllChildrenCount > 0)
             {
@@ -23,7 +23,21 @@
             {
                 <MudText Typo="Typo.body1" Color="Color.Error"> Are you sure you want to delete selected Itemz? </MudText>
             }
+        </p> *@
+        <p style="color:red;">
+            <MudIcon Icon="@Icons.Material.Filled.Dangerous" Size="Size.Large" Color="Color.Error" Title="Delete Itemz" />
+            THIS IS IRREVERSABLE OPERATION!
         </p>
+        <p style="color:red; align-content:center">
+            Are you sure you want to delete following Itemz?
+        </p>
+        <p style="color:red; align-content:center">
+            <b> @deletingItemzName.ToString() </b>
+        </p>
+        <MudPaper Class="pa-4" Elevation="2" Style="background-color:#FFF3F3;">
+            <MudText Color="Color.Error"><b>Deletion Impact Summary</b></MudText>
+            <MudText Color="Color.Error">Itemz:<b> @(AllChildrenCount + 1) </b></MudText>
+        </MudPaper>
     </DialogContent>
     <DialogActions>
         <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="Submit">Yes</MudButton>
@@ -34,6 +48,8 @@
 @code {
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; }
+    [Parameter]
+    public string deletingItemzName { get; set; }
     [Parameter]
     public int AllChildrenCount { get; set; }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -570,7 +570,7 @@
 
 		await ConvertMarkdownToHtml(singleItemz.Description);
 
-        // Mark that description initialization is complete
+		// Mark that description initialization is complete
 		_initializingDescription = false;
 
 		// Reset dirty state
@@ -641,12 +641,12 @@
 		{
 			await ItemzService.__DELETE_Itemz_By_GUID_ID__Async(ItemzId);
 		}
-        catch (Exception ex)
-        {
-            await OpenExceptionDialogAsync("Problem Deleting Itemz : " + ex.Message);
-            return;
-        }
-	await goBackToParent();
+		catch (Exception ex)
+		{
+			await OpenExceptionDialogAsync("Problem Deleting Itemz : " + ex.Message);
+			return;
+		}
+		await goBackToParent();
 	}
 
 	private async Task OpenDeleteConfirmationDialogAsync()
@@ -675,7 +675,9 @@
 		}
 
 		var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, Position = DialogPosition.Center };
-		var dialogParameters = new DialogParameters { { "AllChildrenCount", allChildrenCount } };
+		var dialogParameters = new DialogParameters();
+		dialogParameters.Add("AllChildrenCount", allChildrenCount );
+		dialogParameters.Add("deletingItemzName", singleItemz.Name);
 		var dialogref = await DialogService.ShowAsync<ItemzDeletionConfirmDialog>(title: "CONFIRM", parameters: dialogParameters , options: options);
 		var dialogresult = await dialogref.Result;
 		if (!(dialogresult!.Canceled))

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDeletionConfirmDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDeletionConfirmDialog.razor
@@ -19,6 +19,10 @@
         <p style="color:red; align-content:center">
             <b> @deletingItemzTypeName.ToString() </b>
         </p>
+        <MudPaper Class="pa-4" Elevation="2" Style="background-color:#FFF3F3;">
+            <MudText Color="Color.Error"><b>Deletion Impact Summary</b></MudText>
+            <MudText Color="Color.Error">Itemz:<b> @ItemzCount </b></MudText>
+        </MudPaper>
     </DialogContent>
     <DialogActions>
         <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="Submit">Yes</MudButton>
@@ -31,6 +35,8 @@
     private IMudDialogInstance MudDialog { get; set; }
     [Parameter]
     public string deletingItemzTypeName { get; set; }
+    [Parameter]
+    public int ItemzCount { get; set; }
 
     private void Submit() => MudDialog.Close(DialogResult.Ok(true));
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -7,6 +7,7 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.Services.ItemzType
+@using OpenRose.WebUI.Client.Services.ItemzTypeItemzsService
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
 @using OpenRose.WebUI.Components.EventServices
@@ -295,6 +296,8 @@
 	[Inject]
 	public IItemzService ItemzService { get; set; }
 	[Inject]
+	public IItemzTypeItemzsService ItemzTypeItemzsService { get; set; }
+	[Inject]
 	public FormStateService FormStateService { get; set; }
 
 	public Guid ParentId { get; set; }
@@ -413,7 +416,7 @@
 		// Now even if user decides to Delete this Itemz Record then also we can go back to it's
 		// Parent ItemzType post completing deletion operation.
 		var httpResponse = await hierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzTypeId);
-        if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check. 
+		if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check. 
 		{
 			ParentId = httpResponse.ParentRecordId;
 		}
@@ -492,11 +495,11 @@
 		{
 			await ItemzTypeService.__DELETE_ItemzType_By_GUID_ID__Async(ItemzTypeId);
 		}
-        catch (Exception ex)
-        {
-            await OpenExceptionDialogAsync("Problem Deleting ItemzType : " + ex.Message);
-            return;
-        }
+		catch (Exception ex)
+		{
+			await OpenExceptionDialogAsync("Problem Deleting ItemzType : " + ex.Message);
+			return;
+		}
 
 		if (ParentId != Guid.Empty)
 		{
@@ -511,9 +514,12 @@
 	}
 	private async Task OpenDeleteConfirmationDialogAsync()
 	{
+		var itemzCount = await ItemzTypeItemzsService.__GET_Itemz_Count_By_ItemzType__Async(singleItemzType.Id);
+
 		var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, Position = DialogPosition.Center };
 		var dialogPara = new DialogParameters();
 		dialogPara.Add("deletingItemzTypeName", singleItemzType.Name);
+		dialogPara.Add("itemzCount", itemzCount);
 		var dialogref = await DialogService.ShowAsync<ItemzTypeDeletionConfirmDialog>("CONFIRM", parameters: dialogPara, options);
 		var dialogresult = await dialogref.Result;
 		if (!(dialogresult!.Canceled))

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -512,6 +512,7 @@
 		}
 
 	}
+
 	private async Task OpenDeleteConfirmationDialogAsync()
 	{
 		var itemzCount = await ItemzTypeItemzsService.__GET_Itemz_Count_By_ItemzType__Async(singleItemzType.Id);

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Orphan/OrphanItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Orphan/OrphanItemz.razor
@@ -143,7 +143,10 @@
     {
 
         var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, Position = DialogPosition.Center };
-        var dialogParameters = new DialogParameters { { "AllChildrenCount", 0 } };
+        var dialogParameters = new DialogParameters();
+        dialogParameters.Add("AllChildrenCount", 0);
+        dialogParameters.Add("deletingItemzName", itemz.Name);
+
         var dialogref = await DialogService.ShowAsync<ItemzDeletionConfirmDialog>(title: "CONFIRM", parameters: dialogParameters, options: options);
         var dialogresult = await dialogref.Result;
         if (!(dialogresult!.Canceled))

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDeletionConfirmDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDeletionConfirmDialog.razor
@@ -18,6 +18,15 @@
         <p style="color:red; align-content:center">
             <b> @deletingProjectName.ToString() </b>
         </p>
+
+        <MudPaper Class="pa-4" Elevation="2" Style="background-color:#FFF3F3;">
+            <MudText Color="Color.Error"><b>Deletion Impact Summary</b></MudText>
+            <MudText Color="Color.Error">Itemz:<b> @ItemzCount </b></MudText>
+            <MudText Color="Color.Error">Baselines:<b> @BaselineCount </b></MudText>
+            <MudText Color="Color.Error">Baseline Itemz:<b> @BaselineItemzCount </b></MudText>
+            <MudDivider Class="my-2" />
+            <MudText Color="Color.Error">Total Records Count:<b> @(ItemzCount + BaselineItemzCount)</b></MudText>
+        </MudPaper>
     </DialogContent>
     <DialogActions>
         <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="Submit">Yes</MudButton>
@@ -28,8 +37,19 @@
 @code {
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; }
+
     [Parameter]
     public string deletingProjectName { get; set; }
+    
+    [Parameter] 
+    public int ItemzCount { get; set; }
+    
+    [Parameter] 
+    public int BaselineItemzCount { get; set; }
+    
+    [Parameter] 
+    public int BaselineCount { get; set; }
+
 
     private void Submit() => MudDialog.Close(DialogResult.Ok(true));
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -4,6 +4,7 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 *@
 
+@using OpenRose.WebUI.Client.Services.Baselines
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.ItemzType
 @using OpenRose.WebUI.Client.Services.Project
@@ -315,6 +316,9 @@
     public IProjectService ProjectService { get; set; }
 
     [Inject]
+    public IBaselinesService BaselineService { get; set; }
+
+    [Inject]
     public IItemzTypeService ItemzTypeService { get; set; }
 
     [Inject]
@@ -521,10 +525,22 @@
     }
     private async Task OpenDeleteConfirmationDialogAsync()
     {
-        activeIndex = 2; // DeleteTab is the 3rd tab in ZERO base index.
+
+
+        var itemzCount = await ProjectService.__GET_Itemz_Count_By_Project__Async(singleProject.Id);
+        var baselineItemzCount = await BaselineService.__GET_BaselineItemz_Count_By_Project__Async(singleProject.Id);
+
+        // You already have GetBaselinesByProjectIDAsync on the server.
+        // Use your existing client-side service to fetch baselines:
+        var baselineCount = await BaselineService.__GET_Baseline_Count_By_Project__Async(singleProject.Id);
+
+        // activeIndex = 3; // DeleteTab is the 4th tab in ZERO base index.
         var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, Position = DialogPosition.Center };
         var dialogPara = new DialogParameters();
         dialogPara.Add("deletingProjectName", singleProject.Name);
+        dialogPara.Add("itemzCount", itemzCount ?? 0 );   
+        dialogPara.Add("baselineItemzCount", baselineItemzCount);
+        dialogPara.Add("baselineCount", baselineCount );
         var dialogref = await DialogService.ShowAsync<ProjectDeletionConfirmDialog>("CONFIRM", parameters: dialogPara, options);
         var dialogresult = await dialogref.Result;
         if (!(dialogresult!.Canceled))


### PR DESCRIPTION
Now in OpenRose, we show information about 'Requirement Items' and / or 'Requirement Baseline Items' that are getting deleted as part of delete button that user can click in 

- Project
- Requirement Items Type
- Requirement Items
- Requirement Baseline

We now show users statistics about total number of actual Requirements Items record either as part of LIVE project or as part of Baseline that would be deleted. 

We received this as request from a user who wanted to be provided not only with the name of the record that is getting deleted but also the actual number of requirements records that would be impacted as well. 

We believe that this will help reduce number of support calls that we otherwise would have received if untrained user deleted data at will. 

