### PR TITLE
Introducing Global Style for Two Columns in Description

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/App.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/App.razor
@@ -30,6 +30,7 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     @*     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" /> *@
     <link rel="stylesheet" href="@Assets["css/github-markdown.min.css"]" /> @* version 5.8.1. was downloaded in Dec 2024 *@
+    <link rel="stylesheet" href="@Assets["css/markdown-styles.css"]" />
     <link rel="stylesheet" href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" />
     <link rel="stylesheet" href="@Assets["_content/CodeBeam.MudBlazor.Extensions/MudExtensions.min.css"]" />
     @*     <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script> *@

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -30,8 +30,7 @@
     else
     {
         <MudItem xs="12">
-            @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
-            <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
+            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -31,8 +31,7 @@
     else
     {
         <MudItem xs="12">
-            @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
-            <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
+            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -30,8 +30,7 @@
     else
     {
         <MudItem xs="12">
-            @* <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;"> *@
-            <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
+            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -129,12 +129,20 @@
                         </MudBreakpointProvider>
                     }
                     <br />
+
                     <div class="custom-markdown-editor">
                         @if (!string.IsNullOrEmpty(singleItemz.Description))
                         {
                             <div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
                         }
                     </div>
+                    <!-- MARKDOWN DESCRIPTION - Dark Mode Support -->
+@*                     <MudPaper Class="pa-4 mb-4" Outlined="true" Elevation="1">
+                        @if (!string.IsNullOrEmpty(singleItemz.Description))
+                        {
+                            <div class="custom-markdown-editor markdown-body">@((MarkupString)convertedMarkdown)</div>
+                        }
+                    </MudPaper> *@
                     <TraceabilityReadOnlyComponent ItemzId="@ItemzId" />
                 </MudCardContent>
             </MudCard>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -32,7 +32,7 @@
     else
     {
         <MudItem xs="12" sm="12">
-            <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
+            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding : 6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -29,7 +29,7 @@
     else
     {
         <MudItem xs="12" sm="12">
-            <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
+            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                     <MudText Typo="Typo.inherit"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -30,7 +30,7 @@
     else
     {
         <MudItem xs="12" sm="12">
-            <MudCard style="background-color:#FABBBB; top:0; z-index:10;">
+            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudText Typo="Typo.inherit"

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/app.css
@@ -115,6 +115,12 @@ h1:focus {
 
 
 /* Used for markdown preview */
+
+/* ============================================================
+   MARKDOWN EDITOR STYLES - See css/markdown-styles.css
+   for globally managed, user-accessible layout patterns
+   ============================================================ */
+
 .custom-markdown-editor ul {
     list-style-type: disc !important;
     margin-left: 20px !important; /* Add margin to ensure bullets are visible */

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/css/markdown-styles.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/css/markdown-styles.css
@@ -2,7 +2,35 @@
  * OpenRose Markdown Global Styles
  * These styles are available for use in Description fields across all record types.
  * Users can apply these pre-defined layout patterns within their markdown content.
+ * 
+ * SUPPORTS: Light Mode & Dark Mode (MudBlazor theme-aware)
+ *
+ * NOTES : THIS CSS FILE OVERRIDES DARK MODE WITH LIGHT MODE IN PRACTICAL USAGE.
  */
+
+/* ============================================================
+   ROOT COLOR VARIABLES - Light & Dark Mode
+   ============================================================ */
+
+:root {
+    /* Light Mode Colors */
+    --or-text-primary: #333333;
+    --or-text-secondary: #666666;
+    --or-bg-light: #ffffff;
+    --or-bg-lighter: #f5f5f5;
+    --or-border-color: #e0e0e0;
+    --or-accent-color: #1976d2;
+}
+
+/* Dark Mode Colors */
+.mud-theme-dark {
+    --or-text-primary: #e8e8e8;
+    --or-text-secondary: #b0b0b0;
+    --or-bg-light: #1e1e1e;
+    --or-bg-lighter: #2a2a2a;
+    --or-border-color: #404040;
+    --or-accent-color: #90caf9;
+}
 
 /* ============================================================
    LAYOUT PATTERNS FOR MARKDOWN CONTENT
@@ -28,7 +56,62 @@
     margin: 0;
     padding: 0;
     width: 100%;
+    color: var(--or-text-primary);
 }
+
+    /* Image styling within layouts */
+    .or-layout-two-column img {
+        flex-shrink: 0;
+        max-height: 800px;
+        object-fit: contain;
+        border-radius: 4px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    }
+
+    /* Ensure text content is always readable */
+    .or-layout-two-column > div {
+        flex: 1;
+        color: var(--or-text-primary);
+    }
+
+    .or-layout-two-column h1,
+    .or-layout-two-column h2,
+    .or-layout-two-column h3,
+    .or-layout-two-column h4,
+    .or-layout-two-column h5,
+    .or-layout-two-column h6 {
+        color: var(--or-text-primary);
+        margin-top: 10px;
+        margin-bottom: 8px;
+    }
+
+    .or-layout-two-column p {
+        color: var(--or-text-primary);
+        line-height: 1.6;
+        margin: 8px 0;
+    }
+
+    .or-layout-two-column ul,
+    .or-layout-two-column ol {
+        color: var(--or-text-primary);
+        margin: 10px 0;
+        padding-left: 20px;
+    }
+
+    .or-layout-two-column li {
+        color: var(--or-text-primary);
+        margin: 5px 0;
+    }
+
+    .or-layout-two-column a {
+        color: var(--or-accent-color);
+        text-decoration: none;
+        border-bottom: 1px solid var(--or-accent-color);
+    }
+
+        .or-layout-two-column a:hover {
+            text-decoration: underline;
+        }
 
 /* Responsive behavior for tablets and mobile */
 @media (max-width: 768px) {
@@ -40,61 +123,367 @@
         .or-layout-two-column img {
             width: 100%;
             height: auto;
+            max-height: 600px;
         }
 
         .or-layout-two-column > div {
-            font-size: 70% !important;
+            font-size: 90%;
+        }
+
+        .or-layout-two-column h1 {
+            font-size: 1.5rem;
+        }
+
+        .or-layout-two-column h2 {
+            font-size: 1.3rem;
+        }
+
+        .or-layout-two-column h3 {
+            font-size: 1.1rem;
         }
 }
 
-/* 
-   Image Styling within layouts
-*/
-.or-layout-two-column img {
-    flex-shrink: 0;
-    max-height: 800px;
-    object-fit: contain;
-}
-
 /* ============================================================
-   TEXT & TYPOGRAPHY
+   TEXT & TYPOGRAPHY PATTERNS
    ============================================================ */
 
 .or-text-centered {
     text-align: center;
+    color: var(--or-text-primary);
 }
 
 .or-text-justified {
     text-align: justify;
+    color: var(--or-text-primary);
+    hyphens: auto;
 }
 
 .or-highlight-box {
-    background-color: #f5f5f5;
-    border-left: 4px solid #1976d2;
+    background-color: var(--or-bg-lighter);
+    border-left: 4px solid var(--or-accent-color);
     padding: 15px;
     margin: 10px 0;
     border-radius: 4px;
+    color: var(--or-text-primary);
+    border: 1px solid var(--or-border-color);
+}
+
+    .or-highlight-box h4 {
+        color: var(--or-text-primary);
+        margin-top: 0;
+    }
+
+    .or-highlight-box p {
+        color: var(--or-text-primary);
+        margin: 0;
+    }
+
+/* ============================================================
+   CODE & PRE-FORMATTED TEXT
+   ============================================================ */
+
+.custom-markdown-editor code,
+.markdown-body code {
+    background-color: var(--or-bg-lighter);
+    color: var(--or-text-primary);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: 'Courier New', monospace;
+    border: 1px solid var(--or-border-color);
+}
+
+.custom-markdown-editor pre,
+.markdown-body pre {
+    background-color: var(--or-bg-lighter);
+    border: 1px solid var(--or-border-color);
+    padding: 12px;
+    border-radius: 4px;
+    overflow-x: auto;
+    color: var(--or-text-primary);
+}
+
+    .custom-markdown-editor pre code,
+    .markdown-body pre code {
+        background-color: transparent;
+        border: none;
+        padding: 0;
+        color: var(--or-text-primary);
+    }
+
+/* ============================================================
+   BASE MARKDOWN STYLES - Custom Markdown Editor
+   ============================================================ */
+
+.custom-markdown-editor {
+    color: var(--or-text-primary);
+}
+
+    .custom-markdown-editor ul {
+        list-style-type: disc !important;
+        margin-left: 20px !important;
+        color: var(--or-text-primary);
+    }
+
+        .custom-markdown-editor ul li {
+            color: var(--or-text-primary) !important;
+        }
+
+            .custom-markdown-editor ul li::marker {
+                content: '\2022  ' !important;
+                color: var(--or-text-primary) !important;
+            }
+
+    .custom-markdown-editor ol {
+        color: var(--or-text-primary);
+    }
+
+        .custom-markdown-editor ol li {
+            color: var(--or-text-primary) !important;
+        }
+
+    .custom-markdown-editor h1,
+    .custom-markdown-editor h2,
+    .custom-markdown-editor h3,
+    .custom-markdown-editor h4,
+    .custom-markdown-editor h5,
+    .custom-markdown-editor h6 {
+        color: var(--or-text-primary);
+        border-bottom: 1px solid var(--or-border-color);
+        padding-bottom: 8px;
+    }
+
+    .custom-markdown-editor p {
+        color: var(--or-text-primary);
+        line-height: 1.6;
+    }
+
+    .custom-markdown-editor a {
+        color: var(--or-accent-color);
+        text-decoration: none;
+        border-bottom: 1px solid var(--or-accent-color);
+    }
+
+        .custom-markdown-editor a:hover {
+            text-decoration: underline;
+        }
+
+    .custom-markdown-editor blockquote {
+        border-left: 4px solid var(--or-accent-color);
+        padding-left: 12px;
+        margin-left: 0;
+        color: var(--or-text-secondary);
+        font-style: italic;
+    }
+
+    .custom-markdown-editor hr {
+        border: none;
+        border-top: 2px solid var(--or-border-color);
+        margin: 20px 0;
+    }
+
+    .custom-markdown-editor table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 10px 0;
+    }
+
+        .custom-markdown-editor table th {
+            background-color: var(--or-bg-lighter);
+            color: var(--or-text-primary);
+            padding: 10px;
+            border: 1px solid var(--or-border-color);
+            text-align: left;
+            font-weight: 600;
+        }
+
+        .custom-markdown-editor table td {
+            padding: 10px;
+            border: 1px solid var(--or-border-color);
+            color: var(--or-text-primary);
+        }
+
+        .custom-markdown-editor table tbody tr:hover {
+            background-color: var(--or-bg-lighter);
+        }
+
+/* ============================================================
+   MARKDOWN BODY - Read-Only Preview
+   ============================================================ */
+
+.markdown-body {
+    color: var(--or-text-primary);
+    line-height: 1.6;
+    background-color: transparent;
+    font-size: 14px;
+}
+
+    .markdown-body h1,
+    .markdown-body h2,
+    .markdown-body h3,
+    .markdown-body h4,
+    .markdown-body h5,
+    .markdown-body h6 {
+        color: var(--or-text-primary);
+        border-bottom: 1px solid var(--or-border-color);
+        padding-bottom: 8px;
+        margin-top: 16px;
+        margin-bottom: 8px;
+    }
+
+    .markdown-body p {
+        color: var(--or-text-primary);
+        margin: 8px 0;
+    }
+
+    .markdown-body ul,
+    .markdown-body ol {
+        color: var(--or-text-primary);
+    }
+
+    .markdown-body li {
+        color: var(--or-text-primary);
+        margin: 4px 0;
+    }
+
+    .markdown-body a {
+        color: var(--or-accent-color);
+        text-decoration: none;
+        border-bottom: 1px solid var(--or-accent-color);
+    }
+
+        .markdown-body a:hover {
+            text-decoration: underline;
+        }
+
+    .markdown-body blockquote {
+        border-left: 4px solid var(--or-accent-color);
+        color: var(--or-text-secondary);
+        padding-left: 12px;
+        margin-left: 0;
+        font-style: italic;
+    }
+
+    .markdown-body code {
+        background-color: var(--or-bg-lighter);
+        color: var(--or-text-primary);
+        padding: 2px 6px;
+        border-radius: 3px;
+        border: 1px solid var(--or-border-color);
+    }
+
+    .markdown-body pre {
+        background-color: var(--or-bg-lighter);
+        border: 1px solid var(--or-border-color);
+        padding: 12px;
+        border-radius: 4px;
+        overflow-x: auto;
+        color: var(--or-text-primary);
+    }
+
+        .markdown-body pre code {
+            background-color: transparent;
+            border: none;
+            padding: 0;
+            color: var(--or-text-primary);
+        }
+
+    .markdown-body table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 10px 0;
+    }
+
+        .markdown-body table th {
+            background-color: var(--or-bg-lighter);
+            color: var(--or-text-primary);
+            padding: 10px;
+            border: 1px solid var(--or-border-color);
+            text-align: left;
+            font-weight: 600;
+        }
+
+        .markdown-body table td {
+            padding: 10px;
+            border: 1px solid var(--or-border-color);
+            color: var(--or-text-primary);
+        }
+
+        .markdown-body table tbody tr:hover {
+            background-color: var(--or-bg-lighter);
+        }
+
+    .markdown-body hr {
+        border: none;
+        border-top: 2px solid var(--or-border-color);
+        margin: 20px 0;
+    }
+
+    .markdown-body img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 4px;
+    }
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+.or-text-muted {
+    color: var(--or-text-secondary) !important;
+}
+
+.or-border {
+    border: 1px solid var(--or-border-color);
+    border-radius: 4px;
+    padding: 10px;
+}
+
+.or-rounded {
+    border-radius: 8px;
 }
 
 /* ============================================================
-   BASE MARKDOWN STYLES
+   ACCESSIBILITY
    ============================================================ */
 
-.custom-markdown-editor ul {
-    list-style-type: disc !important;
-    margin-left: 20px !important;
-}
-
-    .custom-markdown-editor ul li {
-        color: black !important;
+/* Ensure sufficient contrast in all elements */
+.custom-markdown-editor,
+.markdown-body {
+    /* Fallback for users with reduced motion preferences */
+    @media (prefers-reduced-motion: reduce) {
+        * {
+            animation: none !important;
+            transition: none !important;
+        }
     }
+    /* High contrast mode support */
+    @media (prefers-contrast: more) {
+        color: var(--or-text-primary);
 
-        .custom-markdown-editor ul li::marker {
-            content: '\2022  ' !important;
-            color: black !important;
+        h1, h2, h3, h4, h5, h6 {
+            font-weight: 700;
         }
 
-.markdown-body {
-    line-height: 1.6;
-    color: #333;
+        a {
+            text-decoration: underline;
+        }
+    }
+}
+
+/* ============================================================
+   PRINT STYLES
+   ============================================================ */
+
+@media print {
+    .custom-markdown-editor,
+    .markdown-body {
+        color: #000000;
+        background-color: #ffffff;
+    }
+
+        .custom-markdown-editor a,
+        .markdown-body a {
+            color: #0066cc;
+            text-decoration: underline;
+        }
 }

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/css/markdown-styles.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/css/markdown-styles.css
@@ -1,0 +1,100 @@
+﻿/* 
+ * OpenRose Markdown Global Styles
+ * These styles are available for use in Description fields across all record types.
+ * Users can apply these pre-defined layout patterns within their markdown content.
+ */
+
+/* ============================================================
+   LAYOUT PATTERNS FOR MARKDOWN CONTENT
+   ============================================================ */
+
+/* 
+   Container Pattern: Two-Column Layout (Image Left, Content Right)
+   Usage: Wrap image and text content in <div class="or-layout-two-column">
+   
+   Example:
+   <div class="or-layout-two-column">
+     <img src="path/to/image.webp" />
+     <div>
+       ### Your Heading
+       Your content here...
+     </div>
+   </div>
+*/
+.or-layout-two-column {
+    display: flex;
+    align-items: flex-start;
+    gap: 20px;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+/* Responsive behavior for tablets and mobile */
+@media (max-width: 768px) {
+    .or-layout-two-column {
+        flex-direction: column;
+        align-items: center;
+    }
+
+        .or-layout-two-column img {
+            width: 100%;
+            height: auto;
+        }
+
+        .or-layout-two-column > div {
+            font-size: 70% !important;
+        }
+}
+
+/* 
+   Image Styling within layouts
+*/
+.or-layout-two-column img {
+    flex-shrink: 0;
+    max-height: 800px;
+    object-fit: contain;
+}
+
+/* ============================================================
+   TEXT & TYPOGRAPHY
+   ============================================================ */
+
+.or-text-centered {
+    text-align: center;
+}
+
+.or-text-justified {
+    text-align: justify;
+}
+
+.or-highlight-box {
+    background-color: #f5f5f5;
+    border-left: 4px solid #1976d2;
+    padding: 15px;
+    margin: 10px 0;
+    border-radius: 4px;
+}
+
+/* ============================================================
+   BASE MARKDOWN STYLES
+   ============================================================ */
+
+.custom-markdown-editor ul {
+    list-style-type: disc !important;
+    margin-left: 20px !important;
+}
+
+    .custom-markdown-editor ul li {
+        color: black !important;
+    }
+
+        .custom-markdown-editor ul li::marker {
+            content: '\2022  ' !important;
+            color: black !important;
+        }
+
+.markdown-body {
+    line-height: 1.6;
+    color: #333;
+}


### PR DESCRIPTION
Now users will be able to use a custom OpenRose style within description to create two column views which becomes a single column view in Mobile devices. 

Here is the example code for the same....

# OpenRose Markdown Styles Guide

## Overview
OpenRose provides pre-defined, globally managed CSS classes that you can use in Description fields across all record types (Project, ItemzType, Itemz, Baseline, and related records).

## Available Layout Patterns

### Two-Column Layout (Image Left, Content Right)

**Class:** `or-layout-two-column`

**Description:** Creates a side-by-side layout with an image on the left and text content on the right. Automatically stacks on mobile devices.

**Example:**
```html
<div class="or-layout-two-column">
  <img src="/UserFiles/YourUsername/image.webp" height="800px" />
  <div>
    ### Your Heading
    
    Your content goes here. This pattern works great for:
    - Announcements with supporting visuals
    - Requirements with context images
    - Ceremonial or cultural descriptions
    - Any side-by-side presentation
  </div>
</div>