### PR TITLE
Removed redundant ShowDataSourceSwitchControl from ViewSettingsService

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
@@ -179,48 +179,45 @@
 
 		} *@
 
-		@if (ViewSettingsServiceForUiState.ShowDataSourceSwitchControl)
+
+		<!--
+			EXPLANATION:
+			- Live Server button is shown if API is available in configuration.
+			- It is hidden when APISettings is missing or BaseUrl is empty.
+            - It is also hidden when already in API mode since there's no need to switch.
+		-->
+		@if (StartupCapabilities.ApiAvailable && 
+				!DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.IsApiMode)
 		{
-			var state = DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState;
+			<MudIconButton Icon="@Icons.Material.Filled.CloudUpload"
+							Title="Live Server"
+							Color="Color.Inherit"
+							OnClick="@SwitchToApiModeAsync" />
+		}
 
-			<!--
-				EXPLANATION:
-				- Live Server button is shown if API is available in configuration.
-				- It is hidden when APISettings is missing or BaseUrl is empty.
-                - It is also hidden when already in API mode since there's no need to switch.
-			-->
-			//@if (StartupCapabilities.ApiAvailable)
-			@if (StartupCapabilities.ApiAvailable && !state.IsApiMode)
-			{
-				<MudIconButton Icon="@Icons.Material.Filled.CloudUpload"
-							   Title="Live Server"
-							   Color="Color.Inherit"
-							   OnClick="@SwitchToApiModeAsync" />
-			}
+		<!--
+			EXPLANATION:
+			- Server Data File button is shown if OfflineContent section exists in configuration.
+			- It is shown even if folder/file are currently missing; dialog will surface errors.
+		-->
+		@if (StartupCapabilities.ServerOfflineAvailable)
+		{
+			<MudIconButton Icon="@Icons.Material.Filled.FolderShared"
+							Title="Server Data File"
+							Color="Color.Inherit"
+							OnClick="@SwitchToServerJsonModeAsync" />
+		}
 
-			<!--
-				EXPLANATION:
-				- Server Data File button is shown if OfflineContent section exists in configuration.
-				- It is shown even if folder/file are currently missing; dialog will surface errors.
-			-->
-			@if (StartupCapabilities.ServerOfflineAvailable)
-			{
-				<MudIconButton Icon="@Icons.Material.Filled.FolderShared"
-							   Title="Server Data File"
-							   Color="Color.Inherit"
-							   OnClick="@SwitchToServerJsonModeAsync" />
-			}
+		<!--
+			EXPLANATION:
+			- Client Data File button is always available as a universal fallback.
+		-->
+		<MudIconButton Icon="@Icons.Material.Filled.UploadFile"
+						Title="Client Data File"
+						Color="Color.Inherit"
+			OnClick="@SwitchToClientJsonModeAsync" />
 
-			<!--
-				EXPLANATION:
-				- Client Data File button is always available as a universal fallback.
-			-->
-			<MudIconButton Icon="@Icons.Material.Filled.UploadFile"
-						   Title="Client Data File"
-						   Color="Color.Inherit"
-				OnClick="@SwitchToClientJsonModeAsync" />
 
-			}
 
 		<MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/OpenRose/OpenRose" Target="_blank" />
 	</MudAppBar>

--- a/OpenRose.Web/OpenRose.WebUI/Services/ViewSettingsService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/ViewSettingsService.cs
@@ -68,16 +68,6 @@ namespace OpenRose.WebUI.Services
 		/// </summary>
 		public bool IsOperatingInJsonFileDataSourceMode { get; set; } = false;
 
-		/// <summary>
-		/// NEW PROPERTY: Controls whether to display the "Switch Data Source" button/icon
-		/// in the application UI (specifically in MainLayout).
-		/// 
-		/// EXPLANATION: This allows the application to conditionally show or hide
-		/// the data source switch control based on configuration or application state.
-		/// For now, this defaults to true (always show the switch button).
-		/// </summary>
-		public bool ShowDataSourceSwitchControl { get; set; } = true;
-
 
 		/// <summary>
 		/// Indicates whether traceability information is displayed in Itemz details view.


### PR DESCRIPTION
With enhanced start-up mode support in place, we do not need ShowDataSourceSwitchControl property. So now we are removing it from the code base and also from the AppBar from within Main Layout so that all decision related to appearance of different connection and data file modes is decided at start-up based on application configuration settings.