### PR TITLE
Default navigating to Offline Files list when in Server JSON data mode

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -56,7 +56,7 @@
                     @if (!ViewSettings.IsKioskMode)
                     {
                     <MudText Class="ms-4" Color="Color.Secondary">
-                        Read‑Only Baseline View
+                        Read‑Only View
                     </MudText>
                     }
                 </MudPaper>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/JsonFileDataView/JsonHierarchyViewer.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/JsonFileDataView/JsonHierarchyViewer.razor
@@ -32,7 +32,15 @@
     <!-- EXISTING VIEWER LOGIC (UNCHANGED) -->
     @if (!isLoaded)
     {
-        <MudText>Please load a JSON file first.</MudText>
+         
+        if(DataSourceState.CurrentDataSourceState.IsServerJsonMode)
+        {
+            Nav.NavigateTo("/serverdatafiles", replace: true);
+        }
+        else
+        {
+            <MudText>Please load OpenRose exported data JSON file first.</MudText>
+        }
     }
     else
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -53,7 +53,7 @@
                     </MudButton>
                     @if (!ViewSettings.IsKioskMode)
                     {
-                        <MudText Class="ms-4" Color="Color.Secondary">Read‑Only Project View</MudText>
+                        <MudText Class="ms-4" Color="Color.Secondary">Read‑Only View</MudText>
                     }
                 </MudPaper>
 


### PR DESCRIPTION
When user has configured their start-up mode to be non API mode then default start-up mode is Server JSON Data file mode. Now we move to Server JSON Data files list mode when ins configured to be available.

This way, instead of showing message to that no JSON data file has been loaded, it will show list of available Off-line data files configured to be used from the server by the user.


