### PR TITLE
Mermaid Export GoTo url with optional TreeView parameter

### DIFF
--- a/OpenRose.API/Controllers/ExportController.cs
+++ b/OpenRose.API/Controllers/ExportController.cs
@@ -443,7 +443,8 @@ namespace ItemzApp.API.Controllers
 																[FromQuery] bool exportIncludedBaselineItemzOnly = false,
 																[FromQuery] string? baseUrl = null,
 																[FromQuery] bool showTraceabilityOnly = false,
-																[FromQuery] bool includeEstimations = false)
+																[FromQuery] bool includeEstimations = false,
+																[FromQuery] string? view = null)
 		{
 			if (exportRecordId == Guid.Empty)
 			{
@@ -557,7 +558,7 @@ namespace ItemzApp.API.Controllers
 							.ToList();
 					}
 
-					var mermaidText = MermaidExporter.Generate(rootNodeToExport, itemzTraces, exportRecordId, baseUrl, includeEstimations);
+					var mermaidText = MermaidExporter.Generate(rootNodeToExport, itemzTraces, exportRecordId, baseUrl, includeEstimations, view);
 
 					// var mermaidText = MermaidExporter.Generate(rootNode, itemzTraces, exportRecordId, baseUrl);
 					return Content(mermaidText, "text/plain");
@@ -670,7 +671,7 @@ namespace ItemzApp.API.Controllers
 							.ToList();
 					}
 
-					var mermaidText = MermaidExporter.GenerateBaseline(rootNodeToExport, baselineItemzTraces, exportRecordId, baseUrl, includeEstimations);
+					var mermaidText = MermaidExporter.GenerateBaseline(rootNodeToExport, baselineItemzTraces, exportRecordId, baseUrl, includeEstimations, view);
 
 
 					//var mermaidText = MermaidExporter.GenerateBaseline(rootNode, baselineItemzTraces, exportRecordId, baseUrl);

--- a/OpenRose.API/Helper/MermaidExporter.cs
+++ b/OpenRose.API/Helper/MermaidExporter.cs
@@ -37,12 +37,13 @@ namespace ItemzApp.API.Helper
 							  IEnumerable<ItemzTraceDTO> traces,
 							  Guid rootId,
 							  string? baseUrl,
-							  bool includeEstimations = false)
+							  bool includeEstimations = false,
+							  string? view = null)
 		{
 			var sb = new StringBuilder();
 			EmitOpenRoseHeader(sb);
 
-			EmitHierarchyInline(root, sb, rootId, 1, baseUrl, includeEstimations);
+			EmitHierarchyInline(root, sb, rootId, 1, baseUrl, includeEstimations, view);
 
 			// Build lookup dictionary from hierarchy
 			var idToName = BuildIdToNameMap(root);
@@ -97,12 +98,13 @@ namespace ItemzApp.API.Helper
 			IEnumerable<BaselineItemzTraceDTO> traces,
 			Guid rootId,
 			string? baseUrl = null,
-			bool includeEstimations = false)
+			bool includeEstimations = false,
+			string? view = null)
 		{
 			var sb = new StringBuilder();
 			EmitOpenRoseHeader(sb);
 
-			EmitBaselineHierarchyInline(root, sb, rootId, 1, baseUrl, includeEstimations);
+			EmitBaselineHierarchyInline(root, sb, rootId, 1, baseUrl, includeEstimations, view);
 
 			// Build lookup dictionary from baseline hierarchy
 			var idToName = BuildBaselineIdToNameMap(root);
@@ -146,7 +148,8 @@ namespace ItemzApp.API.Helper
 												Guid rootId,
 												int indentLevel,
 												string? baseUrl = null,
-												bool includeEstimations = false)
+												bool includeEstimations = false,
+												string? view = null)
 		{
 			string parent = string.Empty;
 			
@@ -167,7 +170,8 @@ namespace ItemzApp.API.Helper
 				sb.AppendLine($"{indent}{parent}");
 				if (!string.IsNullOrWhiteSpace(baseUrl))
 				{
-					var gotoUrl = $"{baseUrl}/GoTo/{node.RecordId}";
+					//var gotoUrl = $"{baseUrl}/GoTo/{node.RecordId}";
+					var gotoUrl = BuildGotoUrl(baseUrl, node.RecordId, view);
 					var safeLabel = TransformLabelForMermaid(node.Name);
 					sb.AppendLine($"{indent}click {node.RecordId} href \"{gotoUrl}\"");
 				}
@@ -194,12 +198,13 @@ namespace ItemzApp.API.Helper
 					// Add click directive if baseUrl is provided
 					if (!string.IsNullOrWhiteSpace(baseUrl))
 					{
-						var gotoUrl = $"{baseUrl}/GoTo/{child.RecordId}";
+						//var gotoUrl = $"{baseUrl}/GoTo/{child.RecordId}";
+						var gotoUrl = BuildGotoUrl(baseUrl, child.RecordId, view);
 						var safeLabel = TransformLabelForMermaid(child.Name);
 						sb.AppendLine($"{indent}click {child.RecordId} href \"{gotoUrl}\"");
 					}
 
-					EmitHierarchyInline(child, sb, rootId, indentLevel + 1, baseUrl, includeEstimations);
+					EmitHierarchyInline(child, sb, rootId, indentLevel + 1, baseUrl, includeEstimations, view);
 				}
 			}
 		}
