### PR TITLE
UI enhancement to remove unwanted Vertical Scroll Bar to display large content

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -77,7 +77,8 @@
 
 
             <!-- Scrollable Content -->
-            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);">
+@*             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);"> *@
+            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
                 <MudCardContent Style="padding : 6px">
                     @if (tagsList is { Count: > 0 })
                     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -66,7 +66,8 @@
                 </MudCardContent>
             </MudCard>
 
-            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);">
+@*             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);"> *@
+            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
                 <MudCardContent Style="padding : 6px">
                     @if (tagsList is { Count: > 0 })
                     {


### PR DESCRIPTION
Now users using wide screen displays or even small screens like mobile phone will be able to see title and navigation buttons for Itemz in ReadOnly TreeView. This will enhance user experience using Open Rose Requirements Management application on different devices with different screen sizes.