### PR TITLE
By default, open newly created Project in TreeView 

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/CreateProject.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/CreateProject.razor
@@ -61,10 +61,6 @@
 						<MudSelectItem T="string" Value="@_stringProjectStatusValue">@_stringProjectStatusValue</MudSelectItem>
 					}
 				</MudSelect>
-@* 				<MudTextField T="string" Label="Description" Required="true" RequiredError="Description is required!"
-							  @bind-Value="singleProject.Description"
-							  For="@(() => singleProject.Description)" /> *@
-
 					<!-- Ensure this div applies the custom class to the Markdown content -->
 					<MudText><strong>Description : </strong></MudText>
 					<div class="custom-markdown-editor">
@@ -228,8 +224,7 @@
 				try
 				{
 					var updatedResult = await ProjectService.__POST_Create_Project__Async(singleProject);
-					await Task.Delay(1500);
-					NavManager.NavigateTo("/projects");
+					NavManager.NavigateTo($"/projectTreeView/{updatedResult.Id}");
 				}
 				catch (Exception ex)
 				{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/CreateProject.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/CreateProject.razor
@@ -58,7 +58,7 @@
 							Label="Status">
 					@foreach (var _stringProjectStatusValue in _stringProjectStatusValues)
 					{
-						<MudSelectItem T="string" Value="_stringProjectStatusValue">@_stringProjectStatusValue</MudSelectItem>
+						<MudSelectItem T="string" Value="@_stringProjectStatusValue">@_stringProjectStatusValue</MudSelectItem>
 					}
 				</MudSelect>
 @* 				<MudTextField T="string" Label="Description" Required="true" RequiredError="Description is required!"
@@ -184,6 +184,8 @@
 
 	string[] _stringProjectStatusValues = { };
 
+
+
 	private MarkupString convertedMarkdown;
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -201,6 +203,13 @@
 			if (singleProject != null && singleProject.Description != null)
 			{
 				await ConvertMarkdownToHtml(singleProject.Description);
+			}
+
+			if(string.IsNullOrEmpty(singleProject.Status))
+			{
+				// EXPLANATION ::
+				// Get default value as 'New' which is the first value in the Enum as per integer base of 0 ZERO
+				singleProject.Status = _stringProjectStatusValues.FirstOrDefault(); 
 			}
 
 			StateHasChanged();


### PR DESCRIPTION
In the past, we use to open full project list view once new project was created, Now with this change we directly open newly created Project in Tree View within Open Rose Requirements Management Tool / Application