@@ -212,7 +217,8 @@ namespace ItemzApp.API.Helper
 														Guid rootId,
 														int indentLevel,
 														string? baseUrl = null,
-														bool includeEstimations = false)
+														bool includeEstimations = false,
+														string? view = null)
 		{
 			string parent = string.Empty;
 
@@ -235,7 +241,8 @@ namespace ItemzApp.API.Helper
 
 				if (!string.IsNullOrWhiteSpace(baseUrl))
 				{
-					var gotoUrl = $"{baseUrl}/GoTo/{node.RecordId}";
+					//var gotoUrl = $"{baseUrl}/GoTo/{node.RecordId}";
+					var gotoUrl = BuildGotoUrl(baseUrl, node.RecordId, view);
 					sb.AppendLine($"{indent}click {node.RecordId} href \"{gotoUrl}\"");
 				}
 			}
@@ -262,11 +269,12 @@ namespace ItemzApp.API.Helper
 
 					if (!string.IsNullOrWhiteSpace(baseUrl))
 					{
-						var gotoUrl = $"{baseUrl}/GoTo/{child.RecordId}";
+						//var gotoUrl = $"{baseUrl}/GoTo/{child.RecordId}";
+						var gotoUrl = BuildGotoUrl(baseUrl, child.RecordId, view);
 						sb.AppendLine($"{indent}click {child.RecordId} href \"{gotoUrl}\"");
 					}
 
-					EmitBaselineHierarchyInline(child, sb, rootId, indentLevel + 1, baseUrl, includeEstimations);
+					EmitBaselineHierarchyInline(child, sb, rootId, indentLevel + 1, baseUrl, includeEstimations, view);
 				}
 			}
 		}
@@ -508,6 +516,23 @@ namespace ItemzApp.API.Helper
 			sb.AppendLine("  OpenRoseIcon@{ img: \"https://github.com/OpenRose/OpenRose/blob/main/OpenRose.Web/OpenRose.WebUI/wwwroot/icons/OpenRose_Mermaid.png?raw=true\", label: \"By OpenRose\", pos: \"b\", h: 60, constraint: \"on\" }");
 			sb.AppendLine("  click OpenRoseIcon href \"https://github.com/OpenRose\" \"OpenRose\" _blank");
 		}
+
+		private static string BuildGotoUrl(string? baseUrl, Guid recordId, string? view)
+		{
+			if (string.IsNullOrWhiteSpace(baseUrl))
+				return $"GoTo/{recordId}";
+
+			var url = $"{baseUrl}/GoTo/{recordId}";
+
+			if (!string.IsNullOrWhiteSpace(view) &&
+				view.Equals("treeview", StringComparison.OrdinalIgnoreCase))
+			{
+				url += "?view=treeview";
+			}
+
+			return url;
+		}
+
 
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/DummyExportService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/DummyExportService.cs
@@ -20,7 +20,13 @@ namespace OpenRose.WebUI.Client.Services.Export
 			throw new InvalidOperationException("OpenRose API base URL is not configured. Please provide a valid URL in the configuration file.");
 		}
 
-		public async Task<string> __GET_MermaidFlowChart_By_GUID_ID__Async(Guid exportRecordId, bool exportIncludedBaselineItemzOnly, bool showTraceabilityOnly, bool includeEstimations, string baseURL, CancellationToken cancellationToken = default)
+		public async Task<string> __GET_MermaidFlowChart_By_GUID_ID__Async(Guid exportRecordId
+			, bool exportIncludedBaselineItemzOnly
+			, bool showTraceabilityOnly
+			, bool includeEstimations
+			, string baseURL
+			, string? view = null
+			, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/ExportService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/ExportService.cs
@@ -79,6 +79,7 @@ namespace OpenRose.WebUI.Client.Services.Export
 			bool showTraceabilityOnly,
 			bool includeEstimations,
 			string baseUrl,
+			string? view = null,
 			CancellationToken cancellationToken = default)
 		{
 			try
@@ -110,6 +111,11 @@ namespace OpenRose.WebUI.Client.Services.Export
 				if (includeEstimations)
 				{
 					urlBuilder_.Append("&includeEstimations=true");
+				}
+
+				if(!string.IsNullOrWhiteSpace(view))
+				{
+					urlBuilder_.Append($"&view={Uri.EscapeDataString(view)}");
 				}
 
 				// urlBuilder_.Length--; // cleanup if trailing ? or & is left

--- a/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/IExportService.cs
+++ b/OpenRose.Web/OpenRose.WebUI.Client/Services/Export/IExportService.cs
@@ -40,6 +40,7 @@ namespace OpenRose.WebUI.Client.Services.Export
 																bool showTraceabilityOnly,
 																bool includeEstimations,
 																string baseUrl,
+																string view,
 																CancellationToken cancellationToken = default);
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportMermaidFlowChart.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportMermaidFlowChart.razor
@@ -14,7 +14,7 @@
 @inject IJSRuntime JS
 
 <MudPaper Class="pa-3 mb-3 align-start d-flex" Outlined="false">
