### PR TITLE
Bug fix -  Requirement Items import with estimations

### DIFF
--- a/OpenRose.API/Services/ImportService.cs
+++ b/OpenRose.API/Services/ImportService.cs
@@ -50,9 +50,6 @@ namespace ItemzApp.API.Services
 											string detectedType,
 											ImportDataPlacementDTO placementDto)
 		{
-			// TODO - Test team reported that first parent record's estimation data import 
-			// and estimation unit import is not working as expected. Please verify and fix if needed.
-
 			var result = new ImportResult
 			{
 				Success = false,
@@ -155,6 +152,16 @@ namespace ItemzApp.API.Services
 					return result;
 				}
 
+				await _itemzRepository.SaveAsync();
+
+				// EXPLANATION: Apply estimation data to the root Itemz after placement is complete.
+				// This mirrors the pattern used for child Itemz records in ImportItemzRecursivelyWithStats,
+				// ensuring consistent behavior for all imported Itemz regardless of hierarchy level.
+				await _itemzRepository.ImportServiceUpdateItemzEstimationInHierarchyAsync(rootEntity.Id
+					, estimationUnit: itemzDto.EstimationUnit
+					, ownEstimation: itemzDto.OwnEstimation
+					, rolledUpEstimation: itemzDto.RolledUpEstimation
+				);
 				await _itemzRepository.SaveAsync();
 
 				// Now that root is placed, import sub-itemz recursively

--- a/OpenRose.API/Services/ImportService.cs
+++ b/OpenRose.API/Services/ImportService.cs
@@ -50,6 +50,9 @@ namespace ItemzApp.API.Services
 											string detectedType,
 											ImportDataPlacementDTO placementDto)
 		{
+			// TODO - Test team reported that first parent record's estimation data import 
+			// and estimation unit import is not working as expected. Please verify and fix if needed.
+
 			var result = new ImportResult
 			{
 				Success = false,


### PR DESCRIPTION
In the past, when we exported a Requirement Item with Requirements Breakdown Structure containing child Requirements and then when we imported the same data back in OpenRose using Import Requirement Items feature then the estimation values for the root requirement item was getting skipped. All the child requirement Items estimations were imported successfully but the root one did not. 

This is now fixed as part of this Pull Request. We now explicitly import estimation data for the root Requirement Item.