-    <MudStack Row="true" Spacing="3">
+    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="3" Justify="Justify.FlexStart">
         <MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
         <MudText Typo="Typo.h5" Align="Align.Left">Export Mermaid FlowChart</MudText>
         <MudSpacer />
@@ -50,16 +50,25 @@
                           Immediate="true"
                           OnKeyDown="@(async e => { if (e.Key == "Enter" && IsGuidInputValid()) { await HandleExportMermaidFlowChartAsync(); } })" />
 
-            <MudCheckBox @bind-Value="exportIncludedBaselineItemzOnly"
-                         Label="Only export BaselineItemz marked for Inclusion" />
+            <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center" Justify="Justify.FlexStart">
 
-            <MudCheckBox Label="Show only traced records (Traceability Only)"
-                         Value="showTraceabilityOnly"
-                         ValueChanged="@((bool x) => OnTraceabilityOnlyChanged(x))" />
+                <MudCheckBox @bind-Value="exportIncludedBaselineItemzOnly"
+                             Label="Only export BaselineItemz marked for Inclusion" />
 
-            <MudCheckBox Label="Include Estimations"
-                         Value="includeEstimations"
-                         ValueChanged="@((bool x) => OnIncludeEstimationsChanged(x))" />
+                <MudCheckBox Label="Show only traced records (Traceability Only)"
+                             Value="showTraceabilityOnly"
+                             ValueChanged="@((bool x) => OnTraceabilityOnlyChanged(x))" />
+
+                <MudCheckBox Label="Include Estimations"
+                             Value="includeEstimations"
+                             ValueChanged="@((bool x) => OnIncludeEstimationsChanged(x))" />
+
+                <MudCheckBox Label="Generate TreeView URL links"
+                             Value="generateTreeViewLinks"
+                             ValueChanged="@((bool x) => OnGenerateTreeViewLinksChanged(x))" />
+
+            </MudStack>
+
 
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
                 <MudButton Variant="Variant.Filled"
@@ -152,6 +161,7 @@
     private bool exportIncludedBaselineItemzOnly { get; set; } = false;
     private bool showTraceabilityOnly { get; set; } = false;
     private bool includeEstimations { get; set; } = false;
+    private bool generateTreeViewLinks { get; set; } = false;
     private string mermaidText { get; set; } = string.Empty;
     private bool loading { get; set; } = false;
 
@@ -179,11 +189,12 @@
             var clientBaseUrl = NavigationManager.BaseUri.TrimEnd('/');
 
             mermaidText = await ExportService.__GET_MermaidFlowChart_By_GUID_ID__Async(
-                                                guid, 
-                                                exportIncludedBaselineItemzOnly,
-                                                showTraceabilityOnly,
-                                                includeEstimations,
-                                                clientBaseUrl);
+                                                exportRecordId: guid,
+                                                exportIncludedBaselineItemzOnly: exportIncludedBaselineItemzOnly,
+                                                showTraceabilityOnly: showTraceabilityOnly,
+                                                includeEstimations: includeEstimations,
+                                                baseUrl: clientBaseUrl,
+                                                view: generateTreeViewLinks ? "treeView" : null);
 
             loading = false;
 
@@ -244,6 +255,12 @@
     private void OnIncludeEstimationsChanged(bool newValue)
     {
         includeEstimations = newValue;
+        mermaidText = string.Empty;  // clear old flowchart text
+    }
+
+    private void OnGenerateTreeViewLinksChanged(bool newValue)
+    {
+        generateTreeViewLinks = newValue;
         mermaidText = string.Empty;  // clear old flowchart text
     }
 


### PR DESCRIPTION
Now Mermaid Export UI supports a new option that users can use to include TreeView as parameter for GoTo URL links in the generated text output. 

Default is going to be 'DetailsView' for records which belong to Projects and Baselines but user can change that to make 'TreeView' as default for the generated links.

In the past GoTo URL link looked as per below...

```
http://localhost:7673/GoTo/ea677c0a-e132-49ae-9f12-80094453dbda
```

Now user can generate GoTo URL link that has TreeView as parameter as per below ....

```
http://localhost:7673/GoTo/ea677c0a-e132-49ae-9f12-80094453dbda?view=treeview
```

