### PR TITLE
Better handling of deleted data notification and informing connected users

### DIFF
--- a/OpenRose.API/Services/BaselineHierarchyRepository.cs
+++ b/OpenRose.API/Services/BaselineHierarchyRepository.cs
@@ -310,8 +310,8 @@ namespace ItemzApp.API.Services
 			if (foundBaselineHierarchyRecord.Count() != 1)
 			{
 				throw new ApplicationException($"Expected 1 Baseline Itemz Hierarchy record to be found " +
-					$"but instead found {foundBaselineHierarchyRecord.Count()} records for ID {recordId}" +
-					"Please contact your System Administrator.");
+					$"but instead found {foundBaselineHierarchyRecord.Count()} records for ID {recordId}." +
+					" Please contact your System Administrator.");
 			}
 
 			var foundBaselineHierarchyRecordLevel = foundBaselineHierarchyRecord.FirstOrDefault()!.BaselineItemzHierarchyId!.GetLevel();

--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/ConnectionAndDataNotFoundErrorDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/ConnectionAndDataNotFoundErrorDialog.razor
@@ -1,0 +1,52 @@
+﻿<MudDialog>
+
+    <TitleContent>
+        <MudText Typo="Typo.h6" Color="Color.Error">
+            @Title
+        </MudText>
+    </TitleContent>
+
+    <DialogContent>
+        <MudGrid>
+            <!-- FIXED ICON -->
+            <MudItem xs="12" sm="2" Class="d-flex justify-center align-center">
+                <MudIcon Icon="@Icons.Material.Filled.Error"
+                         Color="Color.Error"
+                         Size="Size.Large" />
+            </MudItem>
+
+            <!-- MESSAGE -->
+            <MudItem xs="12" sm="10" Class="d-flex align-center">
+                <MudText Dense="true">@((MarkupString)MessageHtml)</MudText>
+            </MudItem>
+        </MudGrid>
+    </DialogContent>
+
+    <DialogActions>
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Success"
+                   OnClick="@(() => Close(true))">
+            @YesText
+        </MudButton>
+
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Error"
+                   OnClick="@(() => Close(false))">
+            @NoText
+        </MudButton>
+    </DialogActions>
+
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
+
+    [Parameter] public string Title { get; set; } = "Message";
+    [Parameter] public string MessageHtml { get; set; } = "";
+
+    // Always two buttons, caller overrides text
+    [Parameter] public string YesText { get; set; } = "Yes";
+    [Parameter] public string NoText { get; set; } = "No";
+
+    private void Close(bool result) => MudDialog.Close(DialogResult.Ok(result));
+}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
@@ -1,0 +1,43 @@
+﻿@* 
+ * OpenRose - Requirements Management
+ * Licensed under the Apache License, Version 2.0. 
+ * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+*@
+
+@using MudBlazor
+
+<MudDialog>
+    <TitleContent>
+        <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Class="mr-3" Color="Color.Warning" />
+        Project Deleted
+    </TitleContent>
+    <DialogContent>
+        <MudAlert Severity="Severity.Warning" Class="mb-4">
+            The project <strong>@ProjectName</strong> has been deleted by another user.
+        </MudAlert>
+        <MudText Class="mt-4">
+            This project is no longer available. You will be redirected to the projects list.
+        </MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="NavigateToProjectsList">
+            Go to Projects List
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter]
+    public Guid ProjectId { get; set; }
+
+    [Parameter]
+    public string ProjectName { get; set; } = string.Empty;
+
+    private void NavigateToProjectsList()
+    {
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/Baseline.razor
@@ -9,6 +9,7 @@
 @using OpenRose.WebUI.Client.Services.Baselines
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.Pages.Breadcrums
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.SharedComponents
@@ -17,6 +18,7 @@
 @inject NavigationManager NavManager
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<Baseline> _logger
 
 @if (BreadcrumsParameter != null)
 {
@@ -41,7 +43,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaseline != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudPaper Class="pa-2 mb-2">
@@ -156,11 +158,11 @@
 	}
 </MudGrid>
 @code {
-    [Parameter]
-    public Guid BaselineId { get; set; }
+	[Parameter]
+	public Guid BaselineId { get; set; }
 
-    [Inject]
-    public IBaselinesService baselineService { get; set; }
+	[Inject]
+	public IBaselinesService baselineService { get; set; }
 
 	[Inject]
 	public IBaselineHierarchyService baselineHierarchyService { get; set; }
@@ -183,35 +185,109 @@
 			StateHasChanged();
 			await Task.Delay(300);
 
-			singleBaseline = await baselineService.__Single_Baseline_By_GUID_ID__Async(BaselineId);
-			if (singleBaseline != null)
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				BreadcrumsParameter = new ParameterForBaselineBreadcrums();
-				BreadcrumsParameter.Id = singleBaseline.Id;
-				BreadcrumsParameter.Name = singleBaseline.Name;
-				BreadcrumsParameter.RecordType = "baseline"; // TODO :: USE CONSTANT
-				BreadcrumsParameter.isIncluded = true; // TODO :: WE SET INCLUSION FOR BASELINEITEMZTYPE TO TRUE BUT WE CAN DO BETTER
-			}
-			//var returnedItemzTypeList = await ProjectService.__GET_ItemzTypes_By_Project__Async(ProjectId);
-			var returnedItemzTypeList = await baselineHierarchyService.__Get_Immediate_Children_Baseline_Hierarchy_By_GUID__Async(BaselineId);
+				try
+				{
+
+					singleBaseline = await baselineService.__Single_Baseline_By_GUID_ID__Async(BaselineId);
+
+					if (singleBaseline == null)
+					{
+						throw new ApplicationException($"Baseline with ID {BaselineId} not found.");
+					}
+
+				}
+				catch (ApplicationException ex)
+				{
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline has been deleted.",
+						BaselineId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Baseline Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested baseline has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline {BaselineId}. Waiting 1 seconds before retry.", BaselineId);
+						// Wait 1 second before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
+				}
+
+				if (singleBaseline != null)
+				{
+					BreadcrumsParameter = new ParameterForBaselineBreadcrums();
+					BreadcrumsParameter.Id = singleBaseline.Id;
+					BreadcrumsParameter.Name = singleBaseline.Name;
+					BreadcrumsParameter.RecordType = "baseline"; // TODO :: USE CONSTANT
+					BreadcrumsParameter.isIncluded = true; // TODO :: WE SET INCLUSION FOR BASELINEITEMZTYPE TO TRUE BUT WE CAN DO BETTER
+				}
+
+				var returnedItemzTypeList = await baselineHierarchyService.__Get_Immediate_Children_Baseline_Hierarchy_By_GUID__Async(BaselineId);
 
 
-			if (returnedItemzTypeList != null)
-			{
-				AllItemzTypesForBaseline = returnedItemzTypeList.ToList();
-			}
+				if (returnedItemzTypeList != null)
+				{
+					AllItemzTypesForBaseline = returnedItemzTypeList.ToList();
+				}
 
-			initializingPage = false;
+				initializingPage = false;
 
-			// EXPLANATION : At the start of initialization process we capture parent record ID.
-			// Now even if user decides to Delete this Itemz Record then also we can go back to it's
-			// Parent ItemzType post completing deletion operation.
-			var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineId);
-			parentId = httpResponse.ParentRecordId;
+				// EXPLANATION : At the start of initialization process we capture parent record ID.
+				// Now even if user decides to Delete this Itemz Record then also we can go back to it's
+				// Parent ItemzType post completing deletion operation.
+				var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineId);
+				parentId = httpResponse.ParentRecordId;
 
-			await ConvertMarkdownToHtml(singleBaseline.Description);
+				await ConvertMarkdownToHtml(singleBaseline.Description);
 
-			StateHasChanged();
+				StateHasChanged();
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
+
+			} // WHILE LOOP ENDS
 		}
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
@@ -20,6 +20,7 @@
 @inject IDialogService DialogService
 @inject BaselineTreeNodeItemzSelectionService BaselineItemzSelectionService
 @inject IJSRuntime JS
+@inject ILogger<BaselineDetailsComponent> _logger
 
 
 @if (FormStateService.IsDirty(BaselineId))
@@ -52,7 +53,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaseline != null)
 	{
 
 		<MudItem hidden="@hideValidationError" xs="12" sm="12">
@@ -372,52 +373,148 @@
 	{
 		initializingPage = true;
 		StateHasChanged();
-		singleBaseline = await baselinesService.__Single_Baseline_By_GUID_ID__Async(BaselineId);
 
-		if (singleBaseline != null)
+		bool loadingSuccessful = false;
+		while (!loadingSuccessful)
 		{
-			BreadcrumsParameter = new ParameterForBaselineBreadcrums();
-			BreadcrumsParameter.Id = singleBaseline.Id;
-			BreadcrumsParameter.Name = singleBaseline.Name;
-			BreadcrumsParameter.RecordType = "baseline"; // TODO :: USE CONSTANT
-			BreadcrumsParameter.isIncluded = true; // TODO :: WE SET INCLUSION FOR BASELINEITEMZTYPE TO TRUE BUT WE CAN DO BETTER
-
-			BaselineItemzSelectionService.UpdateBaselineTreeNodeItemzName(BaselineId, singleBaseline.Name);
-
-			originalItemzName = singleBaseline.Name;
-
-			_originalDescription = singleBaseline.Description ?? string.Empty;
-			MyContent = _originalDescription;
-
-		}
-
-		if (form != null)
-		{
-			await form.Validate();
-			if (form.IsValid)
+			try
 			{
-				disableUpdateBaselineDetailsButton = false;
+				singleBaseline = await baselinesService.__Single_Baseline_By_GUID_ID__Async(BaselineId);
+
+				if (singleBaseline == null)
+				{
+					throw new ApplicationException($"Baseline with ID {BaselineId} not found.");
+				}
+
 			}
-			else
+			catch (ApplicationException ex)
 			{
-				disableUpdateBaselineDetailsButton = true;
+				// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				_logger.LogWarning(
+					ex,
+					"Either API Server is unavailable OR requested baseline has been deleted.",
+					BaselineId);
+
+				initializingPage = true;
+				StateHasChanged();
+
+				var parameters = new DialogParameters
+				{
+					["Title"] = "Connection Error",
+					["MessageHtml"] =
+								"<p style='color:red;'><strong>Unable to obtain Baseline Data</strong></p>" +
+								"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+								"<p>The requested baseline has been deleted.</p>" +
+								"<p><strong>Would you like to retry?</strong></p>",
+					["YesText"] = "Retry",
+					["NoText"] = "Go to Home"
+				};
+
+				// Show error dialog with retry option
+				var options = new DialogOptions
+				{
+					CloseButton = false,
+					BackdropClick = false,
+					CloseOnEscapeKey = false
+				};
+
+				var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					"Connection Error",
+					parameters,
+					options);
+
+				var dialogResult = await dialog.Result;
+
+				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				if (dialogResult != null && dialogResult.Data is bool retry && retry)
+				{
+					_logger.LogInformation("User chose to retry loading baseline {BaselineId}. Waiting 1 seconds before retry.", BaselineId);
+					// Wait 1 second before retrying to give server time to recover
+					await Task.Delay(1000);
+					// Continue the loop to retry
+					continue;
+				}
+				else
+				{
+					// 🔑 USER CLICKED "GO TO Home Screen"
+					_logger.LogInformation("User chose to go to home screen");
+					loadingSuccessful = true;
+					NavManager.NavigateTo("/");
+				}
 			}
-			initializingPage = false;
+		
+		
+		
+			if (singleBaseline != null)
+			{
+				BreadcrumsParameter = new ParameterForBaselineBreadcrums();
+				BreadcrumsParameter.Id = singleBaseline.Id;
+				BreadcrumsParameter.Name = singleBaseline.Name;
+				BreadcrumsParameter.RecordType = "baseline"; // TODO :: USE CONSTANT
+				BreadcrumsParameter.isIncluded = true; // TODO :: WE SET INCLUSION FOR BASELINEITEMZTYPE TO TRUE BUT WE CAN DO BETTER
+
+				BaselineItemzSelectionService.UpdateBaselineTreeNodeItemzName(BaselineId, singleBaseline.Name);
+
+				originalItemzName = singleBaseline.Name;
+
+				_originalDescription = singleBaseline.Description ?? string.Empty;
+				MyContent = _originalDescription;
+
+			}
+
+			if (form != null)
+			{
+				await form.Validate();
+				if (form.IsValid)
+				{
+					disableUpdateBaselineDetailsButton = false;
+				}
+				else
+				{
+					disableUpdateBaselineDetailsButton = true;
+				}
+				// initializingPage = false;
+				// StateHasChanged();
+			}
+
+
+
+			if (singleBaseline != null)
+			{
+
+				// EXPLANATION : At the start of initialization process we capture parent record ID.
+				// Now even if user decides to Delete this Baseline Record then also we can go back to it's
+				// Parent Project post completing deletion operation.
+				var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineId);
+
+				if (httpResponse != null)
+				{
+					ParentId = httpResponse.ParentRecordId;
+				}
+
+				// EXPLANATION :: initializingPage is surrounded by if condition because
+				// as part of exception handling we now allow users to retry loading data. 
+				// if user wants to retry then we want to keep showing user the loading 
+				// layover message. 
+
+				initializingPage = false;
+				await InvokeAsync(StateHasChanged);
+
+				if (!string.IsNullOrEmpty(singleBaseline.Description))
+				{
+					await ConvertMarkdownToHtml(singleBaseline.Description);
+				}
+			}
+
+			// Reset dirty state
+			FormStateService.SetDirty(BaselineId, false);
+
 			StateHasChanged();
-		}
 
-		// EXPLANATION : At the start of initialization process we capture parent record ID.
-		// Now even if user decides to Delete this Baseline Record then also we can go back to it's
-		// Parent Project post completing deletion operation.
-		var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineId);
-		ParentId = httpResponse.ParentRecordId;
-
-		await ConvertMarkdownToHtml(singleBaseline.Description);
-
-		// Reset dirty state
-		FormStateService.SetDirty(BaselineId, false);
-
-		StateHasChanged();
+			// 🔑 MARK LOADING AS SUCCESSFUL
+			loadingSuccessful = true;
+			  
+		} // WHILE LOOP ENDS
 	}
 
 	public async Task HandleBaselineDetailsPatchSubmission()

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -7,6 +7,7 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.Baselines
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.SharedComponents
@@ -18,6 +19,7 @@
 @inject NavigationManager NavManager
 @inject NavigationBlockerService NavigationBlocker
 @inject ViewSettingsService ViewSettings
+@inject ILogger<BaselineReadOnlyComponent> _logger
 
 <MudGrid>
 	@if (initializingPage)
@@ -30,7 +32,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaseline != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
@@ -142,14 +144,90 @@
 			StateHasChanged();
 			await Task.Delay(300);
 
-			singleBaseline = await BaselinesService.__Single_Baseline_By_GUID_ID__Async(BaselineId);
-			if (singleBaseline != null && singleBaseline.Description != null)
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				await ConvertMarkdownToHtml(singleBaseline.Description);
-			}
+				try
+				{
+					singleBaseline = await BaselinesService.__Single_Baseline_By_GUID_ID__Async(BaselineId);
 
-			initializingPage = false;
-			StateHasChanged();
+
+					if (singleBaseline == null)
+					{
+						throw new ApplicationException($"Baseline with ID {BaselineId} not found.");
+					}
+
+				}
+				catch (ApplicationException ex)
+				{
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline has been deleted.",
+						BaselineId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Baseline Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested baseline has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline {BaselineId}. Waiting 1 seconds before retry.", BaselineId);
+						// Wait 1 second before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
+				}
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
+
+			} // WHILE LOOP ENDS
+
+			if (singleBaseline != null) 
+			{ 
+				initializingPage = false;
+				StateHasChanged();
+				if (singleBaseline.Description != null)
+				{
+					await ConvertMarkdownToHtml(singleBaseline.Description);
+				}
+			}
 
 			// ALWAYS run navigation blocker after render if kiosk mode is active
 			if (ViewSettings.IsKioskMode)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
@@ -9,6 +9,7 @@
 @using OpenRose.WebUI.Client.Services.BaselineHierarchy
 @using OpenRose.WebUI.Client.Services.Baselines
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.BaselineItemz
@@ -26,6 +27,7 @@
 @inject IJSRuntime JS
 @inject FormStateService FormStateService
 @inject FullScreenService FullScreenService
+@inject ILogger<BaselineTreeView> _logger
 @inject ViewSettingsService ViewSettings
 @inject ProtectedSessionStorage SessionStorage
 
@@ -545,52 +547,139 @@
                 await SessionStorage.SetAsync("SHOWPROPERTIESINREADONLYVIEWS", false);
             }
 
-            // Load initial data
-            InitialTreeItems = await LoadInitialData(BaselineId);
-            StateHasChanged();
 
-            await Task.Delay(300);
-            // Load Entire Baseline Hierarchy data
-            InitialTreeItems = await LoadAllBaselineHierarchyData(BaselineId);
 
-            // Hide Parking Lot in read-only mode if empty
-            RemoveParkingLotIfEmpty(InitialTreeItems);
 
-            _linearIds = InitialTreeItems.Flatten()
-                                         .Select(x => x.Value)
-                                         .ToList();
 
-            _currentIndex = _linearIds.FindIndex(id => id == _selectedValue);
-
-            // Default to root node if nothing selected
-            if (_selectedValue == Guid.Empty && _linearIds.Count > 0)
+            // 🔑 TRY TO LOAD PROJECT DATA - DISTINGUISH BETWEEN DIFFERENT ERROR TYPES
+            bool loadingSuccessful = false;
+            while (!loadingSuccessful)
             {
-                _selectedValue = _linearIds[0];
-                _currentIndex = 0;
+                try
+                {
 
-                baselineMudTreeView.SelectedValue = _selectedValue;
-                await UpdateSelectedItem(_selectedValue);
+
+
+
+                    // Load initial data
+                    InitialTreeItems = await LoadInitialData(BaselineId);
+                    StateHasChanged();
+
+                    await Task.Delay(300);
+                    // Load Entire Baseline Hierarchy data
+                    InitialTreeItems = await LoadAllBaselineHierarchyData(BaselineId);
+
+                    // Hide Parking Lot in read-only mode if empty
+                    RemoveParkingLotIfEmpty(InitialTreeItems);
+
+                    _linearIds = InitialTreeItems.Flatten()
+                                                 .Select(x => x.Value)
+                                                 .ToList();
+
+                    _currentIndex = _linearIds.FindIndex(id => id == _selectedValue);
+
+                    // Default to root node if nothing selected
+                    if (_selectedValue == Guid.Empty && _linearIds.Count > 0)
+                    {
+                        _selectedValue = _linearIds[0];
+                        _currentIndex = 0;
+
+                        baselineMudTreeView.SelectedValue = _selectedValue;
+                        await UpdateSelectedItem(_selectedValue);
+                    }
+
+
+                    showLoadingMessage = false;
+
+                    StateHasChanged();
+
+                    if (AutoSelectedRecordId.HasValue)
+                    {
+                        // Select the node after the first render
+
+                        // This Task.Delay is important to allow full
+                        // rendering which could take some time for large project.
+                        // await Task.Delay(500);
+
+                        await HandleItemzSelectedAsync(AutoSelectedRecordId.Value);
+                        AutoSelectedRecordId = null;
+                    }
+
+                    await JS.InvokeVoidAsync("initializeResizable");
+                    StateHasChanged();
+
+
+
+
+
+                    // 🔑 MARK LOADING AS SUCCESSFUL
+                    loadingSuccessful = true;
+                }
+                catch (ApplicationException ex)
+                {
+                    // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                    _logger.LogWarning(
+                        ex,
+                        "Either API Server is unavailable OR requested baseline has been deleted.",
+                        BaselineId);
+
+                    showLoadingMessage = false;
+                    // StateHasChanged();
+
+                    var parameters = new DialogParameters
+                        {
+                            ["Title"] = "Connection Error",
+                            ["MessageHtml"] =
+                                "<p style='color:red;'><strong>Unable to obtain Baseline Data</strong></p>" +
+                                "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+                                "<p>The requested baseline has been deleted.</p>" +
+                                "<p><strong>Would you like to retry?</strong></p>",
+                            ["YesText"] = "Retry",
+                            ["NoText"] = "Go to Home"
+                        };
+
+                    // // Show error dialog with retry option
+                    // var retryOptions = new DialogOptions
+                    // {
+                    //     CloseButton = false,
+                    //     BackdropClick = false,
+                    //     CloseOnEscapeKey = false
+                    // };
+
+                    var options = new DialogOptions
+                        {
+                            CloseButton = false,
+                            BackdropClick = false,
+                            CloseOnEscapeKey = false
+                        };
+
+                    var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+                        "Connection Error",
+                        parameters,
+                        options);
+
+                    var dialogResult = await dialog.Result;
+
+                    if (dialogResult != null && dialogResult.Data is bool retry && retry)
+                    {
+                        _logger.LogInformation(
+                            "User chose to retry loading baseline {BaselineId}. Waiting 1 second before retry.",
+                            BaselineId);
+
+                        showLoadingMessage = true;
+
+                        await Task.Delay(1000);
+                        continue;   // retry loop
+                    }
+                    else
+                    {
+                        _logger.LogInformation("User chose to go to home screen");
+                        loadingSuccessful = true;
+                        NavManager.NavigateTo("/");
+                    }
+                }
             }
 
-
-            showLoadingMessage = false;
-
-            StateHasChanged();
-
-            if (AutoSelectedRecordId.HasValue)
-            {
-                // Select the node after the first render
-
-                // This Task.Delay is important to allow full
-                // rendering which could take some time for large project.
-                // await Task.Delay(500);
-
-                await HandleItemzSelectedAsync(AutoSelectedRecordId.Value);
-                AutoSelectedRecordId = null;
-            }
-
-            await JS.InvokeVoidAsync("initializeResizable");
-            StateHasChanged();
         }
     }
 
@@ -828,8 +917,74 @@
         ViewSettings.ReadOnlyView = newValue;
         await SessionStorage.SetAsync("READONLYVIEW", newValue);
 
-        // Reload hierarchy because visibility depends on mode
-        InitialTreeItems = await LoadAllBaselineHierarchyData(BaselineId);
+        bool loadingSuccessful = false;
+        while (!loadingSuccessful)
+        {
+            try
+            {
+                // Reload hierarchy because visibility depends on mode
+                InitialTreeItems = await LoadAllBaselineHierarchyData(BaselineId);
+
+                loadingSuccessful = true;
+                showLoadingMessage = false;
+            }
+            catch (ApplicationException ex)
+            {
+                // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                _logger.LogWarning(
+                    ex,
+                    "Either API Server is unavailable OR requested baseline has been deleted.",
+                    BaselineId);
+
+                showLoadingMessage = false;
+                // StateHasChanged();
+
+                var parameters = new DialogParameters
+                {
+                    ["Title"] = "Connection Error",
+                    ["MessageHtml"] =
+                        "<p style='color:red;'><strong>Unable to obtain Baseline Data</strong></p>" +
+                        "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+                        "<p>The requested baseline has been deleted.</p>" +
+                        "<p><strong>Would you like to retry?</strong></p>",
+                    ["YesText"] = "Retry",
+                    ["NoText"] = "Go to Home"
+                };
+
+                var options = new DialogOptions
+                {
+                    CloseButton = false,
+                    BackdropClick = false,
+                    CloseOnEscapeKey = false
+                };
+
+                var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+                    "Connection Error",
+                    parameters,
+                    options);
+
+                var dialogResult = await dialog.Result;
+
+                if (dialogResult != null && dialogResult.Data is bool retry && retry)
+                {
+                    _logger.LogInformation(
+                        "User chose to retry loading baseline {BaselineId}. Waiting 1 second before retry.",
+                        BaselineId);
+
+                    showLoadingMessage = true;
+                    StateHasChanged();
+
+                    await Task.Delay(1000);
+                    continue;   // retry loop
+                }
+                else
+                {
+                    _logger.LogInformation("User chose to go to home screen");
+                    loadingSuccessful = true;
+                    NavManager.NavigateTo("/");
+                }
+            }
+        }
 
         // Apply Parking Lot hiding logic
         RemoveParkingLotIfEmpty(InitialTreeItems);

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
@@ -28,6 +28,7 @@
 @inject ViewSettingsService ViewSettings
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<BaselineItemz> _logger
 
 @if (BreadcrumsParameter != null)
 {
@@ -70,7 +71,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaselineItemz != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
@@ -263,30 +264,104 @@
 		initializingPage = true;
 		StateHasChanged();
 		//await Task.Delay(300);
-		singleBaselineItemz = await baselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
 
-		if (singleBaselineItemz != null)
+		bool loadingSuccessful = false;
+		while (!loadingSuccessful)
 		{
-			BreadcrumsParameter = new ParameterForBaselineBreadcrums();
-			BreadcrumsParameter.Id = singleBaselineItemz.Id;
-			BreadcrumsParameter.Name = singleBaselineItemz.Name;
-			BreadcrumsParameter.RecordType = "baselineitemz"; // TODO :: USE CONSTANT
-			BreadcrumsParameter.isIncluded = singleBaselineItemz.isIncluded;
-
-			// Obtain tags list from the singleBaselineItemz.
-			if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+			try
 			{
-				// Normalize incoming tags (removes duplicates, trims, preserves order)
-				var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
+				singleBaselineItemz = await baselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
 
-				// Parse into list
-				tagsList = TagParsingUtility.ParseTags(normalized);
+				if (singleBaselineItemz == null)
+				{
+					throw new ApplicationException($"BaselineItemz with ID {BaselineItemzId} not found.");
+				}
 			}
-			else
+			catch (ApplicationException ex)
 			{
-				tagsList = new List<string>();
+				// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				_logger.LogWarning(
+					ex,
+					"Either API Server is unavailable OR requested baseline itemz has been deleted.",
+					BaselineItemzId);
+
+				initializingPage = true;
+				StateHasChanged();
+
+				var parameters = new DialogParameters
+				{
+					["Title"] = "Connection Error",
+					["MessageHtml"] =
+								"<p style='color:red;'><strong>Unable to obtain Baseline Itemz Data</strong></p>" +
+								"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+								"<p>The requested baseline itemz has been deleted.</p>" +
+								"<p><strong>Would you like to retry?</strong></p>",
+					["YesText"] = "Retry",
+					["NoText"] = "Go to Home"
+				};
+
+				// Show error dialog with retry option
+				var options = new DialogOptions
+				{
+					CloseButton = false,
+					BackdropClick = false,
+					CloseOnEscapeKey = false
+				};
+
+				var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					"Connection Error",
+					parameters,
+					options);
+
+				var dialogResult = await dialog.Result;
+
+				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				if (dialogResult != null && dialogResult.Data is bool retry && retry)
+				{
+					_logger.LogInformation("User chose to retry loading baseline itemz {BaselineItemzId}. Waiting 1 second before retry.", BaselineItemzId);
+					// Wait 1 seconds before retrying to give server time to recover
+					await Task.Delay(1000);
+					// Continue the loop to retry
+					continue;
+				}
+				else
+				{
+					// 🔑 USER CLICKED "GO TO Home Screen"
+					_logger.LogInformation("User chose to go to home screen");
+					loadingSuccessful = true;
+					NavManager.NavigateTo("/");
+				}
 			}
 
+
+
+			if (singleBaselineItemz != null)
+			{
+				BreadcrumsParameter = new ParameterForBaselineBreadcrums();
+				BreadcrumsParameter.Id = singleBaselineItemz.Id;
+				BreadcrumsParameter.Name = singleBaselineItemz.Name;
+				BreadcrumsParameter.RecordType = "baselineitemz"; // TODO :: USE CONSTANT
+				BreadcrumsParameter.isIncluded = singleBaselineItemz.isIncluded;
+
+				// Obtain tags list from the singleBaselineItemz.
+				if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+				{
+					// Normalize incoming tags (removes duplicates, trims, preserves order)
+					var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
+
+					// Parse into list
+					tagsList = TagParsingUtility.ParseTags(normalized);
+				}
+				else
+				{
+					tagsList = new List<string>();
+				}
+
+			}
+
+
+			// 🔑 MARK LOADING AS SUCCESSFUL
+			loadingSuccessful = true;
 		}
 
 	}
@@ -321,15 +396,27 @@
 
 			await Task.Delay(200);
 
-			disableIncludeChildOptions = !(baselineBreadcrumsService.RequestParentNodeIsIncluded());
 
-			initializingPage = false;
+			if (singleBaselineItemz != null)
+			{
 
-			await ConvertMarkdownToHtml(singleBaselineItemz.Description);
+				disableIncludeChildOptions = !(baselineBreadcrumsService.RequestParentNodeIsIncluded());
 
-			StateHasChanged();
+				// EXPLANATION :: initializingPage is surrounded by if condition because
+				// as part of exception handling we now allow users to retry loading data.
+				// if user wants to retry then we want to keep showing user the loading
+				// layover message.
 
-			foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzId);
+				initializingPage = false;
+				StateHasChanged();
+
+				if (singleBaselineItemz.Description != null)
+				{
+					await ConvertMarkdownToHtml(singleBaselineItemz.Description);
+				}
+
+				foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzId);
+			}
 
 			//StateHasChanged();
 		}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemz.razor
@@ -547,8 +547,8 @@
 	{
 		// TODO :: Similar Code is there in several places in the project.
 		// We should try and come up with some common way to handle it!
-
-		var foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(Id);
+		    
+		// var foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(Id);
 		if (foundProjectAndBaselineIds.BaselineId != Guid.Empty)
 		{
 			var url = $"/BaselineTreeView/{foundProjectAndBaselineIds.BaselineId}?autoSelectedRecordId={Id}";

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
@@ -182,6 +182,7 @@
 
 
 	public GetBaselineItemzDTO singleBaselineItemz { get; set; } = new();
+	private (Guid ProjectId, Guid BaselineId) foundProjectAndBaselineIds;
 	private ParameterForBaselineBreadcrums BreadcrumsParameter;
 	public bool initializingPage { get; set; } = false;
 
@@ -323,6 +324,8 @@
 						await ConvertMarkdownToHtml(singleBaselineItemz.Description);
 					}
 
+					foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzId);
+
 				}
 
 				// EXPLANATION : At the start of initialization process we capture parent record ID. 
@@ -383,7 +386,7 @@
 		// TODO :: Similar Code is there in several places in the project.
 		// We should try and come up with some common way to handle it!
 
-		var foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzId);
+		// var foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzId);
 		if (foundProjectAndBaselineIds.BaselineId != Guid.Empty)
 		{
 			var url = $"/BaselineTreeView/{foundProjectAndBaselineIds.BaselineId}?autoSelectedRecordId={BaselineItemzId}";

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
@@ -22,6 +22,7 @@
 @inject IFindProjectAndBaselineIdsByBaselineItemzIdService FindProjectAndBaselineIdsByBaselineItemzIdService
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<BaselineItemzDetails> _logger
 
 @if (BreadcrumsParameter != null)
 {
@@ -44,7 +45,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaselineItemz != null)
 	{
 		<MudItem xs="12" sm="12">
 		<MudPaper Class="mb-5">
@@ -203,49 +204,140 @@
 		{
 			initializingPage = true;
 			StateHasChanged();
-			// TODO :: IMPLEMENT TRY AND CATCH WHILE WE CALL BASELINE ITEMZ SERVICE
-			singleBaselineItemz = await BaselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
 
-			if (singleBaselineItemz != null)
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				BreadcrumsParameter = new ParameterForBaselineBreadcrums();
-				BreadcrumsParameter.Id = singleBaselineItemz.Id;
-				BreadcrumsParameter.Name = singleBaselineItemz.Name;
-				BreadcrumsParameter.RecordType = "baselineitemz"; // TODO :: USE CONSTANT
-				BreadcrumsParameter.isIncluded = singleBaselineItemz.isIncluded;
-
-				// Obtain tags list from the singleBaselineItemz.
-				if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+				try
 				{
-					// Normalize incoming tags (removes duplicates, trims, preserves order)
-					var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
+					singleBaselineItemz = await BaselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
 
-					// Parse into list
-					tagsList = TagParsingUtility.ParseTags(normalized);
+					if (singleBaselineItemz == null)
+					{
+						throw new ApplicationException($"BaselineItemz with ID {BaselineItemzId} not found.");
+					}
 				}
-				else
+				catch (ApplicationException ex)
 				{
-					tagsList = new List<string>();
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline itemz has been deleted.",
+						BaselineItemzId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Baseline Itemz Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested baseline itemz has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline itemz {BaselineItemzId}. Waiting 1 second before retry.", BaselineItemzId);
+						// Wait 1 seconds before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
 				}
-			}
 
-			if (form != null)
-			{
-				initializingPage = false;
-			}
+				if (singleBaselineItemz != null)
+				{
+					BreadcrumsParameter = new ParameterForBaselineBreadcrums();
+					BreadcrumsParameter.Id = singleBaselineItemz.Id;
+					BreadcrumsParameter.Name = singleBaselineItemz.Name;
+					BreadcrumsParameter.RecordType = "baselineitemz"; // TODO :: USE CONSTANT
+					BreadcrumsParameter.isIncluded = singleBaselineItemz.isIncluded;
 
-			await ConvertMarkdownToHtml(singleBaselineItemz.Description);
-			StateHasChanged();
+					// Obtain tags list from the singleBaselineItemz.
+					if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+					{
+						// Normalize incoming tags (removes duplicates, trims, preserves order)
+						var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
 
-			// EXPLANATION : At the start of initialization process we capture parent record ID. 
-			// Now even if user decides to Delete this Itemz Record then also we can go back to it's 
-			// Parent ItemzType post completing deletion operation. 
-			var httpResponse = await BaselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzId);
+						// Parse into list
+						tagsList = TagParsingUtility.ParseTags(normalized);
+					}
+					else
+					{
+						tagsList = new List<string>();
+					}
+				}
 
-			if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // If for some reason API call fails then also we can avoid exception by this null check.
-			{
-				ParentId = httpResponse.ParentRecordId;
-				ParentRecordType = httpResponse.ParentRecordType;
+				#region DELETEME NEXT TIME
+				// if (form != null)
+				// {
+				// 	initializingPage = false;
+				// }
+
+				// await ConvertMarkdownToHtml(singleBaselineItemz.Description);
+				// StateHasChanged();
+
+				#endregion
+
+				if (singleBaselineItemz != null)
+				{
+
+					// EXPLANATION :: initializingPage is surrounded by if condition because
+					// as part of exception handling we now allow users to retry loading data.
+					// if user wants to retry then we want to keep showing user the loading
+					// layover message.
+
+					initializingPage = false;
+					StateHasChanged();
+
+					if (singleBaselineItemz.Description != null)
+					{
+						await ConvertMarkdownToHtml(singleBaselineItemz.Description);
+					}
+
+				}
+
+				// EXPLANATION : At the start of initialization process we capture parent record ID. 
+				// Now even if user decides to Delete this Itemz Record then also we can go back to it's 
+				// Parent ItemzType post completing deletion operation. 
+				var httpResponse = await BaselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzId);
+
+				if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // If for some reason API call fails then also we can avoid exception by this null check.
+				{
+					ParentId = httpResponse.ParentRecordId;
+					ParentRecordType = httpResponse.ParentRecordType;
+				}
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
 			}
 		}
 	}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -7,6 +7,7 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.BaselineItemz
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.BaselineItemz.BaselineTraceability
 @using OpenRose.WebUI.Components.Pages.Common
@@ -16,9 +17,11 @@
 @using Microsoft.AspNetCore.Components.Forms
 @inject BaselineTreeNodeItemzSelectionService BaselineItemzSelectionService
 @inject NavigationBlockerService NavigationBlocker
+@inject NavigationManager NavManager
 @inject ViewSettingsService ViewSettings
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<BaselineItemzReadOnlyComponent> _logger
 
 <MudGrid>
 	@if (initializingPage)
@@ -31,7 +34,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaselineItemz != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
@@ -180,33 +183,112 @@
 			StateHasChanged();
 			await Task.Delay(300);
 
-			singleBaselineItemz = await BaselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
-			if (singleBaselineItemz != null && singleBaselineItemz.Description != null)
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				await ConvertMarkdownToHtml(singleBaselineItemz.Description);
-
-				// Obtain tags list from the singleBaselineItemz.
-				if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+				try
 				{
-					// Normalize incoming tags (removes duplicates, trims, preserves order)
-					var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
-
-					// Parse into list
-					tagsList = TagParsingUtility.ParseTags(normalized);
+					singleBaselineItemz = await BaselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
+					if (singleBaselineItemz == null)
+					{
+						throw new ApplicationException($"BaselineItemz with ID {BaselineItemzId} not found.");
+					}
 				}
-				else
+				catch (ApplicationException ex)
 				{
-					tagsList = new List<string>();
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline itemz has been deleted.",
+						BaselineItemzId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+						{
+							["Title"] = "Connection Error",
+							["MessageHtml"] =
+										"<p style='color:red;'><strong>Unable to obtain Baseline Itemz Data</strong></p>" +
+										"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+										"<p>The requested baseline itemz has been deleted.</p>" +
+										"<p><strong>Would you like to retry?</strong></p>",
+							["YesText"] = "Retry",
+							["NoText"] = "Go to Home"
+						};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+						{
+							CloseButton = false,
+							BackdropClick = false,
+							CloseOnEscapeKey = false
+						};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline itemz {BaselineItemzId}. Waiting 1 second before retry.", BaselineItemzId);
+						// Wait 1 seconds before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
 				}
-			}
+				
+				if (singleBaselineItemz != null)
+				{
+					// EXPLANATION :: initializingPage is surrounded by if condition because
+					// as part of exception handling we now allow users to retry loading data.
+					// if user wants to retry then we want to keep showing user the loading
+					// layover message.
 
-			initializingPage = false;
-			StateHasChanged();
+					initializingPage = false;
+					StateHasChanged();
 
-			// ALWAYS run navigation blocker after render if kiosk mode is active
-			if (ViewSettings.IsKioskMode)
-			{
-				await NavigationBlocker.Enable();
+					if (singleBaselineItemz.Description != null)
+					{
+						await ConvertMarkdownToHtml(singleBaselineItemz.Description);
+
+					}
+
+					// Obtain tags list from the singleBaselineItemz.
+					if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+					{
+						// Normalize incoming tags (removes duplicates, trims, preserves order)
+						var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
+
+						// Parse into list
+						tagsList = TagParsingUtility.ParseTags(normalized);
+					}
+					else
+					{
+						tagsList = new List<string>();
+					}
+				}
+
+				// ALWAYS run navigation blocker after render if kiosk mode is active
+				if (ViewSettings.IsKioskMode)
+				{
+					await NavigationBlocker.Enable();
+				}
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
 			}
 		}
 	}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
@@ -8,6 +8,7 @@
 @using OpenRose.WebUI.Client.Services.BaselineItemz
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Components.Pages.BaselineItemz.BaselineTraceability
@@ -16,11 +17,13 @@
 @using System.Globalization
 @using OpenRose.WebUI.Components.Pages.SharedComponents
 @using OpenRose.WebUI.Components.Utilities
-@* @inject NavigationManager NavManager *@
+@inject NavigationManager NavManager
 @inject IFindProjectAndBaselineIdsByBaselineItemzIdService FindProjectAndBaselineIdsByBaselineItemzIdService
 @inject IDialogService DialogService
 @inject BaselineTreeNodeItemzSelectionService BaselineItemzSelectionService
 @inject IJSRuntime JS
+@inject ILogger<BaselineItemzTreeViewComponent> _logger
+
 
 <MudPaper Class="pa-4 mb-3 align-start d-flex" Style="width: auto" Outlined="false">
 	<MudText Typo="Typo.h6" Align="Align.Left">Baseline Itemz</MudText>
@@ -37,7 +40,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaselineItemz != null)
 	{
 		<MudItem xs="12" sm="12">
 		<MudTabs Outlined="true" Position="Position.Top" Rounded="true" Border="true" 
@@ -171,38 +174,114 @@
 			initializingPage = true;
 			StateHasChanged();
 			//await Task.Delay(300);
-			singleBaselineItemz = await baselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
-			if (singleBaselineItemz != null)
+
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				BaselineItemzSelectionService.LoadingOfBaselineItemzTreeViewComponent(BaselineItemzId, singleBaselineItemz.isIncluded);
-
-				// Obtain tags list from the singleBaselineItemz.
-				if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+				try
 				{
-					// Normalize incoming tags (removes duplicates, trims, preserves order)
-					var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
-
-					// Parse into list
-					tagsList = TagParsingUtility.ParseTags(normalized);
+					singleBaselineItemz = await baselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(BaselineItemzId);
+					
+					if (singleBaselineItemz == null)
+					{
+						throw new ApplicationException($"BaselineItemz with ID {BaselineItemzId} not found.");
+					}
 				}
-				else
+				catch (ApplicationException ex)
 				{
-					tagsList = new List<string>();
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline itemz has been deleted.",
+						BaselineItemzId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Baseline Itemz Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested baseline itemz has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline itemz {BaselineItemzId}. Waiting 1 second before retry.", BaselineItemzId);
+						// Wait 1 seconds before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
 				}
+
+
+				if (singleBaselineItemz != null)
+				{
+					BaselineItemzSelectionService.LoadingOfBaselineItemzTreeViewComponent(BaselineItemzId, singleBaselineItemz.isIncluded);
+
+					// EXPLANATION :: initializingPage is surrounded by if condition because
+					// as part of exception handling we now allow users to retry loading data.
+					// if user wants to retry then we want to keep showing user the loading
+					// layover message.
+
+					initializingPage = false;
+					StateHasChanged();
+
+					if (singleBaselineItemz.Description != null)
+					{
+						await ConvertMarkdownToHtml(singleBaselineItemz.Description);
+					}
+
+					// Obtain tags list from the singleBaselineItemz.
+					if (!string.IsNullOrWhiteSpace(singleBaselineItemz?.Tags))
+					{
+						// Normalize incoming tags (removes duplicates, trims, preserves order)
+						var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleBaselineItemz.Tags);
+
+						// Parse into list
+						tagsList = TagParsingUtility.ParseTags(normalized);
+					}
+					else
+					{
+						tagsList = new List<string>();
+					}
+				}
+				await UpdateAllChildBaselineItemzFromServer();
+
+				foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzId);
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
 			}
-			await UpdateAllChildBaselineItemzFromServer();
-
-			initializingPage = false;
-
-			await ConvertMarkdownToHtml(singleBaselineItemz.Description);
-
-			StateHasChanged();
-
-			foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzId);
-
-
-
-			//StateHasChanged();
 		}
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
@@ -258,7 +258,7 @@
 					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
 					if (dialogResult != null && dialogResult.Data is bool retry && retry)
 					{
-						_logger.LogInformation("User chose to retry loading baseline itemz type {BaselineItemzTypeId}. Waiting 2 seconds before retry.", BaselineItemzTypeId);
+						_logger.LogInformation("User chose to retry loading baseline itemz type {BaselineItemzTypeId}. Waiting 1 second before retry.", BaselineItemzTypeId);
 						// Wait 1 seconds before retrying to give server time to recover
 						await Task.Delay(1000);
 						// Continue the loop to retry

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
@@ -189,6 +189,7 @@
 
 	public GetBaselineItemzTypeDTO singleBaselineItemzType { get; set; } = new();
 	private List<BaselineHierarchyIdRecordDetailsDTO> AllBaselineItemzForBaselineItemzType { get; set; } = new List<BaselineHierarchyIdRecordDetailsDTO>();
+	private (Guid ProjectId, Guid BaselineId) foundProjectAndBaselineIds;
 	private ParameterForBaselineBreadcrums BreadcrumsParameter;
 	public bool initializingPage { get; set; } = true;
 
@@ -273,6 +274,9 @@
 					}
 				}
 			
+				// TODO :: WE HAVE TWO IF CONDITIONS THAT ARE SIMILAR WHERE WE ARE CHECKING FOR 
+				// if (singleBaselineItemzType != null). Lets combine them together.
+
 				if (singleBaselineItemzType != null)
 				{
 					BreadcrumsParameter = new ParameterForBaselineBreadcrums();
@@ -305,6 +309,7 @@
 						await ConvertMarkdownToHtml(singleBaselineItemzType.Description);
 					}
 
+					foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(BaselineItemzTypeId);
 				}
 
 				// EXPLANATION : At the start of initialization process we capture parent record ID.
@@ -348,8 +353,8 @@
 		// TODO :: Similar Code is there in ProjectTreeView.razor file as well.
 		// We should try and come up with some common way to handle it!
 
-		var foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(Id);
-		if (foundProjectAndBaselineIds.BaselineId != Guid.Empty)
+		// var foundProjectAndBaselineIds = await FindProjectAndBaselineIdsByBaselineItemzIdService.GetProjectAndBaselineId(Id);
+		if (foundProjectAndBaselineIds.BaselineId != Guid.Empty)  // TODO :: if (foundProjectAndBaselineIds is { BaselineId: not Guid.Empty })
 		{
 			var url = $"/BaselineTreeView/{foundProjectAndBaselineIds.BaselineId}?autoSelectedRecordId={Id}";
 			await JS.InvokeVoidAsync("openInNewTab", url);

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzType.razor
@@ -22,6 +22,7 @@
 @inject IDialogService DialogService
 @inject IFindProjectAndBaselineIdsByBaselineItemzIdService FindProjectAndBaselineIdsByBaselineItemzIdService
 @inject IJSRuntime JS
+@inject ILogger<BaselineItemzType> _logger
 
 
 @if (BreadcrumsParameter != null)
@@ -47,7 +48,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaselineItemzType != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
@@ -56,7 +57,7 @@
 					<MudText Typo="Typo.inherit"
 							Class="flex-grow-1 text-responsive-title"
 							Align="Align.Left">
-						<strong>@singleIBaselineItemzType.Name </strong>
+						<strong>@singleBaselineItemzType.Name </strong>
 					</MudText>
 					<div class="d-flex align-top flex-shrink-0" style="gap:8px;">
 					<MudButton OnClick="async _ => await openBaselineTreeView(BaselineItemzTypeId)" 
@@ -90,28 +91,28 @@
 	                                ">
 							<div style="display:flex; align-items:center; gap:6px;">
 							<strong>ID : </strong>
-							<CopyableText TextToCopy="@singleIBaselineItemzType.Id.ToString()" DisplayLength="8" />
-							<GoToOriginalItemzTypeButton BaselineItemzTypeId="@singleIBaselineItemzType.Id" />
-							<ShowHierarchyTreeButton RecordId="@singleIBaselineItemzType.Id" />
+							<CopyableText TextToCopy="@singleBaselineItemzType.Id.ToString()" DisplayLength="8" />
+							<GoToOriginalItemzTypeButton BaselineItemzTypeId="@singleBaselineItemzType.Id" />
+							<ShowHierarchyTreeButton RecordId="@singleBaselineItemzType.Id" />
 							</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleIBaselineItemzType.Status</div>
-							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(singleIBaselineItemzType.IsSystem ? "Yes" : "No")</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleBaselineItemzType.Status</div>
+							<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</div>
 							<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" /></div>
 						</div>
 					</MudBreakpointProvider>
 
 @* 					<MudStack Row="true" Spacing="2">
 						<MudText><strong>ID           : </strong></MudText>
-						<CopyableText TextToCopy="@singleIBaselineItemzType.Id.ToString()" />
+						<CopyableText TextToCopy="@singleBaselineItemzType.Id.ToString()" />
 					</MudStack>
-					<MudText><strong>Status       : </strong> @singleIBaselineItemzType.Status</MudText>
-					<MudText><strong>Is System?   : </strong> @(singleIBaselineItemzType.IsSystem ? "Yes" : "No") </MudText>
-					<MudText><strong>Created Date : </strong> @singleIBaselineItemzType.CreatedDate.ToString("dd MMM yyyy HH:mm:ss", CultureInfo.CurrentCulture)</MudText> *@
+					<MudText><strong>Status       : </strong> @singleBaselineItemzType.Status</MudText>
+					<MudText><strong>Is System?   : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No") </MudText>
+					<MudText><strong>Created Date : </strong> @singleBaselineItemzType.CreatedDate.ToString("dd MMM yyyy HH:mm:ss", CultureInfo.CurrentCulture)</MudText> *@
 					<MudText><strong>Description : </strong></MudText>
 					<br />
 					<div class="custom-markdown-editor">
 						<MudPaper Class="pa-2" Elevation="0" Outlined="false">
-							@if (!string.IsNullOrEmpty(singleIBaselineItemzType.Description))
+							@if (!string.IsNullOrEmpty(singleBaselineItemzType.Description))
 							{
 								<div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
 							}
@@ -186,7 +187,7 @@
 	// public IHierarchyService hierarchyService { get; set; }
 
 
-	public GetBaselineItemzTypeDTO singleIBaselineItemzType { get; set; } = new();
+	public GetBaselineItemzTypeDTO singleBaselineItemzType { get; set; } = new();
 	private List<BaselineHierarchyIdRecordDetailsDTO> AllBaselineItemzForBaselineItemzType { get; set; } = new List<BaselineHierarchyIdRecordDetailsDTO>();
 	private ParameterForBaselineBreadcrums BreadcrumsParameter;
 	public bool initializingPage { get; set; } = true;
@@ -202,41 +203,122 @@
 			initializingPage = true;
 			StateHasChanged();
 			//await Task.Delay(300);
-			singleIBaselineItemzType = await baselineItemzTypesService.__Single_BaselineItemzType_By_GUID_ID__Async(BaselineItemzTypeId);
 
-			// TODO :: THROW EXCEPTION IF BASELINE ITEMTYPE IS NOT FOUND!
-
-			if (singleIBaselineItemzType != null)
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				BreadcrumsParameter = new ParameterForBaselineBreadcrums();
-				BreadcrumsParameter.Id = singleIBaselineItemzType.Id;
-				BreadcrumsParameter.Name = singleIBaselineItemzType.Name;
-				BreadcrumsParameter.RecordType = "baselineitemztype"; // TODO :: USE CONSTANT
-				BreadcrumsParameter.isIncluded = true ; // TODO :: WE SET INCLUSION FOR BASELINEITEMZTYPE TO TRUE BUT WE CAN DO BETTER
+				try
+				{
+					singleBaselineItemzType = await baselineItemzTypesService.__Single_BaselineItemzType_By_GUID_ID__Async(BaselineItemzTypeId);
+
+					if (singleBaselineItemzType == null)
+					{
+						throw new ApplicationException($"BaselineItemzType with ID {BaselineItemzTypeId} not found.");
+					}
+
+				}
+				catch (ApplicationException ex)
+				{
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline itemz type has been deleted.",
+						BaselineItemzTypeId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Baseline Itemz Type Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested baseline itemz type has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline itemz type {BaselineItemzTypeId}. Waiting 2 seconds before retry.", BaselineItemzTypeId);
+						// Wait 1 seconds before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
+				}
+			
+				if (singleBaselineItemzType != null)
+				{
+					BreadcrumsParameter = new ParameterForBaselineBreadcrums();
+					BreadcrumsParameter.Id = singleBaselineItemzType.Id;
+					BreadcrumsParameter.Name = singleBaselineItemzType.Name;
+					BreadcrumsParameter.RecordType = "baselineitemztype"; // TODO :: USE CONSTANT
+					BreadcrumsParameter.isIncluded = true ; // TODO :: WE SET INCLUSION FOR BASELINEITEMZTYPE TO TRUE BUT WE CAN DO BETTER
+				}
+
+				var returnedItemzList = await baselineHierarchyService.__Get_Immediate_Children_Baseline_Hierarchy_By_GUID__Async(BaselineItemzTypeId);
+
+				if (returnedItemzList != null)
+				{
+					AllBaselineItemzForBaselineItemzType = returnedItemzList.ToList();
+				}
+
+				if (singleBaselineItemzType != null)
+				{
+
+					// EXPLANATION :: initializingPage is surrounded by if condition because
+					// as part of exception handling we now allow users to retry loading data.
+					// if user wants to retry then we want to keep showing user the loading
+					// layover message.
+
+					initializingPage = false;
+					StateHasChanged();
+
+					if (singleBaselineItemzType.Description != null)
+					{
+						await ConvertMarkdownToHtml(singleBaselineItemzType.Description);
+					}
+
+				}
+
+				// EXPLANATION : At the start of initialization process we capture parent record ID.
+				// Now even if user decides to Delete this Itemz Record then also we can go back to it's
+				// Parent post completing deletion operation.
+				var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzTypeId);
+				if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check.
+				{
+					ParentId = httpResponse.ParentRecordId;
+				}
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
 			}
-
-			var returnedItemzList = await baselineHierarchyService.__Get_Immediate_Children_Baseline_Hierarchy_By_GUID__Async(BaselineItemzTypeId);
-
-			if (returnedItemzList != null)
-			{
-				AllBaselineItemzForBaselineItemzType = returnedItemzList.ToList();
-			}
-
-			initializingPage = false;
-
-			// EXPLANATION : At the start of initialization process we capture parent record ID.
-			// Now even if user decides to Delete this Itemz Record then also we can go back to it's
-			// Parent post completing deletion operation.
-			var httpResponse = await baselineHierarchyService.__Get_BaselineHierarchy_Record_Details_By_GUID__Async(BaselineItemzTypeId);
-			if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check.
-			{
-				ParentId = httpResponse.ParentRecordId;
-			}
-
-
-			await ConvertMarkdownToHtml(singleIBaselineItemzType.Description);
-			StateHasChanged();
-			//StateHasChanged();
 		}
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -5,8 +5,8 @@
 *@
 
 @using OpenRose.WebUI.Client.Services.BaselineItemzTypes
-@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.SharedComponents
@@ -18,6 +18,7 @@
 @inject ViewSettingsService ViewSettings
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<BaselineItemzTypeReadOnlyComponent> _logger
 
 <MudGrid>
 	@if (initializingPage)
@@ -30,7 +31,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaselineItemzType != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
@@ -154,18 +155,102 @@
 			StateHasChanged();
 			await Task.Delay(300);
 
-			singleBaselineItemzType = await BaselineItemzTypeServices.__Single_BaselineItemzType_By_GUID_ID__Async(BaselineItemzTypeId);
-			if (singleBaselineItemzType != null && singleBaselineItemzType.Description != null)
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				await ConvertMarkdownToHtml(singleBaselineItemzType.Description);
-			}
+				try
+				{
+					singleBaselineItemzType = await BaselineItemzTypeServices.__Single_BaselineItemzType_By_GUID_ID__Async(BaselineItemzTypeId);
 
-			initializingPage = false;
-			StateHasChanged();
-			// ALWAYS run navigation blocker after render if kiosk mode is active
-			if (ViewSettings.IsKioskMode)
-			{
-				await NavigationBlocker.Enable();
+					if (singleBaselineItemzType == null)
+					{
+						throw new ApplicationException($"BaselineItemzType with ID {BaselineItemzTypeId} not found.");
+					}
+
+				}
+				catch (ApplicationException ex)
+				{
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline itemz type has been deleted.",
+						BaselineItemzTypeId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Baseline Itemz Type Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested baseline itemz type has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline itemz type {BaselineItemzTypeId}. Waiting 2 seconds before retry.", BaselineItemzTypeId);
+						// Wait 1 seconds before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
+				}
+
+				if (singleBaselineItemzType != null)
+				{
+
+					// EXPLANATION :: initializingPage is surrounded by if condition because
+					// as part of exception handling we now allow users to retry loading data.
+					// if user wants to retry then we want to keep showing user the loading
+					// layover message.
+
+					initializingPage = false;
+					StateHasChanged();
+
+					if (singleBaselineItemzType.Description != null)
+					{
+						await ConvertMarkdownToHtml(singleBaselineItemzType.Description);
+					}
+
+				}
+
+				// ALWAYS run navigation blocker after render if kiosk mode is active
+				if (ViewSettings.IsKioskMode)
+				{
+					await NavigationBlocker.Enable();
+				}
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
+
 			}
 		}
 	}

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
@@ -20,6 +20,7 @@
 @inject IFindProjectOfItemzId FindProjectOfItemzId
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<BaselineItemzTypeTreeViewComponent> _logger
 
 <MudPaper Class="pa-4 mb-3 ml-1 align-start d-flex" Style="width: auto" Outlined="false">
 	<MudText Typo="Typo.h6" Align="Align.Left">Baseline ItemzType</MudText>
@@ -36,7 +37,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleBaselineItemzType != null)
 	{
  		<MudItem xs="12" sm="12">
 		<MudTabs Outlined="true" Position="Position.Top" Rounded="true" Border="true" 
@@ -48,7 +49,7 @@
 				<MudItem Class="align-start d-flex" Style="width: auto" Outlined="false">
 					<MudGrid>
 						<MudItem xs="12" sm="12" md="7" lg="7">
-							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleIBaselineItemzType.Name </strong></MudText>
+							<MudText Typo="Typo.h5" Align="Align.Left"><strong>@singleBaselineItemzType.Name </strong></MudText>
 						</MudItem>
 						<MudItem xs="12" sm="12" md="5" lg="5">
 							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Justify="Justify.FlexEnd" Class="w-100">
@@ -65,34 +66,34 @@
 					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
 						<MudStack Row="true" Spacing="2">
 							<MudText><strong>ID          : </strong></MudText>
-							<CopyableText TextToCopy="@singleIBaselineItemzType.Id.ToString()" DisplayLength="8" />
+							<CopyableText TextToCopy="@singleBaselineItemzType.Id.ToString()" DisplayLength="8" />
 							<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
 								<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
 							</MudTooltip>
-                            <GoToOriginalItemzTypeButton BaselineItemzTypeId="@singleIBaselineItemzType.Id"
+                            <GoToOriginalItemzTypeButton BaselineItemzTypeId="@singleBaselineItemzType.Id"
                                                          UseTreeView="true" />
-							<ShowHierarchyTreeButton RecordId="@singleIBaselineItemzType.Id" />
+							<ShowHierarchyTreeButton RecordId="@singleBaselineItemzType.Id" />
 						</MudStack>
-						<MudText><strong> || Status      : </strong> @singleIBaselineItemzType.Status</MudText>
-						<MudText><strong> || Is System?  : </strong> @(singleIBaselineItemzType.IsSystem ? "Yes" : "No")</MudText>
+						<MudText><strong> || Status      : </strong> @singleBaselineItemzType.Status</MudText>
+						<MudText><strong> || Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</MudText>
 						|| <BaselineEstimationReadOnlyComponent RecordId="BaselineItemzTypeId" />
 					</MudStack>
 
 @* 					<MudStack Row="true" Spacing="2">
 						<MudText><strong>ID           : </strong> </MudText>
-						<CopyableText TextToCopy="@singleIBaselineItemzType.Id.ToString()" />
+						<CopyableText TextToCopy="@singleBaselineItemzType.Id.ToString()" />
 						<MudTooltip Text="Show in Tree View">
 						<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
 						</MudTooltip>
 					</MudStack>
-					<MudText><strong>Status       : </strong> @singleIBaselineItemzType.Status</MudText>
-					<MudText><strong>Is System?   : </strong> @(singleIBaselineItemzType.IsSystem ? "Yes" : "No") </MudText>
-					<MudText><strong>Created Date : </strong> @singleIBaselineItemzType.CreatedDate.ToString("dd MMM yyyy HH:mm:ss", CultureInfo.CurrentCulture)</MudText> *@
+					<MudText><strong>Status       : </strong> @singleBaselineItemzType.Status</MudText>
+					<MudText><strong>Is System?   : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No") </MudText>
+					<MudText><strong>Created Date : </strong> @singleBaselineItemzType.CreatedDate.ToString("dd MMM yyyy HH:mm:ss", CultureInfo.CurrentCulture)</MudText> *@
 					<MudText><strong>Description : </strong></MudText>
 					<br />
 					<div class="custom-markdown-editor">
 						<MudPaper Class="pa-4 mb-5">
-							@if (!string.IsNullOrEmpty(singleIBaselineItemzType.Description))
+							@if (!string.IsNullOrEmpty(singleBaselineItemzType.Description))
 							{
 								<div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
 							}
@@ -122,7 +123,7 @@
     public IBaselineItemzTypesService baselineItemzTypesService { get; set; }
 
 
-    public GetBaselineItemzTypeDTO singleIBaselineItemzType { get; set; } = new();
+    public GetBaselineItemzTypeDTO singleBaselineItemzType { get; set; } = new();
     public bool initializingPage { get; set; } = true;
 
     private MarkupString convertedMarkdown;
@@ -134,15 +135,100 @@
             initializingPage = true;
             StateHasChanged();
             //await Task.Delay(300);
-            singleIBaselineItemzType = await baselineItemzTypesService.__Single_BaselineItemzType_By_GUID_ID__Async(BaselineItemzTypeId);
 
-            // TODO :: THROW EXCEPTION IF BASELINE ITEMTYPE IS NOT FOUND!
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
+			{
+				try
+				{
+				  singleBaselineItemzType = await baselineItemzTypesService.__Single_BaselineItemzType_By_GUID_ID__Async(BaselineItemzTypeId);
 
-            initializingPage = false;
+				  if (singleBaselineItemzType == null)
+					{
+						throw new ApplicationException($"BaselineItemzType with ID {BaselineItemzTypeId} not found.");
+					}
 
-            await ConvertMarkdownToHtml(singleIBaselineItemzType.Description);
+				}
+				catch (ApplicationException ex)
+				{
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested baseline itemz type has been deleted.",
+						BaselineItemzTypeId);
 
-            StateHasChanged();
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Baseline Itemz Type Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested baseline itemz type has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading baseline itemz type {BaselineItemzTypeId}. Waiting 2 seconds before retry.", BaselineItemzTypeId);
+						// Wait 1 seconds before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						loadingSuccessful = true;
+						NavManager.NavigateTo("/");
+					}
+				}
+
+
+
+				if (singleBaselineItemzType != null)
+				{
+
+					// EXPLANATION :: initializingPage is surrounded by if condition because
+					// as part of exception handling we now allow users to retry loading data.
+					// if user wants to retry then we want to keep showing user the loading
+					// layover message.
+
+					initializingPage = false;
+					StateHasChanged();
+
+					if (singleBaselineItemzType.Description != null)
+					{
+						await ConvertMarkdownToHtml(singleBaselineItemzType.Description);
+					}
+
+				}
+				// StateHasChanged();
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
+			}
         }
     }
     private void findAndShowInTreeView()

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -27,6 +27,7 @@
 @inject ProtectedSessionStorage SessionStorage
 @inject ViewSettingsService ViewSettings
 @inject IJSRuntime JS
+@inject ILogger<Itemz> _logger
 @inject IServiceProvider serviceProvider
 
 @if (BreadcrumsParameter != null)
@@ -47,7 +48,8 @@
 
 		<!-- This spacer pushes everything after it to the far right -->
 		<MudSpacer />
-
+		@if (singleItemz != null)
+		{
 		<MudSwitch T="bool"
 				   Value="@ViewSettings.ShowTraceabilityInItemzDetails"
 				   ValueChanged="ToggleShowTraces"
@@ -55,7 +57,7 @@
 				   UncheckedColor="Color.Success"
 				   Color="Color.Success"
 				   LabelPlacement="Placement.End" />
-
+		}
 	</MudStack>
 </MudPaper>
 
@@ -263,34 +265,107 @@
 		initializingPage = true;
 		StateHasChanged();
 		//await Task.Delay(300);
-		singleItemz = await itemzService.__Single_Itemz_By_GUID_ID__Async(ItemzId);
 
-		if (singleItemz != null)
+		bool loadingSuccessful = false;
+		while (!loadingSuccessful)
 		{
-			BreadcrumsParameter = new ParameterForItemzBreadcrums();
-			BreadcrumsParameter.Id = singleItemz.Id;
-			BreadcrumsParameter.Name = singleItemz.Name;
-			BreadcrumsParameter.RecordType = "itemz"; // TODO :: USE CONSTANT
-
-			if (!string.IsNullOrWhiteSpace(singleItemz?.Tags))
+			try
 			{
-				// Normalize incoming tags (removes duplicates, trims, preserves order)
-				var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleItemz.Tags);
 
-				// Parse into list
-				tagsList = TagParsingUtility.ParseTags(normalized);
+				singleItemz = await itemzService.__Single_Itemz_By_GUID_ID__Async(ItemzId);
+
+				if (singleItemz == null)
+				{
+					throw new ApplicationException($"Itemz with ID {ItemzId} not found.");
+				}
+
 			}
-			else
+			catch (ApplicationException ex)
 			{
-				tagsList = new List<string>();
+				// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				_logger.LogWarning(
+					ex,
+					"Either API Server is unavailable OR requested itemz has been deleted.",
+					ItemzId);
+
+				initializingPage = true;
+				StateHasChanged();
+
+				var parameters = new DialogParameters
+				{
+					["Title"] = "Connection Error",
+					["MessageHtml"] =
+								"<p style='color:red;'><strong>Unable to obtain Itemz Data</strong></p>" +
+								"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+								"<p>The requested itemz has been deleted.</p>" +
+								"<p><strong>Would you like to retry?</strong></p>",
+					["YesText"] = "Retry",
+					["NoText"] = "Go to Home"
+				};
+
+				// Show error dialog with retry option
+				var options = new DialogOptions
+				{
+					CloseButton = false,
+					BackdropClick = false,
+					CloseOnEscapeKey = false
+				};
+
+				var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					"Connection Error",
+					parameters,
+					options);
+
+				var dialogResult = await dialog.Result;
+
+				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				if (dialogResult != null && dialogResult.Data is bool retry && retry)
+				{
+					_logger.LogInformation("User chose to retry loading itemz {ItemzId}. Waiting 1 seconds before retry.", ItemzId);
+					// Wait 1 second before retrying to give server time to recover
+					await Task.Delay(1000);
+					// Continue the loop to retry
+					continue;
+				}
+				else
+				{
+					// 🔑 USER CLICKED "GO TO Home Screen"
+					_logger.LogInformation("User chose to go to home screen");
+					loadingSuccessful = true;
+					NavManager.NavigateTo("/");
+				}
 			}
 
-			var returnedItemzList = await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ItemzId);
-
-			if (returnedItemzList != null)
+			if (singleItemz != null)
 			{
-				AllChildItemz = returnedItemzList.ToList();
+				BreadcrumsParameter = new ParameterForItemzBreadcrums();
+				BreadcrumsParameter.Id = singleItemz.Id;
+				BreadcrumsParameter.Name = singleItemz.Name;
+				BreadcrumsParameter.RecordType = "itemz"; // TODO :: USE CONSTANT
+
+				if (!string.IsNullOrWhiteSpace(singleItemz?.Tags))
+				{
+					// Normalize incoming tags (removes duplicates, trims, preserves order)
+					var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleItemz.Tags);
+
+					// Parse into list
+					tagsList = TagParsingUtility.ParseTags(normalized);
+				}
+				else
+				{
+					tagsList = new List<string>();
+				}
+
+				var returnedItemzList = await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ItemzId);
+
+				if (returnedItemzList != null)
+				{
+					AllChildItemz = returnedItemzList.ToList();
+				}
 			}
+			// 🔑 MARK LOADING AS SUCCESSFUL
+			loadingSuccessful = true;
+
 		}
 	}
 
@@ -310,9 +385,16 @@
 			await Task.Delay(200); // Wanted Breadcrums to load so that decision about displaying Child Itemz can be taken properly.
 		}
 
-		await ConvertMarkdownToHtml(singleItemz.Description);
-		await InvokeAsync(StateHasChanged);
-		initializingPage = false;
+		if (singleItemz != null)
+		{
+			initializingPage = false;
+			await InvokeAsync(StateHasChanged);
+
+			if (!string.IsNullOrEmpty(singleItemz.Description))
+			{
+				await ConvertMarkdownToHtml(singleItemz.Description);
+			}
+		}
 	}
 
 	public async Task editItemzDetails(string itemzId)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -73,10 +73,10 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleItemz != null) 
 	{
-	if (singleItemz != null)
-	{
+	
+	
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
 				<MudCardContent Style="padding:6px">
@@ -216,7 +216,6 @@
 
 		}
 		}
-	}
 	}
 </MudGrid>
 @if (_showOverlay)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -431,10 +431,10 @@
 		}
 
 		// TODO :: The initializingPage didn't really work for 
-        // showing overlay when connection to API layer was dropped
+		// showing overlay when connection to API layer was dropped
 
 		initializingPage = true;
-        StateHasChanged();
+		StateHasChanged();
 
 		var httpResponse = await HierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzId);
 
@@ -464,7 +464,7 @@
 			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
 			await dialogRef.Result;
 			initializingPage = false;
-            StateHasChanged();
+			StateHasChanged();
 		}
 	}
 
@@ -600,6 +600,13 @@
 		{
 			var url = $"/ProjectTreeView/{foundProjectId}?autoSelectedRecordId={ItemzId}";
 			await JS.InvokeVoidAsync("openInNewTab", url);
+		}
+		else
+		{
+			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining requirement related data" };
+			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
+			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
+			await dialogRef.Result;
 		}
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -76,7 +76,6 @@
 	else if (singleItemz != null) 
 	{
 	
-	
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
 				<MudCardContent Style="padding:6px">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Itemz.razor
@@ -603,7 +603,7 @@
 		}
 		else
 		{
-			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining requirement related data" };
+			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining related data from server" };
 			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
 			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
 			await dialogRef.Result;

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -78,7 +78,7 @@
 </MudPaper>
 @* <MudGrid Class="ms-0 mt-0 pa-0"> *@
 <MudGrid>
-		@if (initializingPage)
+	@if (initializingPage)
 	{
 		<MudPaper Style="margin-top : 20px" Height="calc(100vh - 100px);" Width="100%">
 			<MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
@@ -88,7 +88,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleItemz != null)
 	{
 		<MudItem xs="12" sm="12" Outline="false">
 @* 		<MudPaper Class="mb-5" Outlined="false"> *@
@@ -454,10 +454,6 @@
 		}
 	}
 
-
-
-
-
 	//MudForm related fields
 	bool success = true;
 	bool disableUpdateItemzDetailsButton = false;
@@ -640,6 +636,11 @@
 
 			if (singleItemz != null)
 			{
+
+				// EXPLANATION :: initializingPage is surrounded by if condition because
+				// as part of exception handling we now allow users to retry loading data.
+				// if user wants to retry then we want to keep showing user the loading
+				// layover message.
 				initializingPage = false;
 				await InvokeAsync(StateHasChanged);
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -928,7 +928,7 @@
 		}
 		else
 		{
-			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining requirement related data" };
+			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining related data from server" };
 			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
 			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
 			await dialogRef.Result;

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -902,7 +902,7 @@
 	{
 		// EXPLANATION :: Before we navigate to a different view, ensure any unsaved changes are handled.
 		bool canProceed = await FormStateService.ConfirmDiscardChangesAsync(ItemzId);
-        if (!canProceed) return;
+		if (!canProceed) return;
 
 		var url = $"/itemz/{ItemzId.ToString()}";
 		await JS.InvokeVoidAsync("openInNewTab", url);
@@ -925,6 +925,13 @@
 		{
 			var url = $"/ProjectTreeView/{foundProjectId}?autoSelectedRecordId={ItemzId}";
 			await JS.InvokeVoidAsync("openInNewTab", url);
+		}
+		else
+		{
+			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining requirement related data" };
+			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
+			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
+			await dialogRef.Result;
 		}
 	}
 	private async Task ConfirmNavigation(LocationChangingContext context)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -8,6 +8,7 @@
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Components.Pages.Breadcrums
@@ -26,6 +27,7 @@
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject BreadcrumsService breadcrumsService
 @inject IJSRuntime JS
+@inject ILogger<ItemzDetailsComponent> _logger
 @inject IServiceProvider serviceProvider
 
 
@@ -57,7 +59,7 @@
 	<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="w-100">
 		<MudText Typo="Typo.h6" Align="Align.Left">Itemz Details</MudText>
 		<MudSpacer />
-		@if (CalledFrom == nameof(ProjectTreeView))
+		@if (CalledFrom == nameof(ProjectTreeView) && singleItemz != null)
 		{
 			<MudButton Variant="Variant.Filled" Color="Color.Success"
 					   Disabled="FormStateService.IsDirty(ItemzId)"
@@ -78,7 +80,7 @@
 <MudGrid>
 		@if (initializingPage)
 	{
-		<MudPaper Height="calc(100vh - 100px);" Width="100%">
+		<MudPaper Style="margin-top : 20px" Height="calc(100vh - 100px);" Width="100%">
 			<MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
 				<MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
 				<br />
@@ -485,99 +487,177 @@
 		initializingPage = true;
 		StateHasChanged();
 		//await Task.Delay(300);
-		singleItemz = await ItemzService.__Single_Itemz_By_GUID_ID__Async(ItemzId);
 
-		if (singleItemz != null)
+		bool loadingSuccessful = false;
+		while (!loadingSuccessful)
 		{
-			BreadcrumsParameter = new ParameterForItemzBreadcrums();
-			BreadcrumsParameter.Id = singleItemz.Id;
-			BreadcrumsParameter.Name = singleItemz.Name;
-			BreadcrumsParameter.RecordType = "itemz"; // TODO :: USE CONSTANT
-
-			TreeNodeItemzSelectionService.UpdateTreeNodeItemzName(ItemzId, singleItemz.Name!);
-			originalItemzName = singleItemz.Name ?? string.Empty;
-
-			_originalDescription = singleItemz.Description ?? string.Empty;
-			MyContent = _originalDescription;
-
-			if (!string.IsNullOrWhiteSpace(singleItemz?.Tags))
+			try
 			{
-				// Normalize incoming tags (removes duplicates, trims, preserves order)
-				var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleItemz.Tags);
+				singleItemz = await ItemzService.__Single_Itemz_By_GUID_ID__Async(ItemzId);
 
-				// Parse into list
-				tagsList = TagParsingUtility.ParseTags(normalized);
+				if (singleItemz == null)
+				{
+					throw new ApplicationException($"Itemz with ID {ItemzId} not found.");
+				}
 
-				UpdateTagLength();
 			}
-			else
+			catch (ApplicationException ex)
 			{
-				tagsList = new List<string>();
+				// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				_logger.LogWarning(
+					ex,
+					"Either API Server is unavailable OR requested itemz has been deleted.",
+					ItemzId);
+
+				initializingPage = true;
+				StateHasChanged();
+
+				var parameters = new DialogParameters
+				{
+					["Title"] = "Connection Error",
+					["MessageHtml"] =
+								"<p style='color:red;'><strong>Unable to obtain Itemz Data</strong></p>" +
+								"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+								"<p>The requested itemz has been deleted.</p>" +
+								"<p><strong>Would you like to retry?</strong></p>",
+					["YesText"] = "Retry",
+					["NoText"] = "Go to Home"
+				};
+
+				// Show error dialog with retry option
+				var options = new DialogOptions
+				{
+					CloseButton = false,
+					BackdropClick = false,
+					CloseOnEscapeKey = false
+				};
+
+				var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					"Connection Error",
+					parameters,
+					options);
+
+				var dialogResult = await dialog.Result;
+
+				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				if (dialogResult != null && dialogResult.Data is bool retry && retry)
+				{
+					_logger.LogInformation("User chose to retry loading itemz {ItemzId}. Waiting 1 seconds before retry.", ItemzId);
+					// Wait 1 second before retrying to give server time to recover
+					await Task.Delay(1000);
+					// Continue the loop to retry
+					continue;
+				}
+				else
+				{
+					// 🔑 USER CLICKED "GO TO Home Screen"
+					_logger.LogInformation("User chose to go to home screen");
+					loadingSuccessful = true;
+					NavManager.NavigateTo("/");
+				}
 			}
+
+			if (singleItemz != null)
+			{
+				BreadcrumsParameter = new ParameterForItemzBreadcrums();
+				BreadcrumsParameter.Id = singleItemz.Id;
+				BreadcrumsParameter.Name = singleItemz.Name;
+				BreadcrumsParameter.RecordType = "itemz"; // TODO :: USE CONSTANT
+
+				TreeNodeItemzSelectionService.UpdateTreeNodeItemzName(ItemzId, singleItemz.Name!);
+				originalItemzName = singleItemz.Name ?? string.Empty;
+
+				_originalDescription = singleItemz.Description ?? string.Empty;
+				MyContent = _originalDescription;
+
+				if (!string.IsNullOrWhiteSpace(singleItemz?.Tags))
+				{
+					// Normalize incoming tags (removes duplicates, trims, preserves order)
+					var normalized = TagParsingUtility.NormalizeAndRemoveDuplicates(singleItemz.Tags);
+
+					// Parse into list
+					tagsList = TagParsingUtility.ParseTags(normalized);
+
+					UpdateTagLength();
+				}
+				else
+				{
+					tagsList = new List<string>();
+				}
+			}
+
+			if (form != null)
+			{
+				await form.Validate();
+				if (form.IsValid)
+				{
+					disableUpdateItemzDetailsButton = false;
+				}
+				else
+				{
+					disableUpdateItemzDetailsButton = true;
+				}
+
+				// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
+				List<string> tempStatusList = new List<string>();
+				foreach (var _itemzStatusValue in Enum.GetValues<ItemzStatus>())
+				{
+					tempStatusList.Add(_itemzStatusValue.ToString().Trim());
+				}
+				_stringItemzStatusValues = tempStatusList.ToArray();
+
+				// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
+				List<string> tempPriorityList = new List<string>();
+				foreach (var _itemzPriorityValue in Enum.GetValues<ItemzPriority>())
+				{
+					tempPriorityList.Add(_itemzPriorityValue.ToString().Trim());
+				}
+				_stringItemzPriorityValues = tempPriorityList.ToArray();
+
+				// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
+				List<string> tempSeverityList = new List<string>();
+				foreach (var _itemzSeverityValue in Enum.GetValues<ItemzSeverity>())
+				{
+					tempSeverityList.Add(_itemzSeverityValue.ToString().Trim());
+				}
+				_stringItemzSeverityValues = tempSeverityList.ToArray();
+
+				// initializingPage = false;
+			}
+
+			// EXPLANATION : At the start of initialization process we capture parent record ID.
+			// Now even if user decides to Delete this Itemz Record then also we can go back to it's
+			// Parent ItemzType post completing deletion operation.
+			var httpResponse = await hierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzId);
+			if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // Orphaned Itemz will not have any Hierarchy records.
+			{
+				ParentId = httpResponse.ParentRecordId;
+				ParentRecordType = httpResponse.ParentRecordType;
+			}
+
+			// Determine orphaned state (no parent -> we don't expect children)
+			isOrphaned = (httpResponse == null) || (httpResponse.ParentRecordId == Guid.Empty);
+
+			if (singleItemz != null)
+			{
+				initializingPage = false;
+				await InvokeAsync(StateHasChanged);
+
+				if (!string.IsNullOrEmpty(singleItemz.Description))
+				{
+					await ConvertMarkdownToHtml(singleItemz.Description);
+				}
+			}
+
+			// Reset dirty state
+			FormStateService.SetDirty(ItemzId, false);
+
+			// Mark that description initialization is complete
+			_initializingDescription = false;
+
+			// 🔑 MARK LOADING AS SUCCESSFUL
+			loadingSuccessful = true;
 		}
-
-		if (form != null)
-		{
-			await form.Validate();
-			if (form.IsValid)
-			{
-				disableUpdateItemzDetailsButton = false;
-			}
-			else
-			{
-				disableUpdateItemzDetailsButton = true;
-			}
-
-			// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
-			List<string> tempStatusList = new List<string>();
-			foreach (var _itemzStatusValue in Enum.GetValues<ItemzStatus>())
-			{
-				tempStatusList.Add(_itemzStatusValue.ToString().Trim());
-			}
-			_stringItemzStatusValues = tempStatusList.ToArray();
-
-			// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
-			List<string> tempPriorityList = new List<string>();
-			foreach (var _itemzPriorityValue in Enum.GetValues<ItemzPriority>())
-			{
-				tempPriorityList.Add(_itemzPriorityValue.ToString().Trim());
-			}
-			_stringItemzPriorityValues = tempPriorityList.ToArray();
-
-			// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
-			List<string> tempSeverityList = new List<string>();
-			foreach (var _itemzSeverityValue in Enum.GetValues<ItemzSeverity>())
-			{
-				tempSeverityList.Add(_itemzSeverityValue.ToString().Trim());
-			}
-			_stringItemzSeverityValues = tempSeverityList.ToArray();
-
-			// initializingPage = false;
-		}
-
-		// EXPLANATION : At the start of initialization process we capture parent record ID.
-		// Now even if user decides to Delete this Itemz Record then also we can go back to it's
-		// Parent ItemzType post completing deletion operation.
-		var httpResponse = await hierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzId);
-		if (httpResponse != null && httpResponse.ParentRecordId != Guid.Empty) // Orphaned Itemz will not have any Hierarchy records.
-		{
-			ParentId = httpResponse.ParentRecordId;
-			ParentRecordType = httpResponse.ParentRecordType;
-		}
-
-		// Determine orphaned state (no parent -> we don't expect children)
-		isOrphaned = (httpResponse == null) || (httpResponse.ParentRecordId == Guid.Empty);
-
-		await ConvertMarkdownToHtml(singleItemz.Description);
-
-		// Mark that description initialization is complete
-		_initializingDescription = false;
-
-		// Reset dirty state
-		FormStateService.SetDirty(ItemzId, false);
-
-		initializingPage = false;
-		StateHasChanged();
 	}
 
 	public async Task HandleItemzDetailsPatchSubmission()

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -7,6 +7,7 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.Itemz.Traceability
@@ -15,10 +16,12 @@
 @using OpenRose.WebUI.Services
 @using Microsoft.AspNetCore.Components.Forms
 @inject NavigationBlockerService NavigationBlocker
+@inject NavigationManager NavManager
 @inject ViewSettingsService ViewSettings
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<Itemz> _logger
 
 <MudGrid>
     @if (initializingPage)
@@ -195,26 +198,103 @@
             initializingPage = true;
             StateHasChanged();
             await Task.Delay(300);
+        
+            bool loadingSuccessful = false;
+		    while (!loadingSuccessful)
+		    {
+			    try
+			    {
 
-            singleItemz = await ItemzService.__Single_Itemz_By_GUID_ID__Async(ItemzId);
-            if (singleItemz != null && singleItemz.Description != null)
-            {
-                await ConvertMarkdownToHtml(singleItemz.Description);
+                singleItemz = await ItemzService.__Single_Itemz_By_GUID_ID__Async(ItemzId);
+
+
+				    if (singleItemz == null)
+				    {
+					    throw new ApplicationException($"Itemz with ID {ItemzId} not found.");
+				    }
+
+			    }
+			    catch (ApplicationException ex)
+			    {
+				    // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				    _logger.LogWarning(
+					    ex,
+					    "Either API Server is unavailable OR requested itemz has been deleted.",
+					    ItemzId);
+
+				    initializingPage = true;
+				    StateHasChanged();
+
+				    var parameters = new DialogParameters
+				    {
+					    ["Title"] = "Connection Error",
+					    ["MessageHtml"] =
+								    "<p style='color:red;'><strong>Unable to obtain Itemz Data</strong></p>" +
+								    "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+								    "<p>The requested itemz has been deleted.</p>" +
+								    "<p><strong>Would you like to retry?</strong></p>",
+					    ["YesText"] = "Retry",
+					    ["NoText"] = "Go to Home"
+				    };
+
+				    // Show error dialog with retry option
+				    var options = new DialogOptions
+				    {
+					    CloseButton = false,
+					    BackdropClick = false,
+					    CloseOnEscapeKey = false
+				    };
+
+				    var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					    "Connection Error",
+					    parameters,
+					    options);
+
+				    var dialogResult = await dialog.Result;
+
+				    // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				    if (dialogResult != null && dialogResult.Data is bool retry && retry)
+				    {
+					    _logger.LogInformation("User chose to retry loading itemz {ItemzId}. Waiting 1 seconds before retry.", ItemzId);
+					    // Wait 1 second before retrying to give server time to recover
+					    await Task.Delay(1000);
+					    // Continue the loop to retry
+					    continue;
+				    }
+				    else
+				    {
+					    // 🔑 USER CLICKED "GO TO Home Screen"
+					    _logger.LogInformation("User chose to go to home screen");
+					    loadingSuccessful = true;
+					    NavManager.NavigateTo("/");
+				    }
+			    }
+
+                if (singleItemz != null && singleItemz.Description != null)
+                {
+                    await ConvertMarkdownToHtml(singleItemz.Description);
+                }
+
+                if (singleItemz != null && singleItemz?.Tags != null)
+                {
+                    tagsList = TagParsingUtility.ParseTags(singleItemz.Tags);
+                }
+
+                if (singleItemz != null)
+                {
+                    initializingPage = false;
+                    await InvokeAsync(StateHasChanged);
+                }
+
+                // ALWAYS run navigation blocker after render if kiosk mode is active
+                if (ViewSettings.IsKioskMode)
+                {
+                    await NavigationBlocker.Enable();
+                }
+
+                // 🔑 MARK LOADING AS SUCCESSFUL
+                loadingSuccessful = true;
             }
-
-            if (singleItemz?.Tags != null)
-            {
-                tagsList = TagParsingUtility.ParseTags(singleItemz.Tags);
-            }
-
-            initializingPage = false;
-            StateHasChanged();
-        }
-
-        // ALWAYS run navigation blocker after render if kiosk mode is active
-        if (ViewSettings.IsKioskMode)
-        {
-            await NavigationBlocker.Enable();
         }
     }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -21,7 +21,7 @@
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject IDialogService DialogService
 @inject IJSRuntime JS
-@inject ILogger<Itemz> _logger
+@inject ILogger<ItemzReadOnlyComponent> _logger
 
 <MudGrid>
     @if (initializingPage)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
@@ -517,6 +517,13 @@
 			var url = $"/ProjectTreeView/{foundProjectId}?autoSelectedRecordId={ItemzTypeId}";
 			await JS.InvokeVoidAsync("openInNewTab", url);
 		}
+		else
+		{
+			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining related data from server" };
+			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
+			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
+			await dialogRef.Result;
+		}
 	}
 
 	private async Task ConvertMarkdownToHtml(string markdown)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
@@ -276,8 +276,8 @@
 				{
 					// 🔑 USER CLICKED "GO TO Home Screen"
 					_logger.LogInformation("User chose to go to home screen");
-					NavManager.NavigateTo("/");
 					loadingSuccessful = true;
+					NavManager.NavigateTo("/");
 				}
 			}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
@@ -350,7 +350,6 @@
 
 		if ( singleItemzType != null )
 		{
-
 			initializingPage = false;
 			await InvokeAsync(StateHasChanged);
 
@@ -359,7 +358,6 @@
 				await ConvertMarkdownToHtml(singleItemzType.Description);
 			}
 		}
-
 	}
 
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzType.razor
@@ -11,6 +11,7 @@
 @using OpenRose.WebUI.Client.Services.ItemzTypeItemzsService
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Components.Pages.Breadcrums
@@ -22,6 +23,7 @@
 @inject IDialogService DialogService
 @inject BreadcrumsService breadcrumsService
 @inject IJSRuntime JS
+@inject ILogger<ItemzType> _logger
 @inject IServiceProvider serviceProvider
 
 
@@ -47,7 +49,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+    else if (singleItemzType != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color : #FABBBB;" >
@@ -66,15 +68,12 @@
 								Color="Color.Success">
 								@(bp >= Breakpoint.Sm ? "Edit ItemzType" : "E")
 							</MudButton>
-								@if (!(breadcrumsService.RequestIsOrphanStatus()))
-								{
 									<MudButton Variant="Variant.Filled"
 										Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
 										Color="Color.Success"
 										OnClick="(() => HandleGoToTreeView())">
 										@(bp >= Breakpoint.Sm ? "Tree View" : "T")
 									</MudButton>
-								}
 								<MudButton OnClick="goBackToProject" Variant="Variant.Filled"
 									Size="@(bp >= Breakpoint.Sm ? Size.Medium : Size.Small)"
 									Color="Color.Warning">
@@ -108,7 +107,7 @@
 					<br />
 					<div class="custom-markdown-editor">
 						<MudPaper Class="pa-2" Elevation="0" Outlined="false">
-							@if (!string.IsNullOrEmpty(singleItemzType.Description))
+							@if (singleItemzType != null && !string.IsNullOrEmpty(singleItemzType.Description))
 							{
 								<div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
 							}
@@ -211,22 +210,96 @@
 
 		initializingPage = true;
 		StateHasChanged();
-		//await Task.Delay(300);
-		singleItemzType = await itemzTypeService.__Single_ItemzType_By_GUID_ID__Async(ItemzTypeId);
-		if (singleItemzType != null)
-		{
-			BreadcrumsParameter = new ParameterForItemzBreadcrums();
-			BreadcrumsParameter.Id = singleItemzType.Id;
-			BreadcrumsParameter.Name = singleItemzType.Name;
-			BreadcrumsParameter.RecordType = "itemztype"; // TODO :: USE CONSTANT
-		}
 
-		//var returnedItemzList = await itemzTypeItemzsService.__GET_Itemzs_By_ItemzType__Async(ItemzTypeId,1,25,"Name");
-		var returnedItemzList = await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ItemzTypeId);
-
-		if (returnedItemzList != null)
+		bool loadingSuccessful = false;
+		while (!loadingSuccessful)
 		{
-			AllItemzForItemzType = returnedItemzList.ToList();
+			try
+			{
+				//await Task.Delay(300);
+				singleItemzType = await itemzTypeService.__Single_ItemzType_By_GUID_ID__Async(ItemzTypeId);
+
+				if (singleItemzType == null)
+				{
+					throw new ApplicationException($"ItemzType with ID {ItemzTypeId} not found.");
+				}
+
+			}
+			catch (ApplicationException ex)
+			{
+				// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				_logger.LogWarning(
+					ex,
+					"Either API Server is unavailable OR requested itemz type has been deleted.",
+					ItemzTypeId);
+
+				initializingPage = true;
+				StateHasChanged();
+
+				var parameters = new DialogParameters
+				{
+					["Title"] = "Connection Error",
+					["MessageHtml"] =
+								"<p style='color:red;'><strong>Unable to obtain Itemz Type Data</strong></p>" +
+								"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+								"<p>The requested itemz type has been deleted.</p>" +
+								"<p><strong>Would you like to retry?</strong></p>",
+					["YesText"] = "Retry",
+					["NoText"] = "Go to Home"
+				};
+
+				// Show error dialog with retry option
+				var options = new DialogOptions
+				{
+					CloseButton = false,
+					BackdropClick = false,
+					CloseOnEscapeKey = false
+				};
+
+				var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					"Connection Error",
+					parameters,
+					options);
+
+				var dialogResult = await dialog.Result;
+
+				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				if (dialogResult != null && dialogResult.Data is bool retry && retry)
+				{
+					_logger.LogInformation("User chose to retry loading itemz type {ItemzTypeId}. Waiting 2 seconds before retry.", ItemzTypeId);
+					// Wait 1 seconds before retrying to give server time to recover
+					await Task.Delay(1000);
+					// Continue the loop to retry
+					continue;
+				}
+				else
+				{
+					// 🔑 USER CLICKED "GO TO Home Screen"
+					_logger.LogInformation("User chose to go to home screen");
+					NavManager.NavigateTo("/");
+					loadingSuccessful = true;
+				}
+			}
+
+				if (singleItemzType != null)
+				{
+					BreadcrumsParameter = new ParameterForItemzBreadcrums();
+					BreadcrumsParameter.Id = singleItemzType.Id;
+					BreadcrumsParameter.Name = singleItemzType.Name;
+					BreadcrumsParameter.RecordType = "itemztype"; // TODO :: USE CONSTANT
+				}
+
+				//var returnedItemzList = await itemzTypeItemzsService.__GET_Itemzs_By_ItemzType__Async(ItemzTypeId,1,25,"Name");
+				var returnedItemzList = await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ItemzTypeId);
+
+				if (returnedItemzList != null)
+				{
+					AllItemzForItemzType = returnedItemzList.ToList();
+				}
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
+			
 		}
 	}
 
@@ -238,10 +311,26 @@
 			// Now even if user decides to Delete this Itemz Record then also we can go back to it's
 			// Parent ItemzType post completing deletion operation.
 
-			var httpResponse = await HierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzTypeId);
-			ParentId = httpResponse.ParentRecordId;
+			try
+			{
+				var httpResponse = await HierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzTypeId);
 
-			await Task.Delay(200); // Wanted Breadcrums to load so that decision about displaying Child Itemz can be taken properly.
+				if(httpResponse == null)
+				{
+					throw new ApplicationException($"ONAFTERRENDERASYNC - Unable to obtain hierarchy record details for ItemzTypeId: {ItemzTypeId}");
+				}
+
+				ParentId = httpResponse.ParentRecordId;
+
+				await Task.Delay(200); // Wanted Breadcrums to load so that decision about displaying Child Itemz can be taken properly.
+			}
+			catch (ApplicationException ex)
+			{
+                // EXPLANATION :: We are handling exception in the OnInitializedAsync method 
+				// and so we can just dont perform any logical action in this catch block.
+
+				await InvokeAsync(StateHasChanged);
+			}
 
 			// var returnedParentHierarchyList = await HierarchyService.__Get_All_Parents_Hierarchy_By_GUID__Async(ItemzTypeId);
 
@@ -259,9 +348,18 @@
 			//StateHasChanged();
 		}
 
-		await ConvertMarkdownToHtml(singleItemzType.Description);
-		await InvokeAsync(StateHasChanged);
-		initializingPage = false;
+		if ( singleItemzType != null )
+		{
+
+			initializingPage = false;
+			await InvokeAsync(StateHasChanged);
+
+			if (!string.IsNullOrEmpty(singleItemzType.Description))
+			{
+				await ConvertMarkdownToHtml(singleItemzType.Description);
+			}
+		}
+
 	}
 
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -59,7 +59,7 @@
 <MudGrid>
 	@if (initializingPage)
 	{
-		<MudPaper Style = "margin-top : 20px" Height="calc(100vh - 100px);" Width="100%">
+		<MudPaper Style="margin-top : 20px" Height="calc(100vh - 100px);" Width="100%">
 			<MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
 				<MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
 				<br />

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -10,6 +10,7 @@
 @using OpenRose.WebUI.Client.Services.ItemzTypeItemzsService
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.SharedModels.BetweenPagesAndComponent
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Components.Pages.Breadcrums
@@ -23,6 +24,7 @@
 @inject IDialogService DialogService
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject IJSRuntime JS
+@inject ILogger<ItemzTypeDetails> _logger
 @inject IServiceProvider serviceProvider
 
 @if (CalledFrom == nameof(ItemzTypeDetails))
@@ -42,7 +44,7 @@
 	<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="w-100">
 	<MudText Typo="Typo.h6" Align="Align.Left">ItemzType Details</MudText>
 		<MudSpacer />
-		@if (CalledFrom == nameof(ProjectTreeView))
+		@if (CalledFrom == nameof(ProjectTreeView) && singleItemzType != null)
 		{
 			<MudButton Variant="Variant.Filled" Color="Color.Success"
 					   Disabled="FormStateService.IsDirty(ItemzTypeId)"
@@ -57,7 +59,7 @@
 <MudGrid>
 	@if (initializingPage)
 	{
-		<MudPaper Height="calc(100vh - 100px);" Width="100%">
+		<MudPaper Style = "margin-top : 20px" Height="calc(100vh - 100px);" Width="100%">
 			<MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
 				<MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
 				<br />
@@ -65,7 +67,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleItemzType != null)
 	{
 		<MudItem hidden="@hideValidationError" xs="12" sm="12">
 			<MudPaper Class="mb-5 mud-height-full">
@@ -365,67 +367,155 @@
 		initializingPage = true;
 		StateHasChanged();
 		//await Task.Delay(300);
-		singleItemzType = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(ItemzTypeId);
-		if (singleItemzType != null)
+
+		bool loadingSuccessful = false;
+		while (!loadingSuccessful)
 		{
-			BreadcrumsParameter = new ParameterForItemzBreadcrums();
-			BreadcrumsParameter.Id = singleItemzType.Id;
-			BreadcrumsParameter.Name = singleItemzType.Name;
-			BreadcrumsParameter.RecordType = "itemztype"; // TODO :: USE CONSTANT
-
-			TreeNodeItemzSelectionService.UpdateTreeNodeItemzName(ItemzTypeId, singleItemzType.Name!);
-			_originalDescription = singleItemzType.Description ?? string.Empty;
-			MyContent = _originalDescription;
-		}
-
-		if (form != null)
-		{
-			await form.Validate();
-			if (form.IsValid)
+			try
 			{
-				disableUpdateItemzTypeDetailsButton = false;
+
+				singleItemzType = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(ItemzTypeId);
+
+				if (singleItemzType == null)
+				{
+					throw new ApplicationException($"ItemzType with ID {ItemzTypeId} not found.");
+				}
+
+				// EXPLANATION : At the start of initialization process we capture parent record ID.
+				// Now even if user decides to Delete this Itemz Record then also we can go back to it's
+				// Parent ItemzType post completing deletion operation.
+				var httpResponse = await hierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzTypeId);
+				if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check.
+				{
+					ParentId = httpResponse.ParentRecordId;
+				}
+				else
+				{
+					throw new ApplicationException($"Parent record for ItemzType with ID {ItemzTypeId} not found.");
+				}
+
 			}
-			else
+			catch (ApplicationException ex)
 			{
-				disableUpdateItemzTypeDetailsButton = true;
+				// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				_logger.LogWarning(
+					ex,
+					"Either API Server is unavailable OR requested itemz type has been deleted.",
+					ItemzTypeId);
+
+				initializingPage = true;
+				await InvokeAsync(StateHasChanged);
+
+				var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Itemz Type Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested itemz type has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+				// Show error dialog with retry option
+				var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+				var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					"Connection Error",
+					parameters,
+					options);
+
+				var dialogResult = await dialog.Result;
+
+				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				if (dialogResult != null && dialogResult.Data is bool retry && retry)
+				{
+					_logger.LogInformation("User chose to retry loading itemz type {ItemzTypeId}. Waiting 2 seconds before retry.", ItemzTypeId);
+					// Wait 1 seconds before retrying to give server time to recover
+					await Task.Delay(1000);
+					// Continue the loop to retry
+					continue;
+				}
+				else
+				{
+					// 🔑 USER CLICKED "GO TO Home Screen"
+					_logger.LogInformation("User chose to go to home screen");
+					NavManager.NavigateTo("/");
+					loadingSuccessful = true;
+				}
 			}
 
-			// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
-			List<string> tempList = new List<string>();
-			foreach (var _itemzTypeStatusValue in Enum.GetValues<ItemzTypeStatus>())
-			{
-				tempList.Add(_itemzTypeStatusValue.ToString().Trim());
-			}
-			_stringItemzTypeStatusValues = tempList.ToArray();
+
+
 
 			if (singleItemzType != null)
 			{
-				if (singleItemzType.IsSystem)
+				BreadcrumsParameter = new ParameterForItemzBreadcrums();
+				BreadcrumsParameter.Id = singleItemzType.Id;
+				BreadcrumsParameter.Name = singleItemzType.Name;
+				BreadcrumsParameter.RecordType = "itemztype"; // TODO :: USE CONSTANT
+
+				TreeNodeItemzSelectionService.UpdateTreeNodeItemzName(ItemzTypeId, singleItemzType.Name!);
+				_originalDescription = singleItemzType.Description ?? string.Empty;
+				MyContent = _originalDescription;
+			}
+
+			if (form != null)
+			{
+				await form.Validate();
+				if (form.IsValid)
 				{
-					if (CalledFrom == nameof(ItemzTypeDetails))
-					{
-						await OpenExceptionDialogAsync("System ItemzType can not be edited!");
-					}
+					disableUpdateItemzTypeDetailsButton = false;
+				}
+				else
+				{
 					disableUpdateItemzTypeDetailsButton = true;
-					form.Disabled = true;
+				}
+
+				// EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
+				List<string> tempList = new List<string>();
+				foreach (var _itemzTypeStatusValue in Enum.GetValues<ItemzTypeStatus>())
+				{
+					tempList.Add(_itemzTypeStatusValue.ToString().Trim());
+				}
+				_stringItemzTypeStatusValues = tempList.ToArray();
+
+				if (singleItemzType != null)
+				{
+					if (singleItemzType.IsSystem)
+					{
+						if (CalledFrom == nameof(ItemzTypeDetails))
+						{
+							await OpenExceptionDialogAsync("System ItemzType can not be edited!");
+						}
+						disableUpdateItemzTypeDetailsButton = true;
+						form.Disabled = true;
+					}
 				}
 			}
+
+			if (singleItemzType != null)
+			{
+				initializingPage = false;
+				StateHasChanged();
+
+				if (!string.IsNullOrEmpty(singleItemzType.Description))
+				{
+					await ConvertMarkdownToHtml(singleItemzType.Description);
+				}
+			}
+
+			FormStateService.SetDirty(ItemzTypeId, false);
+
+			// 🔑 MARK LOADING AS SUCCESSFUL
+			loadingSuccessful = true;
 		}
-
-		// EXPLANATION : At the start of initialization process we capture parent record ID.
-		// Now even if user decides to Delete this Itemz Record then also we can go back to it's
-		// Parent ItemzType post completing deletion operation.
-		var httpResponse = await hierarchyService.__Get_Hierarchy_Record_Details_By_GUID__Async(ItemzTypeId);
-		if (httpResponse != null) // If for some reason API call fails then also we can avoid exception by this null check. 
-		{
-			ParentId = httpResponse.ParentRecordId;
-		}
-
-		await ConvertMarkdownToHtml(singleItemzType.Description);
-
-		FormStateService.SetDirty(ItemzTypeId, false);
-		initializingPage = false;
-		StateHasChanged();
 	}
 
 	public async Task HandleItemzTypeDetailsPatchSubmission()

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -716,6 +716,13 @@
 			var url = $"/ProjectTreeView/{foundProjectId}?autoSelectedRecordId={ItemzTypeId}";
 			await JS.InvokeVoidAsync("openInNewTab", url);
 		}
+		else
+		{
+			var parameters = new DialogParameters { ["Message"] = "Issue encountered while obtaining related data from server" };
+			var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small, FullWidth = true };
+			var dialogRef = await DialogService.ShowAsync<ErrorDialog>("Error", parameters, options);
+			await dialogRef.Result;
+		}
 	}
 
 	private async Task ConfirmNavigation(LocationChangingContext context)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -7,16 +7,19 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.ItemzType
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.SharedComponents
 @using OpenRose.WebUI.Services
 @using Microsoft.AspNetCore.Components.Forms
 @inject NavigationBlockerService NavigationBlocker
+@inject NavigationManager NavManager
 @inject ViewSettingsService ViewSettings
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<ItemzType> _logger
 
 <MudGrid>
 	@if (initializingPage)
@@ -29,7 +32,7 @@
 			</MudOverlay>
 		</MudPaper>
 	}
-	else
+	else if (singleItemzType != null)
 	{
  		<MudItem xs="12" sm="12">
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
@@ -143,14 +146,89 @@
 			StateHasChanged();
 			await Task.Delay(300);
 
-			singleItemzType = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(ItemzTypeId);
-			if (singleItemzType != null && singleItemzType.Description != null)
+			bool loadingSuccessful = false;
+			while (!loadingSuccessful)
 			{
-				await ConvertMarkdownToHtml(singleItemzType.Description);
+				try
+				{
+					singleItemzType = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(ItemzTypeId);
+
+					if (singleItemzType == null)
+					{
+						throw new ApplicationException($"ItemzType with ID {ItemzTypeId} not found.");
+					}
+
+				}
+				catch (ApplicationException ex)
+				{
+					// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+					_logger.LogWarning(
+						ex,
+						"Either API Server is unavailable OR requested itemz type has been deleted.",
+						ItemzTypeId);
+
+					initializingPage = true;
+					StateHasChanged();
+
+					var parameters = new DialogParameters
+					{
+						["Title"] = "Connection Error",
+						["MessageHtml"] =
+									"<p style='color:red;'><strong>Unable to obtain Itemz Type Data</strong></p>" +
+									"<p>Either API server is currently unreachable</p> <p> OR</p>" +
+									"<p>The requested itemz type has been deleted.</p>" +
+									"<p><strong>Would you like to retry?</strong></p>",
+						["YesText"] = "Retry",
+						["NoText"] = "Go to Home"
+					};
+
+					// Show error dialog with retry option
+					var options = new DialogOptions
+					{
+						CloseButton = false,
+						BackdropClick = false,
+						CloseOnEscapeKey = false
+					};
+
+					var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+						"Connection Error",
+						parameters,
+						options);
+
+					var dialogResult = await dialog.Result;
+
+					// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+					if (dialogResult != null && dialogResult.Data is bool retry && retry)
+					{
+						_logger.LogInformation("User chose to retry loading itemz type {ItemzTypeId}. Waiting 2 seconds before retry.", ItemzTypeId);
+						// Wait 1 seconds before retrying to give server time to recover
+						await Task.Delay(1000);
+						// Continue the loop to retry
+						continue;
+					}
+					else
+					{
+						// 🔑 USER CLICKED "GO TO Home Screen"
+						_logger.LogInformation("User chose to go to home screen");
+						NavManager.NavigateTo("/");
+						loadingSuccessful = true;
+					}
+				}
+
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
+
 			}
 
-			initializingPage = false;
-			StateHasChanged();
+			if (singleItemzType != null)
+			{
+				initializingPage = false;
+				StateHasChanged();
+				if (!string.IsNullOrEmpty(singleItemzType.Description))
+				{
+					await ConvertMarkdownToHtml(singleItemzType.Description);
+				}
+			}
 
 			// ALWAYS run navigation blocker after render if kiosk mode is active
 			if (ViewSettings.IsKioskMode)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -9,13 +9,19 @@
 @using OpenRose.WebUI.Client.Services.Project
 @using OpenRose.WebUI.Client.Services.ItemzType
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.SharedComponents
+@using OpenRose.WebUI.Constants
 @using OpenRose.WebUI.Services
+@using OpenRose.WebUI.Services.NotificationHub
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.SignalR.Client
 @inject NavigationManager NavManager
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<Project> _logger
+@inject ProjectDeletionService DeletionService
 
 <MudPaper Class="pa-3 mb-3 align-start d-flex" Style="width: auto " Outlined="false">
     <MudStack Row="true" Spacing="3">
@@ -182,6 +188,11 @@
 
 	private Breakpoint bp;
 
+	//SignalR Hub Connection
+	private HubConnection? hubConnection;
+
+
+
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		if (firstRender)
@@ -206,6 +217,46 @@
 
 			initializingPage = false;
 			StateHasChanged();
+
+		// EXPLANATION :: INITIALIZE SIGNALR CONNECTION TO THE HUB (Only if project loaded successfully)
+			try
+			{
+				hubConnection = new HubConnectionBuilder()
+					.WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
+					.WithAutomaticReconnect()
+					.Build();
+
+				// Listen for project deleted notifications
+				hubConnection.On<Guid>(
+					SignalRConstants.ProjectEvents.ProjectDeleted,
+					OnProjectDeletedAsync);
+
+				// Listen for project updated notifications
+				hubConnection.On<Guid>(
+					SignalRConstants.ProjectEvents.ProjectModified,
+					OnProjectUpdatedAsync);
+
+				// Listen for project created notifications
+				hubConnection.On<Guid>(
+					SignalRConstants.ProjectEvents.ProjectCreated,
+					OnProjectCreatedAsync);
+
+				await hubConnection.StartAsync();
+
+				// Subscribe to notifications for the current project
+				if (hubConnection.State == HubConnectionState.Connected)
+				{
+					await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+					_logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
+			}
+
+			StateHasChanged();
+
 		}
 	}
 
@@ -367,5 +418,94 @@
 			// await JS.InvokeVoidAsync("applyMarkdownEditorFullscreenStyles");
 		}
 	}
+
+    #region SignalR Event Handlers including overall Dispose method
+	/// <summary>
+	/// Called when server broadcasts that this project was deleted.
+	/// Receives only the ProjectId - we already have the project details.
+	/// </summary>
+	private async Task OnProjectDeletedAsync(Guid projectIdDeleted)
+	{
+		// Only process if this is for the current project
+		if (projectIdDeleted != ProjectId)
+			return;
+
+		_logger.LogInformation(
+			$"Received notification: Project {projectIdDeleted} was deleted");
+
+		// Use the already-loaded project details from singleProject
+		var parameters = new DialogParameters<DeletedProjectDialog>
+		{
+			{ x => x.ProjectId, projectIdDeleted },
+			{ x => x.ProjectName, singleProject?.Name ?? "Unknown Project" }
+		};
+
+		var dialog = await DialogService.ShowAsync<DeletedProjectDialog>(
+			"Project Deleted",
+			parameters);
+
+		var result = await dialog.Result;
+
+		// Navigate away if user confirmed
+		if (!result.Canceled)
+		{
+			NavManager.NavigateTo("/Projects", forceLoad: true);
+		}
+	}
+
+	/// <summary>
+	/// Called when server broadcasts that this project was updated.
+	/// Receives only the ProjectId.
+	/// </summary>
+	private async Task OnProjectUpdatedAsync(Guid projectIdUpdated)
+	{
+		if (projectIdUpdated != ProjectId)
+			return;
+
+		_logger.LogInformation(
+			$"Project {projectIdUpdated} was updated");
+
+		// Optionally refresh the project data if needed
+		// await LoadProjectDataAsync();
+		// StateHasChanged();
+	}
+
+	/// <summary>
+	/// Called when server broadcasts that this project was created.
+	/// Receives only the ProjectId.
+	/// </summary>
+	private async Task OnProjectCreatedAsync(Guid projectIdCreated)
+	{
+		if (projectIdCreated != ProjectId)
+			return;
+
+		_logger.LogInformation(
+			$"Project {projectIdCreated} was created");
+		// Optionally refresh the project data if needed
+		// await LoadProjectDataAsync();
+		// StateHasChanged();
+	}
+
+	
+
+	public async ValueTask DisposeAsync()
+	{
+
+		// Cleanup SignalR connection
+		if (hubConnection is not null)
+		{
+			try
+			{
+				await hubConnection.InvokeAsync("UnsubscribeFromProjectAsync", ProjectId);
+				await hubConnection.DisposeAsync();
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError($"Error disposing hub connection: {ex.Message}");
+			}
+		}
+	}
+
+	#endregion
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -243,9 +243,11 @@
 
 				// Show error dialog with retry option
 				var retryOptions = new DialogOptions
-					{
-						CloseButton = false
-					};
+				{
+					CloseButton = false,
+					BackdropClick = false,
+					CloseOnEscapeKey = false
+				};
 
 				var dialogResult = await DialogService.ShowMessageBox(
 					title: "Connection Error",
@@ -319,9 +321,11 @@
 				// StateHasChanged();
 
 				var retryOptions = new DialogOptions
-					{
-						CloseButton = false
-					};
+				{
+					CloseButton = false,
+					BackdropClick = false,
+					CloseOnEscapeKey = false
+				};
 
 				// If it's a connection error, treat it as such
 				if (isConnectionError)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -197,22 +197,192 @@
 	{
 		initializingPage = true;
 
-		// Load project
-		singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
-
-		// If markdown exists, defer JS conversion until first render
-		if (!string.IsNullOrEmpty(singleProject?.Description))
+		bool loadingSuccessful = false;
+		while (!loadingSuccessful)
 		{
-			_pendingMarkdown = singleProject.Description;
+			try
+			{
+
+				// Load project
+				singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
+
+				// If markdown exists, defer JS conversion until first render
+
+				if (singleProject == null)
+				{
+					throw new ApplicationException($"Either API Server is unavailable OR Project with ID {ProjectId} has been deleted.");
+                }
+
+				if (!string.IsNullOrEmpty(singleProject?.Description))
+				{
+					_pendingMarkdown = singleProject.Description;
+				}
+
+				// Load Itemz Types
+				var returnedItemzTypeList =
+					await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ProjectId);
+
+				AllItemzTypesForProject = returnedItemzTypeList?.ToList() ?? new();
+
+				initializingPage = false;
+				
+				// 🔑 MARK LOADING AS SUCCESSFUL
+				loadingSuccessful = true;
+			}
+			catch (ApplicationException ex)
+			{
+				// 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				_logger.LogWarning(
+					ex,
+					"Either API Server is unavailable OR requested project has been deleted.",
+					ProjectId);
+
+				initializingPage = true;
+				// showLoadingMessage = false;
+				// StateHasChanged();
+
+				// Show error dialog with retry option
+				var retryOptions = new DialogOptions
+					{
+						CloseButton = false
+					};
+
+				var dialogResult = await DialogService.ShowMessageBox(
+					title: "Connection Error",
+					markupMessage: new MarkupString(
+						$"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+						$"<p>Either API server is currently unreachable OR</p>" +
+						$"<p>The requested project has been deleted.</p>" +
+						$"<p><strong>Would you like to retry?</strong></p>"
+					),
+					yesText: "Retry",
+					noText: "Go to Home",
+					options: retryOptions
+				);
+
+				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				if (dialogResult == true)
+				{
+					_logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+					// Wait 1 seconds before retrying to give server time to recover
+					await Task.Delay(1000);
+					// showLoadingMessage = true;
+					// StateHasChanged();
+					// Continue the loop to retry
+					continue;
+				}
+				else
+				{
+					// 🔑 USER CLICKED "GO TO Home Screen"
+					_logger.LogInformation("User chose to go to home screen");
+					NavManager.NavigateTo("/");
+					loadingSuccessful = true;
+				}
+			}
+			catch (Exception ex)
+			{
+				// 🔑 HANDLE ANY OTHER UNEXPECTED ERRORS
+				// Check if this is a connection error wrapped in AggregateException or OperationCanceledException
+				bool isConnectionError = false;
+				string errorType = "Unknown Error";
+
+				if (ex is OperationCanceledException)
+				{
+					isConnectionError = true;
+					errorType = "Connection Timeout";
+				}
+				else if (ex.InnerException is HttpRequestException)
+				{
+					isConnectionError = true;
+					errorType = "Connection Error";
+				}
+				else if (ex.InnerException is OperationCanceledException)
+				{
+					isConnectionError = true;
+					errorType = "Connection Timeout";
+				}
+				else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+				{
+					isConnectionError = true;
+					errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
+				}
+
+				_logger.LogError(
+					ex,
+					"Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+					ProjectId,
+					errorType,
+					isConnectionError,
+					ex.Message);
+
+				// showLoadingMessage = false;
+				// StateHasChanged();
+
+				var retryOptions = new DialogOptions
+					{
+						CloseButton = false
+					};
+
+				// If it's a connection error, treat it as such
+				if (isConnectionError)
+				{
+					var dialogResult = await DialogService.ShowMessageBox(
+						"Connection Error",
+						markupMessage: new MarkupString(
+							$"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+							$"<p>The API server is currently unreachable or not responding.</p>" +
+							$"<p>The project data cannot be loaded at this moment.</p>" +
+							$"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
+							$"<p><strong>Would you like to retry?</strong></p>"
+						),
+						yesText: "Retry",
+						noText: "Go to Projects List",
+						options: retryOptions
+					);
+
+					if (dialogResult == true)
+					{
+						_logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
+						await Task.Delay(2000);
+						continue;
+					}
+					else
+					{
+						_logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+						NavManager.NavigateTo("/projects", forceLoad: true);
+						loadingSuccessful = true;
+					}
+				}
+				else
+				{
+					// Show generic error message with retry for other unexpected errors
+					var dialogResult = await DialogService.ShowMessageBox(
+						"Error Loading Project",
+						markupMessage: new MarkupString(
+							$"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
+							$"<p>Error: {ex.Message}</p>" +
+							$"<p><strong>Would you like to retry?</strong></p>"
+						),
+						yesText: "Retry",
+						noText: "Go to Projects List",
+						options: retryOptions
+					);
+
+					if (dialogResult == true)
+					{
+						_logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
+						await Task.Delay(2000);
+						continue;
+					}
+					else
+					{
+						_logger.LogInformation("User chose to go to projects list after error");
+						NavManager.NavigateTo("/projects", forceLoad: true);
+						loadingSuccessful = true;
+					}
+				}
+			}
 		}
-
-		// Load Itemz Types
-		var returnedItemzTypeList =
-			await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ProjectId);
-
-		AllItemzTypesForProject = returnedItemzTypeList?.ToList() ?? new();
-
-		initializingPage = false;
 
 		// -------------------------------
 		// Initialize SignalR connection

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -238,38 +238,40 @@
 					ProjectId);
 
 				initializingPage = true;
-				// showLoadingMessage = false;
-				// StateHasChanged();
+
+                var parameters = new DialogParameters
+                {
+                    ["Title"] = "Connection Error",
+                    ["MessageHtml"] =
+                        "<p style='color:red;'><strong>Unable to obtain Project Data</strong></p>" +
+                        "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+                        "<p>The requested project has been deleted.</p>" +
+                        "<p><strong>Would you like to retry?</strong></p>",
+                    ["YesText"] = "Retry",
+                    ["NoText"] = "Go to Home"
+                };
 
 				// Show error dialog with retry option
-				var retryOptions = new DialogOptions
+				var options = new DialogOptions
 				{
 					CloseButton = false,
 					BackdropClick = false,
 					CloseOnEscapeKey = false
 				};
 
-				var dialogResult = await DialogService.ShowMessageBox(
-					title: "Connection Error",
-					markupMessage: new MarkupString(
-						$"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
-						$"<p>Either API server is currently unreachable OR</p>" +
-						$"<p>The requested project has been deleted.</p>" +
-						$"<p><strong>Would you like to retry?</strong></p>"
-					),
-					yesText: "Retry",
-					noText: "Go to Home",
-					options: retryOptions
-				);
+				var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+					"Connection Error",
+					parameters,
+					options);
+
+				var dialogResult = await dialog.Result;
 
 				// 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
-				if (dialogResult == true)
+				if (dialogResult != null && dialogResult.Data is bool retry && retry)
 				{
 					_logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
 					// Wait 1 seconds before retrying to give server time to recover
 					await Task.Delay(1000);
-					// showLoadingMessage = true;
-					// StateHasChanged();
 					// Continue the loop to retry
 					continue;
 				}
@@ -280,112 +282,163 @@
 					NavManager.NavigateTo("/");
 					loadingSuccessful = true;
 				}
+
+				// // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+				// _logger.LogWarning(
+				// 	ex,
+				// 	"Either API Server is unavailable OR requested project has been deleted.",
+				// 	ProjectId);
+
+				// initializingPage = true;
+				// // showLoadingMessage = false;
+				// // StateHasChanged();
+
+				// // Show error dialog with retry option
+				// var retryOptions = new DialogOptions
+				// {
+				// 	CloseButton = false,
+				// 	BackdropClick = false,
+				// 	CloseOnEscapeKey = false
+				// };
+
+				// var dialogResult = await DialogService.ShowMessageBox(
+				// 	title: "Connection Error",
+				// 	markupMessage: new MarkupString(
+				// 		$"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+				// 		$"<p>Either API server is currently unreachable OR</p>" +
+				// 		$"<p>The requested project has been deleted.</p>" +
+				// 		$"<p><strong>Would you like to retry?</strong></p>"
+				// 	),
+				// 	yesText: "Retry",
+				// 	noText: "Go to Home",
+				// 	options: retryOptions
+				// );
+
+				// // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+				// if (dialogResult == true)
+				// {
+				// 	_logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+				// 	// Wait 1 seconds before retrying to give server time to recover
+				// 	await Task.Delay(1000);
+				// 	// showLoadingMessage = true;
+				// 	// StateHasChanged();
+				// 	// Continue the loop to retry
+				// 	continue;
+				// }
+				// else
+				// {
+				// 	// 🔑 USER CLICKED "GO TO Home Screen"
+				// 	_logger.LogInformation("User chose to go to home screen");
+				// 	NavManager.NavigateTo("/");
+				// 	loadingSuccessful = true;
+				// }
+
 			}
-			catch (Exception ex)
-			{
-				// 🔑 HANDLE ANY OTHER UNEXPECTED ERRORS
-				// Check if this is a connection error wrapped in AggregateException or OperationCanceledException
-				bool isConnectionError = false;
-				string errorType = "Unknown Error";
+			// catch (Exception ex)
+			// {
+			// 	// 🔑 HANDLE ANY OTHER UNEXPECTED ERRORS
+			// 	// Check if this is a connection error wrapped in AggregateException or OperationCanceledException
+			// 	bool isConnectionError = false;
+			// 	string errorType = "Unknown Error";
 
-				if (ex is OperationCanceledException)
-				{
-					isConnectionError = true;
-					errorType = "Connection Timeout";
-				}
-				else if (ex.InnerException is HttpRequestException)
-				{
-					isConnectionError = true;
-					errorType = "Connection Error";
-				}
-				else if (ex.InnerException is OperationCanceledException)
-				{
-					isConnectionError = true;
-					errorType = "Connection Timeout";
-				}
-				else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
-				{
-					isConnectionError = true;
-					errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
-				}
+			// 	if (ex is OperationCanceledException)
+			// 	{
+			// 		isConnectionError = true;
+			// 		errorType = "Connection Timeout";
+			// 	}
+			// 	else if (ex.InnerException is HttpRequestException)
+			// 	{
+			// 		isConnectionError = true;
+			// 		errorType = "Connection Error";
+			// 	}
+			// 	else if (ex.InnerException is OperationCanceledException)
+			// 	{
+			// 		isConnectionError = true;
+			// 		errorType = "Connection Timeout";
+			// 	}
+			// 	else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+			// 	{
+			// 		isConnectionError = true;
+			// 		errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
+			// 	}
 
-				_logger.LogError(
-					ex,
-					"Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
-					ProjectId,
-					errorType,
-					isConnectionError,
-					ex.Message);
+			// 	_logger.LogError(
+			// 		ex,
+			// 		"Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+			// 		ProjectId,
+			// 		errorType,
+			// 		isConnectionError,
+			// 		ex.Message);
 
-				// showLoadingMessage = false;
-				// StateHasChanged();
+			// 	// showLoadingMessage = false;
+			// 	// StateHasChanged();
 
-				var retryOptions = new DialogOptions
-				{
-					CloseButton = false,
-					BackdropClick = false,
-					CloseOnEscapeKey = false
-				};
+			// 	var retryOptions = new DialogOptions
+			// 	{
+			// 		CloseButton = false,
+			// 		BackdropClick = false,
+			// 		CloseOnEscapeKey = false
+			// 	};
 
-				// If it's a connection error, treat it as such
-				if (isConnectionError)
-				{
-					var dialogResult = await DialogService.ShowMessageBox(
-						"Connection Error",
-						markupMessage: new MarkupString(
-							$"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
-							$"<p>The API server is currently unreachable or not responding.</p>" +
-							$"<p>The project data cannot be loaded at this moment.</p>" +
-							$"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
-							$"<p><strong>Would you like to retry?</strong></p>"
-						),
-						yesText: "Retry",
-						noText: "Go to Projects List",
-						options: retryOptions
-					);
+			// 	// If it's a connection error, treat it as such
+			// 	if (isConnectionError)
+			// 	{
+			// 		var dialogResult = await DialogService.ShowMessageBox(
+			// 			"Connection Error",
+			// 			markupMessage: new MarkupString(
+			// 				$"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+			// 				$"<p>The API server is currently unreachable or not responding.</p>" +
+			// 				$"<p>The project data cannot be loaded at this moment.</p>" +
+			// 				$"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
+			// 				$"<p><strong>Would you like to retry?</strong></p>"
+			// 			),
+			// 			yesText: "Retry",
+			// 			noText: "Go to Projects List",
+			// 			options: retryOptions
+			// 		);
 
-					if (dialogResult == true)
-					{
-						_logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
-						await Task.Delay(2000);
-						continue;
-					}
-					else
-					{
-						_logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
-						NavManager.NavigateTo("/projects", forceLoad: true);
-						loadingSuccessful = true;
-					}
-				}
-				else
-				{
-					// Show generic error message with retry for other unexpected errors
-					var dialogResult = await DialogService.ShowMessageBox(
-						"Error Loading Project",
-						markupMessage: new MarkupString(
-							$"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
-							$"<p>Error: {ex.Message}</p>" +
-							$"<p><strong>Would you like to retry?</strong></p>"
-						),
-						yesText: "Retry",
-						noText: "Go to Projects List",
-						options: retryOptions
-					);
+			// 		if (dialogResult == true)
+			// 		{
+			// 			_logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
+			// 			await Task.Delay(2000);
+			// 			continue;
+			// 		}
+			// 		else
+			// 		{
+			// 			_logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+			// 			NavManager.NavigateTo("/projects", forceLoad: true);
+			// 			loadingSuccessful = true;
+			// 		}
+			// 	}
+			// 	else
+			// 	{
+			// 		// Show generic error message with retry for other unexpected errors
+			// 		var dialogResult = await DialogService.ShowMessageBox(
+			// 			"Error Loading Project",
+			// 			markupMessage: new MarkupString(
+			// 				$"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
+			// 				$"<p>Error: {ex.Message}</p>" +
+			// 				$"<p><strong>Would you like to retry?</strong></p>"
+			// 			),
+			// 			yesText: "Retry",
+			// 			noText: "Go to Projects List",
+			// 			options: retryOptions
+			// 		);
 
-					if (dialogResult == true)
-					{
-						_logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
-						await Task.Delay(2000);
-						continue;
-					}
-					else
-					{
-						_logger.LogInformation("User chose to go to projects list after error");
-						NavManager.NavigateTo("/projects", forceLoad: true);
-						loadingSuccessful = true;
-					}
-				}
-			}
+			// 		if (dialogResult == true)
+			// 		{
+			// 			_logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
+			// 			await Task.Delay(2000);
+			// 			continue;
+			// 		}
+			// 		else
+			// 		{
+			// 			_logger.LogInformation("User chose to go to projects list after error");
+			// 			NavManager.NavigateTo("/projects", forceLoad: true);
+			// 			loadingSuccessful = true;
+			// 		}
+			// 	}
+			// }
 		}
 
 		// -------------------------------

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/Project.razor
@@ -191,74 +191,152 @@
 	//SignalR Hub Connection
 	private HubConnection? hubConnection;
 
+	private string? _pendingMarkdown;
 
+	protected override async Task OnInitializedAsync()
+	{
+		initializingPage = true;
+
+		// Load project
+		singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
+
+		// If markdown exists, defer JS conversion until first render
+		if (!string.IsNullOrEmpty(singleProject?.Description))
+		{
+			_pendingMarkdown = singleProject.Description;
+		}
+
+		// Load Itemz Types
+		var returnedItemzTypeList =
+			await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ProjectId);
+
+		AllItemzTypesForProject = returnedItemzTypeList?.ToList() ?? new();
+
+		initializingPage = false;
+
+		// -------------------------------
+		// Initialize SignalR connection
+		// -------------------------------
+		try
+		{
+			hubConnection = new HubConnectionBuilder()
+				.WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
+				.WithAutomaticReconnect()
+				.Build();
+
+				// Listen for project deleted notifications
+			hubConnection.On<Guid>(
+				SignalRConstants.ProjectEvents.ProjectDeleted,
+				OnProjectDeletedAsync);
+
+				// Listen for project updated notifications
+			hubConnection.On<Guid>(
+				SignalRConstants.ProjectEvents.ProjectModified,
+				OnProjectUpdatedAsync);
+
+				// Listen for project created notifications
+			hubConnection.On<Guid>(
+				SignalRConstants.ProjectEvents.ProjectCreated,
+				OnProjectCreatedAsync);
+
+			await hubConnection.StartAsync();
+
+				// Subscribe to notifications for the current project
+			if (hubConnection.State == HubConnectionState.Connected)
+			{
+				await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+				_logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+			}
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
+		}
+	}
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		if (firstRender)
 		{
-			initializingPage = true;
-			StateHasChanged();
-			await Task.Delay(300);
-
-			singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
-			if (singleProject != null && singleProject.Description != null)
+			// Convert markdown to HTML only after DOM is ready
+			if (!string.IsNullOrEmpty(_pendingMarkdown))
 			{
-				await ConvertMarkdownToHtml(singleProject.Description);
+				var html = await JS.InvokeAsync<string>("markdownToHtml", _pendingMarkdown);
+				convertedMarkdown = (MarkupString)html;
+				_pendingMarkdown = null;
+
+				await InvokeAsync(StateHasChanged);
 			}
-			//var returnedItemzTypeList = await ProjectService.__GET_ItemzTypes_By_Project__Async(ProjectId);
-			var returnedItemzTypeList = await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ProjectId);
-
-
-			if (returnedItemzTypeList != null)
-			{
-				AllItemzTypesForProject = returnedItemzTypeList.ToList();
-			}
-
-			initializingPage = false;
-			StateHasChanged();
-
-		// EXPLANATION :: INITIALIZE SIGNALR CONNECTION TO THE HUB (Only if project loaded successfully)
-			try
-			{
-				hubConnection = new HubConnectionBuilder()
-					.WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
-					.WithAutomaticReconnect()
-					.Build();
-
-				// Listen for project deleted notifications
-				hubConnection.On<Guid>(
-					SignalRConstants.ProjectEvents.ProjectDeleted,
-					OnProjectDeletedAsync);
-
-				// Listen for project updated notifications
-				hubConnection.On<Guid>(
-					SignalRConstants.ProjectEvents.ProjectModified,
-					OnProjectUpdatedAsync);
-
-				// Listen for project created notifications
-				hubConnection.On<Guid>(
-					SignalRConstants.ProjectEvents.ProjectCreated,
-					OnProjectCreatedAsync);
-
-				await hubConnection.StartAsync();
-
-				// Subscribe to notifications for the current project
-				if (hubConnection.State == HubConnectionState.Connected)
-				{
-					await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
-					_logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
-				}
-			}
-			catch (Exception ex)
-			{
-				_logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
-			}
-
-			StateHasChanged();
-
 		}
 	}
+
+
+	// protected override async Task OnAfterRenderAsync(bool firstRender)
+	// {
+	// 	if (firstRender)
+	// 	{
+	// 		initializingPage = true;
+	// 		StateHasChanged();
+	// 		await Task.Delay(300);
+
+	// 		singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
+	// 		if (singleProject != null && singleProject.Description != null)
+	// 		{
+	// 			await ConvertMarkdownToHtml(singleProject.Description);
+	// 		}
+	// 		//var returnedItemzTypeList = await ProjectService.__GET_ItemzTypes_By_Project__Async(ProjectId);
+	// 		var returnedItemzTypeList = await HierarchyService.__Get_Immediate_Children_Hierarchy_By_GUID__Async(ProjectId);
+
+
+	// 		if (returnedItemzTypeList != null)
+	// 		{
+	// 			AllItemzTypesForProject = returnedItemzTypeList.ToList();
+	// 		}
+
+	// 		initializingPage = false;
+	// 		StateHasChanged();
+
+	// 	// EXPLANATION :: INITIALIZE SIGNALR CONNECTION TO THE HUB (Only if project loaded successfully)
+	// 		try
+	// 		{
+	// 			hubConnection = new HubConnectionBuilder()
+	// 				.WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
+	// 				.WithAutomaticReconnect()
+	// 				.Build();
+
+	// 			// Listen for project deleted notifications
+	// 			hubConnection.On<Guid>(
+	// 				SignalRConstants.ProjectEvents.ProjectDeleted,
+	// 				OnProjectDeletedAsync);
+
+	// 			// Listen for project updated notifications
+	// 			hubConnection.On<Guid>(
+	// 				SignalRConstants.ProjectEvents.ProjectModified,
+	// 				OnProjectUpdatedAsync);
+
+	// 			// Listen for project created notifications
+	// 			hubConnection.On<Guid>(
+	// 				SignalRConstants.ProjectEvents.ProjectCreated,
+	// 				OnProjectCreatedAsync);
+
+	// 			await hubConnection.StartAsync();
+
+	// 			// Subscribe to notifications for the current project
+	// 			if (hubConnection.State == HubConnectionState.Connected)
+	// 			{
+	// 				await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+	// 				_logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+	// 			}
+	// 		}
+	// 		catch (Exception ex)
+	// 		{
+	// 			_logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
+	// 		}
+
+	// 		StateHasChanged();
+
+	// 	}
+	// }
 
 	public async Task editItemzTypeDetails(string Id)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -14,14 +14,18 @@
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Baseline
 @using OpenRose.WebUI.Components.Pages.Common
+@using OpenRose.WebUI.Services.NotificationHub
 @using Microsoft.AspNetCore.Components.Forms
 @using OpenRose.WebUI.Components.Pages.SharedComponents
 @using PSC.Blazor.Components.MarkdownEditor
 @using PSC.Blazor.Components.MarkdownEditor.EventsArgs
+@inject ProjectDeletionService DeletionService
+@inject ILogger<ProjectDetailsComponent> _logger
 @inject NavigationManager NavManager
 @inject IDialogService DialogService
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject IJSRuntime JS
+
 
 @if (FormStateService.IsDirty(ProjectId))
 {
@@ -510,19 +514,64 @@
     }
 
 
+    // public async Task deleteProject()
+    // {
+    //     try
+    //     {
+    //         await ProjectService.__DELETE_Project_By_GUID_ID__Async(ProjectId);
+    //     }
+    //     catch (Exception ex)
+    //     {
+    //         await OpenExceptionDialogAsync("Problem Deleting Project : " + ex.Message);
+    //         return;
+    //     }
+    //     NavManager.NavigateTo("/projects");
+    // }
+
     public async Task deleteProject()
     {
         try
         {
-            await ProjectService.__DELETE_Project_By_GUID_ID__Async(ProjectId);
+            _logger.LogInformation(
+                "Starting project deletion for project {ProjectId} ({ProjectName})",
+                ProjectId,
+            singleProject?.Name ?? "Unknown");
+
+            // Call the deletion service which will:
+            // 1. Delete the project via API
+            // 2. Broadcast notification to all connected users
+            var success = await DeletionService.DeleteProjectWithNotificationAsync(ProjectId);
+
+            if (success)
+            {
+                _logger.LogInformation(
+                    "Project {ProjectId} deleted successfully and notification broadcasted",
+                    ProjectId);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Project deletion returned false for project {ProjectId}",
+                    ProjectId);
+                await OpenExceptionDialogAsync("Failed to delete project. Please try again.");
+                return;
+            }
         }
         catch (Exception ex)
         {
+            _logger.LogError(
+                ex,
+                "Exception occurred while deleting project {ProjectId}",
+                ProjectId);
             await OpenExceptionDialogAsync("Problem Deleting Project : " + ex.Message);
             return;
         }
+
+        // Navigate back to projects list after successful deletion
         NavManager.NavigateTo("/projects");
     }
+
+
     private async Task OpenDeleteConfirmationDialogAsync()
     {
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -539,54 +539,6 @@
                     NavManager.NavigateTo("/");
                     loadingSuccessful = true;
                 }
-
-                // // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
-                // _logger.LogWarning(
-                //     ex,
-                //     "Either API Server is unavailable OR requested project has been deleted.",
-                //     ProjectId);
-
-                // initializingPage = true;
-
-                // // Show error dialog with retry option
-                // var retryOptions = new DialogOptions
-                // {
-                //     CloseButton = false,
-                //     BackdropClick = false,
-                //     CloseOnEscapeKey = false
-                // };
-
-                // var dialogResult = await DialogService.ShowMessageBox(
-                //     title: "Connection Error",
-                //     markupMessage: new MarkupString(
-                //         $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
-                //         $"<p>Either API server is currently unreachable OR</p>" +
-                //         $"<p>The requested project has been deleted.</p>" +
-                //         $"<p><strong>Would you like to retry?</strong></p>"
-                //     ),
-                //     yesText: "Retry",
-                //     noText: "Go to Home",
-                //     options: retryOptions
-                // );
-
-                // // USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
-                // if (dialogResult == true)
-                // {
-                //     _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
-                //     // Wait 1 seconds before retrying to give server time to recover
-                //     await Task.Delay(1000);
-                //     // showLoadingMessage = true;
-                //     // StateHasChanged();
-                //     // Continue the loop to retry
-                //     continue;
-                // }
-                // else
-                // {
-                //     // USER CLICKED "GO TO Home Screen"
-                //     _logger.LogInformation("User chose to go to home screen");
-                //     NavManager.NavigateTo("/");
-                //     loadingSuccessful = true;
-                // }
             }
             // catch (Exception ex)
             // {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -306,32 +306,32 @@
 </MudGrid>
 @code 
 {
-    [Parameter]
-    public Guid ProjectId { get; set; }
-    [Parameter]
-    [SupplyParameterFromQuery(Name = "showBaselineTab")]
-    public bool ShowBaselineTab { get; set; } = false;
-    [Parameter]
-    [SupplyParameterFromQuery(Name = "calledFrom")]
-    public string CalledFrom { get; set; } = string.Empty;
+        [Parameter]
+        public Guid ProjectId { get; set; }
+        [Parameter]
+        [SupplyParameterFromQuery(Name = "showBaselineTab")]
+        public bool ShowBaselineTab { get; set; } = false;
+        [Parameter]
+        [SupplyParameterFromQuery(Name = "calledFrom")]
+        public string CalledFrom { get; set; } = string.Empty;
 
-    [Parameter]
-    public EventCallback<string> ContentChanged { get; set; }
+        [Parameter]
+        public EventCallback<string> ContentChanged { get; set; }
 
-    [Inject]
-    public IProjectService ProjectService { get; set; }
+        [Inject]
+        public IProjectService ProjectService { get; set; }
 
-    [Inject]
-    public IBaselinesService BaselineService { get; set; }
+        [Inject]
+        public IBaselinesService BaselineService { get; set; }
 
-    [Inject]
-    public IItemzTypeService ItemzTypeService { get; set; }
+        [Inject]
+        public IItemzTypeService ItemzTypeService { get; set; }
 
-    [Inject]
-    public IHierarchyService HierarchyService { get; set; }
+        [Inject]
+        public IHierarchyService HierarchyService { get; set; }
 
-    [Inject]
-    public FormStateService FormStateService { get; set; }
+        [Inject]
+        public FormStateService FormStateService { get; set; }
 
 
     // public Guid displayOnlyProjectID = Guid.Empty ;
@@ -346,7 +346,7 @@
     private bool isRecalculatingRollUpEstimations = false;
 
     private EstimationManagementComponent? estimationComponent;
-    
+
     //SignalR Hub Connection
     private HubConnection? hubConnection;
 
@@ -423,50 +423,214 @@
         initializingPage = true;
         StateHasChanged();
         //await Task.Delay(300);
-        singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
 
-        if (singleProject != null)
+        bool loadingSuccessful = false;
+        while (!loadingSuccessful)
         {
-            TreeNodeItemzSelectionService.UpdateTreeNodeItemzName(ProjectId, singleProject.Name!);
-            _originalDescription = singleProject.Description ?? string.Empty;
-            MyContent = _originalDescription;
+            try
+            {
+
+                singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
+
+                if (singleProject != null)
+                {
+                    TreeNodeItemzSelectionService.UpdateTreeNodeItemzName(ProjectId, singleProject.Name!);
+                    _originalDescription = singleProject.Description ?? string.Empty;
+                    MyContent = _originalDescription;
+                }
+                else
+                {
+                    throw new ApplicationException($"Either API Server is unavailable OR Project with ID {ProjectId} has been deleted.");
+                }
+
+                if (form != null)
+                {
+                    await form.Validate();
+                    // Always keep Save disabled on first render.
+                    disableUpdateProjectDetailsButton = true;
+                }
+                initializingPage = false;
+
+                // EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
+                List<string> tempList = new List<string>();
+                foreach (var _projectStatusValue in Enum.GetValues<ProjectStatus>())
+                {
+                    tempList.Add(_projectStatusValue.ToString().Trim());
+                }
+                _stringProjectStatusValues = tempList.ToArray();
+
+                await ConvertMarkdownToHtml(singleProject.Description);
+
+                // Reset dirty state
+                disableUpdateProjectDetailsButton = true;
+                FormStateService.SetDirty(singleProject.Id, false);
+
+                // EXPLANATION :: Location of setting active tab is important to be here at the end of data loading, 
+                // because if we set it before data loading then it will cause multiple unnecessary renders and may 
+                // also cause the tab to not switch properly on first load due to the async nature of data loading.
+
+                if (ShowBaselineTab == true)
+                {
+                    // activeIndex = 2;
+                    await projectTabs.ActivatePanelAsync(baselineTab);
+                }
+
+                StateHasChanged();
+
+
+                // 🔑 MARK LOADING AS SUCCESSFUL
+                loadingSuccessful = true;
+            }
+            catch (ApplicationException ex)
+            {
+                // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                _logger.LogWarning(
+                    ex,
+                    "Either API Server is unavailable OR requested project has been deleted.",
+                    ProjectId);
+
+                initializingPage = true;
+
+                // Show error dialog with retry option
+                var retryOptions = new DialogOptions
+                {
+                    CloseButton = false
+                };
+
+                var dialogResult = await DialogService.ShowMessageBox(
+                    title: "Connection Error",
+                    markupMessage: new MarkupString(
+                        $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+                        $"<p>Either API server is currently unreachable OR</p>" +
+                        $"<p>The requested project has been deleted.</p>" +
+                        $"<p><strong>Would you like to retry?</strong></p>"
+                    ),
+                    yesText: "Retry",
+                    noText: "Go to Home",
+                    options: retryOptions
+                );
+
+                // USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+                if (dialogResult == true)
+                {
+                    _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+                    // Wait 1 seconds before retrying to give server time to recover
+                    await Task.Delay(1000);
+                    // showLoadingMessage = true;
+                    // StateHasChanged();
+                    // Continue the loop to retry
+                    continue;
+                }
+                else
+                {
+                    // USER CLICKED "GO TO Home Screen"
+                    _logger.LogInformation("User chose to go to home screen");
+                    NavManager.NavigateTo("/");
+                    loadingSuccessful = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                // HANDLE ANY OTHER UNEXPECTED ERRORS
+                // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
+                bool isConnectionError = false;
+                string errorType = "Unknown Error";
+
+                if (ex is OperationCanceledException)
+                {
+                    isConnectionError = true;
+                    errorType = "Connection Timeout";
+                }
+                else if (ex.InnerException is HttpRequestException)
+                {
+                    isConnectionError = true;
+                    errorType = "Connection Error";
+                }
+                else if (ex.InnerException is OperationCanceledException)
+                {
+                    isConnectionError = true;
+                    errorType = "Connection Timeout";
+                }
+                else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+                {
+                    isConnectionError = true;
+                    errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
+                }
+
+                _logger.LogError(
+                    ex,
+                    "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+                    ProjectId,
+                    errorType,
+                    isConnectionError,
+                    ex.Message);
+
+                var retryOptions = new DialogOptions
+                {
+                    CloseButton = false
+                };
+
+                // If it's a connection error, treat it as such
+                if (isConnectionError)
+                {
+                    var dialogResult = await DialogService.ShowMessageBox(
+                        "Connection Error",
+                        markupMessage: new MarkupString(
+                            $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+                            $"<p>The API server is currently unreachable or not responding.</p>" +
+                            $"<p>The project data cannot be loaded at this moment.</p>" +
+                            $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
+                            $"<p><strong>Would you like to retry?</strong></p>"
+                        ),
+                        yesText: "Retry",
+                        noText: "Go to Projects List",
+                        options: retryOptions
+                    );
+
+                    if (dialogResult == true)
+                    {
+                        _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
+                        await Task.Delay(2000);
+                        continue;
+                    }
+                    else
+                    {
+                        _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+                        NavManager.NavigateTo("/projects", forceLoad: true);
+                        loadingSuccessful = true;
+                    }
+                }
+                else
+                {
+                    // Show generic error message with retry for other unexpected errors
+                    var dialogResult = await DialogService.ShowMessageBox(
+                        "Error Loading Project",
+                        markupMessage: new MarkupString(
+                            $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
+                            $"<p>Error: {ex.Message}</p>" +
+                            $"<p><strong>Would you like to retry?</strong></p>"
+                        ),
+                        yesText: "Retry",
+                        noText: "Go to Projects List",
+                        options: retryOptions
+                    );
+
+                    if (dialogResult == true)
+                    {
+                        _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
+                        await Task.Delay(2000);
+                        continue;
+                    }
+                    else
+                    {
+                        _logger.LogInformation("User chose to go to projects list after error");
+                        NavManager.NavigateTo("/projects", forceLoad: true);
+                        loadingSuccessful = true;
+                    }
+                }
+            }
         }
 
-        if (form != null)
-        {
-            await form.Validate();
-            // Always keep Save disabled on first render.
-            disableUpdateProjectDetailsButton = true;
-        }
-        initializingPage = false;
-
-        // EXPLANATION :: First we create string list and then just call ToArray() for producing required string array
-        List<string> tempList = new List<string>();
-        foreach (var _projectStatusValue in Enum.GetValues<ProjectStatus>())
-        {
-            tempList.Add(_projectStatusValue.ToString().Trim());
-        }
-        _stringProjectStatusValues = tempList.ToArray();
-
-
-
-        await ConvertMarkdownToHtml(singleProject.Description);
-
-        // Reset dirty state
-        disableUpdateProjectDetailsButton = true;
-        FormStateService.SetDirty(singleProject.Id, false);
-
-        // EXPLANATION :: Location of setting active tab is important to be here at the end of data loading, 
-        // because if we set it before data loading then it will cause multiple unnecessary renders and may 
-        // also cause the tab to not switch properly on first load due to the async nature of data loading.
-
-        if (ShowBaselineTab == true)
-        {
-            // activeIndex = 2;
-            await projectTabs.ActivatePanelAsync(baselineTab);
-        }
-
-        StateHasChanged();
 
         // -------------------------------
         // Initialize SignalR connection

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -14,8 +14,10 @@
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Baseline
 @using OpenRose.WebUI.Components.Pages.Common
+@using OpenRose.WebUI.Constants
 @using OpenRose.WebUI.Services.NotificationHub
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.SignalR.Client
 @using OpenRose.WebUI.Components.Pages.SharedComponents
 @using PSC.Blazor.Components.MarkdownEditor
 @using PSC.Blazor.Components.MarkdownEditor.EventsArgs
@@ -344,7 +346,9 @@
     private bool isRecalculatingRollUpEstimations = false;
 
     private EstimationManagementComponent? estimationComponent;
-
+    
+    //SignalR Hub Connection
+    private HubConnection? hubConnection;
 
     // private string _Content = string.Empty;
     private string MyContent
@@ -463,6 +467,45 @@
         }
 
         StateHasChanged();
+
+        // -------------------------------
+        // Initialize SignalR connection
+        // -------------------------------
+        try
+        {
+            hubConnection = new HubConnectionBuilder()
+                .WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
+                .WithAutomaticReconnect()
+                .Build();
+
+            // Listen for project deleted notifications
+            hubConnection.On<Guid>(
+                SignalRConstants.ProjectEvents.ProjectDeleted,
+                OnProjectDeletedAsync);
+
+            // Listen for project updated notifications
+            hubConnection.On<Guid>(
+                SignalRConstants.ProjectEvents.ProjectModified,
+                OnProjectUpdatedAsync);
+
+            // Listen for project created notifications
+            hubConnection.On<Guid>(
+                SignalRConstants.ProjectEvents.ProjectCreated,
+                OnProjectCreatedAsync);
+
+            await hubConnection.StartAsync();
+
+            // Subscribe to notifications for the current project
+            if (hubConnection.State == HubConnectionState.Connected)
+            {
+                await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+                _logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
+        }
 
     }
     public async Task HandleProjectDetailsPatchSubmission()
@@ -794,4 +837,93 @@
 			StateHasChanged();
 		}
 	}
+
+    #region SignalR Event Handlers including overall Dispose method
+    /// <summary>
+    /// Called when server broadcasts that this project was deleted.
+    /// Receives only the ProjectId - we already have the project details.
+    /// </summary>
+    private async Task OnProjectDeletedAsync(Guid projectIdDeleted)
+    {
+        // Only process if this is for the current project
+        if (projectIdDeleted != ProjectId)
+            return;
+
+        _logger.LogInformation(
+            $"Received notification: Project {projectIdDeleted} was deleted");
+
+        // Use the already-loaded project details from singleProject
+        var parameters = new DialogParameters<DeletedProjectDialog>
+        {
+            { x => x.ProjectId, projectIdDeleted },
+            { x => x.ProjectName, singleProject?.Name ?? "Unknown Project" }
+        };
+
+        var dialog = await DialogService.ShowAsync<DeletedProjectDialog>(
+            "Project Deleted",
+            parameters);
+
+        var result = await dialog.Result;
+
+        // Navigate away if user confirmed
+        if (!result.Canceled)
+        {
+            NavManager.NavigateTo("/Projects", forceLoad: true);
+        }
+    }
+
+    /// <summary>
+    /// Called when server broadcasts that this project was updated.
+    /// Receives only the ProjectId.
+    /// </summary>
+    private async Task OnProjectUpdatedAsync(Guid projectIdUpdated)
+    {
+        if (projectIdUpdated != ProjectId)
+            return;
+
+        _logger.LogInformation(
+            $"Project {projectIdUpdated} was updated");
+
+        // Optionally refresh the project data if needed
+        // await LoadProjectDataAsync();
+        // StateHasChanged();
+    }
+
+    /// <summary>
+    /// Called when server broadcasts that this project was created.
+    /// Receives only the ProjectId.
+    /// </summary>
+    private async Task OnProjectCreatedAsync(Guid projectIdCreated)
+    {
+        if (projectIdCreated != ProjectId)
+            return;
+
+        _logger.LogInformation(
+            $"Project {projectIdCreated} was created");
+        // Optionally refresh the project data if needed
+        // await LoadProjectDataAsync();
+        // StateHasChanged();
+    }
+
+
+
+    public async ValueTask DisposeAsync()
+    {
+
+        // Cleanup SignalR connection
+        if (hubConnection is not null)
+        {
+            try
+            {
+                await hubConnection.InvokeAsync("UnsubscribeFromProjectAsync", ProjectId);
+                await hubConnection.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error disposing hub connection: {ex.Message}");
+            }
+        }
+    }
+
+    #endregion
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -635,46 +635,47 @@
             }
         }
 
-
-        // -------------------------------
-        // Initialize SignalR connection
-        // -------------------------------
-        try
+        @if (CalledFrom == nameof(ProjectDetails))
         {
-            hubConnection = new HubConnectionBuilder()
-                .WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
-                .WithAutomaticReconnect()
-                .Build();
-
-            // Listen for project deleted notifications
-            hubConnection.On<Guid>(
-                SignalRConstants.ProjectEvents.ProjectDeleted,
-                OnProjectDeletedAsync);
-
-            // Listen for project updated notifications
-            hubConnection.On<Guid>(
-                SignalRConstants.ProjectEvents.ProjectModified,
-                OnProjectUpdatedAsync);
-
-            // Listen for project created notifications
-            hubConnection.On<Guid>(
-                SignalRConstants.ProjectEvents.ProjectCreated,
-                OnProjectCreatedAsync);
-
-            await hubConnection.StartAsync();
-
-            // Subscribe to notifications for the current project
-            if (hubConnection.State == HubConnectionState.Connected)
+            // -------------------------------
+            // Initialize SignalR connection
+            // -------------------------------
+            try
             {
-                await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
-                _logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+                hubConnection = new HubConnectionBuilder()
+                    .WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
+                    .WithAutomaticReconnect()
+                    .Build();
+
+                // Listen for project deleted notifications
+                hubConnection.On<Guid>(
+                    SignalRConstants.ProjectEvents.ProjectDeleted,
+                    OnProjectDeletedAsync);
+
+                // Listen for project updated notifications
+                hubConnection.On<Guid>(
+                    SignalRConstants.ProjectEvents.ProjectModified,
+                    OnProjectUpdatedAsync);
+
+                // Listen for project created notifications
+                hubConnection.On<Guid>(
+                    SignalRConstants.ProjectEvents.ProjectCreated,
+                    OnProjectCreatedAsync);
+
+                await hubConnection.StartAsync();
+
+                // Subscribe to notifications for the current project
+                if (hubConnection.State == HubConnectionState.Connected)
+                {
+                    await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+                    _logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
             }
         }
-        catch (Exception ex)
-        {
-            _logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
-        }
-
     }
     public async Task HandleProjectDetailsPatchSubmission()
     {
@@ -748,9 +749,20 @@
                 ProjectId,
             singleProject?.Name ?? "Unknown");
 
+
+            // EXPLANATION :: Before we delete the project, we need to unsubscribe 
+            // from notifications for this project otherwise user will briefly see 
+            // a notification that the project was deleted before the page navigates away.
+
+            if (hubConnection is not null)
+            {
+                await hubConnection.InvokeAsync("UnsubscribeFromProjectAsync", ProjectId);
+            }
+
             // Call the deletion service which will:
             // 1. Delete the project via API
             // 2. Broadcast notification to all connected users
+
             var success = await DeletionService.DeleteProjectWithNotificationAsync(ProjectId);
 
             if (success)
@@ -765,6 +777,18 @@
                     "Project deletion returned false for project {ProjectId}",
                     ProjectId);
                 await OpenExceptionDialogAsync("Failed to delete project. Please try again.");
+
+                if (hubConnection is not null)
+                {
+                    // EXPLANATION :: Subscribe back to notifications for the current project
+                    // This is important because the user may want to retry the deletion 
+                    // or continue working with the project.
+                    if (hubConnection.State == HubConnectionState.Connected)
+                    {
+                        await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+                        _logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+                    }
+                }
                 return;
             }
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -405,7 +405,7 @@
     // 	{
     // 		projectTabs.ActivatePanel(baselineTab);
     // 	}
-
+    
     // 	StateHasChanged();
     // }
 
@@ -494,7 +494,9 @@
                 // Show error dialog with retry option
                 var retryOptions = new DialogOptions
                 {
-                    CloseButton = false
+                    CloseButton = false,
+                    BackdropClick = false,
+                    CloseOnEscapeKey = false
                 };
 
                 var dialogResult = await DialogService.ShowMessageBox(
@@ -567,7 +569,9 @@
 
                 var retryOptions = new DialogOptions
                 {
-                    CloseButton = false
+                    CloseButton = false,
+                    BackdropClick = false,
+                    CloseOnEscapeKey = false
                 };
 
                 // If it's a connection error, treat it as such

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -483,6 +483,7 @@
             }
             catch (ApplicationException ex)
             {
+
                 // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
                 _logger.LogWarning(
                     ex,
@@ -491,37 +492,45 @@
 
                 initializingPage = true;
 
+
+                var parameters = new DialogParameters
+                {
+                    ["Title"] = "Connection Error",
+                    ["MessageHtml"] =
+                        "<p style='color:red;'><strong>Unable to obtain Project Data</strong></p>" +
+                        "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+                        "<p>The requested project has been deleted.</p>" +
+                        "<p><strong>Would you like to retry?</strong></p>",
+                    ["YesText"] = "Retry",
+                    ["NoText"] = "Go to Home"
+                };
+
                 // Show error dialog with retry option
-                var retryOptions = new DialogOptions
+
+                var options = new DialogOptions
                 {
                     CloseButton = false,
                     BackdropClick = false,
                     CloseOnEscapeKey = false
                 };
 
-                var dialogResult = await DialogService.ShowMessageBox(
-                    title: "Connection Error",
-                    markupMessage: new MarkupString(
-                        $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
-                        $"<p>Either API server is currently unreachable OR</p>" +
-                        $"<p>The requested project has been deleted.</p>" +
-                        $"<p><strong>Would you like to retry?</strong></p>"
-                    ),
-                    yesText: "Retry",
-                    noText: "Go to Home",
-                    options: retryOptions
-                );
+                var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+                    "Connection Error",
+                    parameters,
+                    options);
+
+                var dialogResult = await dialog.Result;
 
                 // USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
-                if (dialogResult == true)
+                if (dialogResult != null && dialogResult.Data is bool retry && retry)
                 {
-                    _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+                    _logger.LogInformation(
+                        "User chose to retry loading project {ProjectId}. Waiting 1 second before retry.",
+                        ProjectId);
                     // Wait 1 seconds before retrying to give server time to recover
+                    
                     await Task.Delay(1000);
-                    // showLoadingMessage = true;
-                    // StateHasChanged();
-                    // Continue the loop to retry
-                    continue;
+                    continue; // retry loop
                 }
                 else
                 {
@@ -530,109 +539,157 @@
                     NavManager.NavigateTo("/");
                     loadingSuccessful = true;
                 }
+
+                // // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                // _logger.LogWarning(
+                //     ex,
+                //     "Either API Server is unavailable OR requested project has been deleted.",
+                //     ProjectId);
+
+                // initializingPage = true;
+
+                // // Show error dialog with retry option
+                // var retryOptions = new DialogOptions
+                // {
+                //     CloseButton = false,
+                //     BackdropClick = false,
+                //     CloseOnEscapeKey = false
+                // };
+
+                // var dialogResult = await DialogService.ShowMessageBox(
+                //     title: "Connection Error",
+                //     markupMessage: new MarkupString(
+                //         $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+                //         $"<p>Either API server is currently unreachable OR</p>" +
+                //         $"<p>The requested project has been deleted.</p>" +
+                //         $"<p><strong>Would you like to retry?</strong></p>"
+                //     ),
+                //     yesText: "Retry",
+                //     noText: "Go to Home",
+                //     options: retryOptions
+                // );
+
+                // // USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+                // if (dialogResult == true)
+                // {
+                //     _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+                //     // Wait 1 seconds before retrying to give server time to recover
+                //     await Task.Delay(1000);
+                //     // showLoadingMessage = true;
+                //     // StateHasChanged();
+                //     // Continue the loop to retry
+                //     continue;
+                // }
+                // else
+                // {
+                //     // USER CLICKED "GO TO Home Screen"
+                //     _logger.LogInformation("User chose to go to home screen");
+                //     NavManager.NavigateTo("/");
+                //     loadingSuccessful = true;
+                // }
             }
-            catch (Exception ex)
-            {
-                // HANDLE ANY OTHER UNEXPECTED ERRORS
-                // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
-                bool isConnectionError = false;
-                string errorType = "Unknown Error";
+            // catch (Exception ex)
+            // {
+            //     // HANDLE ANY OTHER UNEXPECTED ERRORS
+            //     // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
+            //     bool isConnectionError = false;
+            //     string errorType = "Unknown Error";
 
-                if (ex is OperationCanceledException)
-                {
-                    isConnectionError = true;
-                    errorType = "Connection Timeout";
-                }
-                else if (ex.InnerException is HttpRequestException)
-                {
-                    isConnectionError = true;
-                    errorType = "Connection Error";
-                }
-                else if (ex.InnerException is OperationCanceledException)
-                {
-                    isConnectionError = true;
-                    errorType = "Connection Timeout";
-                }
-                else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
-                {
-                    isConnectionError = true;
-                    errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
-                }
+            //     if (ex is OperationCanceledException)
+            //     {
+            //         isConnectionError = true;
+            //         errorType = "Connection Timeout";
+            //     }
+            //     else if (ex.InnerException is HttpRequestException)
+            //     {
+            //         isConnectionError = true;
+            //         errorType = "Connection Error";
+            //     }
+            //     else if (ex.InnerException is OperationCanceledException)
+            //     {
+            //         isConnectionError = true;
+            //         errorType = "Connection Timeout";
+            //     }
+            //     else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+            //     {
+            //         isConnectionError = true;
+            //         errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
+            //     }
 
-                _logger.LogError(
-                    ex,
-                    "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
-                    ProjectId,
-                    errorType,
-                    isConnectionError,
-                    ex.Message);
+            //     _logger.LogError(
+            //         ex,
+            //         "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+            //         ProjectId,
+            //         errorType,
+            //         isConnectionError,
+            //         ex.Message);
 
-                var retryOptions = new DialogOptions
-                {
-                    CloseButton = false,
-                    BackdropClick = false,
-                    CloseOnEscapeKey = false
-                };
+            //     var retryOptions = new DialogOptions
+            //     {
+            //         CloseButton = false,
+            //         BackdropClick = false,
+            //         CloseOnEscapeKey = false
+            //     };
 
-                // If it's a connection error, treat it as such
-                if (isConnectionError)
-                {
-                    var dialogResult = await DialogService.ShowMessageBox(
-                        "Connection Error",
-                        markupMessage: new MarkupString(
-                            $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
-                            $"<p>The API server is currently unreachable or not responding.</p>" +
-                            $"<p>The project data cannot be loaded at this moment.</p>" +
-                            $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
-                            $"<p><strong>Would you like to retry?</strong></p>"
-                        ),
-                        yesText: "Retry",
-                        noText: "Go to Projects List",
-                        options: retryOptions
-                    );
+            //     // If it's a connection error, treat it as such
+            //     if (isConnectionError)
+            //     {
+            //         var dialogResult = await DialogService.ShowMessageBox(
+            //             "Connection Error",
+            //             markupMessage: new MarkupString(
+            //                 $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+            //                 $"<p>The API server is currently unreachable or not responding.</p>" +
+            //                 $"<p>The project data cannot be loaded at this moment.</p>" +
+            //                 $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
+            //                 $"<p><strong>Would you like to retry?</strong></p>"
+            //             ),
+            //             yesText: "Retry",
+            //             noText: "Go to Projects List",
+            //             options: retryOptions
+            //         );
 
-                    if (dialogResult == true)
-                    {
-                        _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
-                        await Task.Delay(2000);
-                        continue;
-                    }
-                    else
-                    {
-                        _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
-                        NavManager.NavigateTo("/projects", forceLoad: true);
-                        loadingSuccessful = true;
-                    }
-                }
-                else
-                {
-                    // Show generic error message with retry for other unexpected errors
-                    var dialogResult = await DialogService.ShowMessageBox(
-                        "Error Loading Project",
-                        markupMessage: new MarkupString(
-                            $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
-                            $"<p>Error: {ex.Message}</p>" +
-                            $"<p><strong>Would you like to retry?</strong></p>"
-                        ),
-                        yesText: "Retry",
-                        noText: "Go to Projects List",
-                        options: retryOptions
-                    );
+            //         if (dialogResult == true)
+            //         {
+            //             _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
+            //             await Task.Delay(2000);
+            //             continue;
+            //         }
+            //         else
+            //         {
+            //             _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+            //             NavManager.NavigateTo("/projects", forceLoad: true);
+            //             loadingSuccessful = true;
+            //         }
+            //     }
+            //     else
+            //     {
+            //         // Show generic error message with retry for other unexpected errors
+            //         var dialogResult = await DialogService.ShowMessageBox(
+            //             "Error Loading Project",
+            //             markupMessage: new MarkupString(
+            //                 $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
+            //                 $"<p>Error: {ex.Message}</p>" +
+            //                 $"<p><strong>Would you like to retry?</strong></p>"
+            //             ),
+            //             yesText: "Retry",
+            //             noText: "Go to Projects List",
+            //             options: retryOptions
+            //         );
 
-                    if (dialogResult == true)
-                    {
-                        _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
-                        await Task.Delay(2000);
-                        continue;
-                    }
-                    else
-                    {
-                        _logger.LogInformation("User chose to go to projects list after error");
-                        NavManager.NavigateTo("/projects", forceLoad: true);
-                        loadingSuccessful = true;
-                    }
-                }
-            }
+            //         if (dialogResult == true)
+            //         {
+            //             _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
+            //             await Task.Delay(2000);
+            //             continue;
+            //         }
+            //         else
+            //         {
+            //             _logger.LogInformation("User chose to go to projects list after error");
+            //             NavManager.NavigateTo("/projects", forceLoad: true);
+            //             loadingSuccessful = true;
+            //         }
+            //     }
+            // }
         }
 
         @if (CalledFrom == nameof(ProjectDetails))

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -827,6 +827,9 @@
                 _logger.LogInformation(
                     "Project {ProjectId} deleted successfully and notification broadcasted",
                     ProjectId);
+
+                // Navigate back to projects list after successful deletion
+                NavManager.NavigateTo("/projects");
             }
             else
             {
@@ -859,8 +862,8 @@
             return;
         }
 
-        // Navigate back to projects list after successful deletion
-        NavManager.NavigateTo("/projects");
+        // // Navigate back to projects list after successful deletion
+        // NavManager.NavigateTo("/projects");
     }
 
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -186,154 +186,161 @@
                     // 🔑 MARK LOADING AS SUCCESSFUL
                     loadingSuccessful = true;
                 }
-                catch (ApplicationException ex)
+
+                # region Catch Blocks for Error Handling
+
+                catch (Exception ex)
                 {
-                    // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
                     _logger.LogWarning(
                         ex,
-                        "Either API Server is unavailable OR requested project has been deleted.",
+                        "Either API Server is unavailable OR requested project has been deleted. ProjectId: {ProjectId}",
                         ProjectId);
 
                     initializingPage = true;
 
-                    // Show error dialog with retry option
-                    var retryOptions = new DialogOptions
+                    var parameters = new DialogParameters
                     {
-                        CloseButton = false
+                        ["Title"] = "Connection Error",
+                        ["MessageHtml"] =
+                            "<p style='color:red;'><strong>Unable to obtain Project Data</strong></p>" +
+                            "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+                            "<p>The requested project has been deleted.</p>" +
+                            "<p><strong>Would you like to retry?</strong></p>",
+                        ["YesText"] = "Retry",
+                        ["NoText"] = "Go to Home"
                     };
 
-                    var dialogResult = await DialogService.ShowMessageBox(
-                        title: "Connection Error",
-                        markupMessage: new MarkupString(
-                            $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
-                            $"<p>Either API server is currently unreachable OR</p>" +
-                            $"<p>The requested project has been deleted.</p>" +
-                            $"<p><strong>Would you like to retry?</strong></p>"
-                        ),
-                        yesText: "Retry",
-                        noText: "Go to Home",
-                        options: retryOptions
-                    );
-
-                    // USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
-                    if (dialogResult == true)
+                    var options = new DialogOptions
                     {
-                        _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
-                        // Wait 1 seconds before retrying to give server time to recover
+                        CloseButton = false,
+                        BackdropClick = false,
+                        CloseOnEscapeKey = false
+                    };
+
+                    var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+                        "Connection Error",
+                        parameters,
+                        options);
+
+                    var result = await dialog.Result;
+
+                    if (result.Data is bool retry && retry)
+                    {
+                        _logger.LogInformation(
+                            "User chose to retry loading project {ProjectId}. Waiting 1 second before retry.",
+                            ProjectId);
+
                         await Task.Delay(1000);
-                        // showLoadingMessage = true;
-                        // StateHasChanged();
-                        // Continue the loop to retry
-                        continue;
+                        continue;   // retry loop
                     }
                     else
                     {
-                        // USER CLICKED "GO TO Home Screen"
                         _logger.LogInformation("User chose to go to home screen");
                         NavManager.NavigateTo("/");
                         loadingSuccessful = true;
                     }
                 }
-                catch (Exception ex)
-                {
-                    // HANDLE ANY OTHER UNEXPECTED ERRORS
-                    // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
-                    bool isConnectionError = false;
-                    string errorType = "Unknown Error";
+                // catch (Exception ex)
+                // {
+                //     bool isConnectionError = false;
+                //     string errorType = "Unknown Error";
 
-                    if (ex is OperationCanceledException)
-                    {
-                        isConnectionError = true;
-                        errorType = "Connection Timeout";
-                    }
-                    else if (ex.InnerException is HttpRequestException)
-                    {
-                        isConnectionError = true;
-                        errorType = "Connection Error";
-                    }
-                    else if (ex.InnerException is OperationCanceledException)
-                    {
-                        isConnectionError = true;
-                        errorType = "Connection Timeout";
-                    }
-                    else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
-                    {
-                        isConnectionError = true;
-                        errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
-                    }
+                //     if (ex is OperationCanceledException)
+                //     {
+                //         isConnectionError = true;
+                //         errorType = "Connection Timeout";
+                //     }
+                //     else if (ex.InnerException is HttpRequestException)
+                //     {
+                //         isConnectionError = true;
+                //         errorType = "Connection Error";
+                //     }
+                //     else if (ex.InnerException is OperationCanceledException)
+                //     {
+                //         isConnectionError = true;
+                //         errorType = "Connection Timeout";
+                //     }
+                //     else if (ex is AggregateException aggEx &&
+                //              aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+                //     {
+                //         isConnectionError = true;
+                //         errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any()
+                //             ? "Connection Timeout"
+                //             : "Connection Error";
+                //     }
 
-                    _logger.LogError(
-                        ex,
-                        "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
-                        ProjectId,
-                        errorType,
-                        isConnectionError,
-                        ex.Message);
+                //     _logger.LogError(
+                //         ex,
+                //         "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+                //         ProjectId,
+                //         errorType,
+                //         isConnectionError,
+                //         ex.Message);
 
-                    var retryOptions = new DialogOptions
-                    {
-                        CloseButton = false
-                    };
+                //     var options = new DialogOptions
+                //     {
+                //         CloseButton = false,
+                //         BackdropClick = false,
+                //         CloseOnEscapeKey = false
+                //     };
 
-                    // If it's a connection error, treat it as such
-                    if (isConnectionError)
-                    {
-                        var dialogResult = await DialogService.ShowMessageBox(
-                            "Connection Error",
-                            markupMessage: new MarkupString(
-                                $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
-                                $"<p>The API server is currently unreachable or not responding.</p>" +
-                                $"<p>The project data cannot be loaded at this moment.</p>" +
-                                $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
-                                $"<p><strong>Would you like to retry?</strong></p>"
-                            ),
-                            yesText: "Retry",
-                            noText: "Go to Projects List",
-                            options: retryOptions
-                        );
+                //     DialogParameters parameters;
 
-                        if (dialogResult == true)
-                        {
-                            _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
-                            await Task.Delay(2000);
-                            continue;
-                        }
-                        else
-                        {
-                            _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
-                            NavManager.NavigateTo("/projects", forceLoad: true);
-                            loadingSuccessful = true;
-                        }
-                    }
-                    else
-                    {
-                        // Show generic error message with retry for other unexpected errors
-                        var dialogResult = await DialogService.ShowMessageBox(
-                            "Error Loading Project",
-                            markupMessage: new MarkupString(
-                                $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
-                                $"<p>Error: {ex.Message}</p>" +
-                                $"<p><strong>Would you like to retry?</strong></p>"
-                            ),
-                            yesText: "Retry",
-                            noText: "Go to Projects List",
-                            options: retryOptions
-                        );
+                //     if (isConnectionError)
+                //     {
+                //         parameters = new DialogParameters
+                //         {
+                //             ["Title"] = "Connection Error",
+                //             ["MessageHtml"] =
+                //                 $"<p style='color:red;'><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+                //                 "<p>The API server is currently unreachable or not responding.</p>" +
+                //                 "<p>The project data cannot be loaded at this moment.</p>" +
+                //                 $"<p style='color:gray; font-size:0.9em;'>Error: {ex.Message}</p>" +
+                //                 "<p><strong>Would you like to retry?</strong></p>",
+                //             ["YesText"] = "Retry",
+                //             ["NoText"] = "Go to Projects List"
+                //         };
+                //     }
+                //     else
+                //     {
+                //         parameters = new DialogParameters
+                //         {
+                //             ["Title"] = "Error Loading Project",
+                //             ["MessageHtml"] =
+                //                 "<p style='color:red;'><strong>An Unexpected Error Occurred</strong></p>" +
+                //                 $"<p>Error: {ex.Message}</p>" +
+                //                 "<p><strong>Would you like to retry?</strong></p>",
+                //             ["YesText"] = "Retry",
+                //             ["NoText"] = "Go to Projects List"
+                //         };
+                //     }
 
-                        if (dialogResult == true)
-                        {
-                            _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
-                            await Task.Delay(2000);
-                            continue;
-                        }
-                        else
-                        {
-                            _logger.LogInformation("User chose to go to projects list after error");
-                            NavManager.NavigateTo("/projects", forceLoad: true);
-                            loadingSuccessful = true;
-                        }
-                    }
-                }
+                //     var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+                //         parameters["Title"].ToString(),
+                //         parameters,
+                //         options);
+
+                //     var result = await dialog.Result;
+
+                //     if (result.Data is bool retry && retry)
+                //     {
+                //         _logger.LogInformation(
+                //             "User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.",
+                //             errorType,
+                //             ProjectId);
+
+                //         await Task.Delay(2000);
+                //         continue;
+                //     }
+                //     else
+                //     {
+                //         _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+                //         NavManager.NavigateTo("/projects", forceLoad: true);
+                //         loadingSuccessful = true;
+                //     }
+                // }
+
+                #endregion
             }
 
             // // -------------------------------

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -7,23 +7,16 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.Project
 @using OpenRose.WebUI.Client.SharedModels
-@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.SharedComponents
-@using OpenRose.WebUI.Constants
 @using OpenRose.WebUI.Services
-@using OpenRose.WebUI.Services.NotificationHub
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.SignalR.Client
 @inject NavigationBlockerService NavigationBlocker
-@inject NavigationManager NavManager
-@inject ProjectDeletionService DeletionService
 @inject ViewSettingsService ViewSettings
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
-@inject IDialogService DialogService
 @inject IJSRuntime JS
-@inject ILogger<ProjectDetailsComponent> _logger
 
 <MudGrid>
     @if (initializingPage)
@@ -38,6 +31,8 @@
     }
     else
     {
+        if (singleProject != null && singleProject.Id != Guid.Empty)
+        {
         <MudItem xs="12" sm="12">
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
@@ -70,13 +65,6 @@
 
             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
                 <MudCardContent>
-                    @* 					<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-						<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
-							<MudText><strong>ID :</strong></MudText>
-							<CopyableText TextToCopy="@singleProject.Id.ToString()" />
-						</MudStack>
-						<MudText><strong>Status :</strong> @singleProject.Status</MudText>
-					</MudStack> *@
                     @if (!ViewSettings.IsKioskMode)
                     {
                         <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
@@ -113,7 +101,23 @@
                 </MudCardContent>
             </MudCard>
         </MudItem>
-        <br />
+            <br />
+        }
+@*         else
+        {
+            if (initializingPage == false)
+            { 
+                <MudItem xs="12" sm="12">
+                    <br />
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Secondary"
+                               OnClick="@(() => OnAfterRenderAsync(true))">
+                        CLICK TO LOAD PROJECT DATA MANUALLY
+                    </MudButton>
+                    <br />
+                </MudItem>
+            }
+        } *@
     }
 </MudGrid>
 @if (_showOverlay)
@@ -121,21 +125,19 @@
     <MudPaper Height="calc(100vh - 100px);" Width="100%">
         <MudOverlay Visible="@_showOverlay" DarkBackground="true" Absolute="true">
             <MudContainer Class="d-flex flex-column justify-center align-center" Style="height: 100%;">
-                @* <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Moving ... </MudText>
-			<br /> *@
                 <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
             </MudContainer>
         </MudOverlay>
     </MudPaper>
 }
 @code {
-    [Parameter]
-    public Guid ProjectId { get; set; }
+        [Parameter]
+        public Guid ProjectId { get; set; }
 
-    [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
+        [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
 
-    [Inject]
-    public IProjectService ProjectService { get; set; }
+        [Inject]
+        public IProjectService ProjectService { get; set; }
 
     public GetProjectDTO singleProject { get; set; } = new();
     public bool initializingPage { get; set; } = true;
@@ -145,9 +147,6 @@
 
     private Breakpoint bp;
 
-    // //SignalR Hub Connection
-    // private HubConnection? hubConnection;
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -156,233 +155,21 @@
             StateHasChanged();
             await Task.Delay(300);
 
-            bool loadingSuccessful = false;
-            while (!loadingSuccessful)
+            singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
+
+            if (singleProject != null && singleProject.Description != null)
             {
-                try
-                {
-
-                    singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
-
-                    if (singleProject == null)
-                    {
-                        throw new ApplicationException($"Either API Server is unavailable OR Project with ID {ProjectId} has been deleted.");
-                    }
-
-                    if (singleProject != null && singleProject.Description != null)
-                    {
-                        await ConvertMarkdownToHtml(singleProject.Description);
-                    }
-
-                    initializingPage = false;
-                    StateHasChanged();
-
-                    // ALWAYS run navigation blocker after render if kiosk mode is active
-                    if (ViewSettings.IsKioskMode)
-                    {
-                        await NavigationBlocker.Enable();
-                    }
-
-                    // 🔑 MARK LOADING AS SUCCESSFUL
-                    loadingSuccessful = true;
-                }
-
-                # region Catch Blocks for Error Handling
-
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(
-                        ex,
-                        "Either API Server is unavailable OR requested project has been deleted. ProjectId: {ProjectId}",
-                        ProjectId);
-
-                    initializingPage = true;
-
-                    var parameters = new DialogParameters
-                    {
-                        ["Title"] = "Connection Error",
-                        ["MessageHtml"] =
-                            "<p style='color:red;'><strong>Unable to obtain Project Data</strong></p>" +
-                            "<p>Either API server is currently unreachable</p> <p> OR</p>" +
-                            "<p>The requested project has been deleted.</p>" +
-                            "<p><strong>Would you like to retry?</strong></p>",
-                        ["YesText"] = "Retry",
-                        ["NoText"] = "Go to Home"
-                    };
-
-                    var options = new DialogOptions
-                    {
-                        CloseButton = false,
-                        BackdropClick = false,
-                        CloseOnEscapeKey = false
-                    };
-
-                    var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
-                        "Connection Error",
-                        parameters,
-                        options);
-
-                    var result = await dialog.Result;
-
-                    if (result.Data is bool retry && retry)
-                    {
-                        _logger.LogInformation(
-                            "User chose to retry loading project {ProjectId}. Waiting 1 second before retry.",
-                            ProjectId);
-
-                        await Task.Delay(1000);
-                        continue;   // retry loop
-                    }
-                    else
-                    {
-                        _logger.LogInformation("User chose to go to home screen");
-                        NavManager.NavigateTo("/");
-                        loadingSuccessful = true;
-                    }
-                }
-                // catch (Exception ex)
-                // {
-                //     bool isConnectionError = false;
-                //     string errorType = "Unknown Error";
-
-                //     if (ex is OperationCanceledException)
-                //     {
-                //         isConnectionError = true;
-                //         errorType = "Connection Timeout";
-                //     }
-                //     else if (ex.InnerException is HttpRequestException)
-                //     {
-                //         isConnectionError = true;
-                //         errorType = "Connection Error";
-                //     }
-                //     else if (ex.InnerException is OperationCanceledException)
-                //     {
-                //         isConnectionError = true;
-                //         errorType = "Connection Timeout";
-                //     }
-                //     else if (ex is AggregateException aggEx &&
-                //              aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
-                //     {
-                //         isConnectionError = true;
-                //         errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any()
-                //             ? "Connection Timeout"
-                //             : "Connection Error";
-                //     }
-
-                //     _logger.LogError(
-                //         ex,
-                //         "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
-                //         ProjectId,
-                //         errorType,
-                //         isConnectionError,
-                //         ex.Message);
-
-                //     var options = new DialogOptions
-                //     {
-                //         CloseButton = false,
-                //         BackdropClick = false,
-                //         CloseOnEscapeKey = false
-                //     };
-
-                //     DialogParameters parameters;
-
-                //     if (isConnectionError)
-                //     {
-                //         parameters = new DialogParameters
-                //         {
-                //             ["Title"] = "Connection Error",
-                //             ["MessageHtml"] =
-                //                 $"<p style='color:red;'><strong>Unable to Connect to Server ({errorType})</strong></p>" +
-                //                 "<p>The API server is currently unreachable or not responding.</p>" +
-                //                 "<p>The project data cannot be loaded at this moment.</p>" +
-                //                 $"<p style='color:gray; font-size:0.9em;'>Error: {ex.Message}</p>" +
-                //                 "<p><strong>Would you like to retry?</strong></p>",
-                //             ["YesText"] = "Retry",
-                //             ["NoText"] = "Go to Projects List"
-                //         };
-                //     }
-                //     else
-                //     {
-                //         parameters = new DialogParameters
-                //         {
-                //             ["Title"] = "Error Loading Project",
-                //             ["MessageHtml"] =
-                //                 "<p style='color:red;'><strong>An Unexpected Error Occurred</strong></p>" +
-                //                 $"<p>Error: {ex.Message}</p>" +
-                //                 "<p><strong>Would you like to retry?</strong></p>",
-                //             ["YesText"] = "Retry",
-                //             ["NoText"] = "Go to Projects List"
-                //         };
-                //     }
-
-                //     var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
-                //         parameters["Title"].ToString(),
-                //         parameters,
-                //         options);
-
-                //     var result = await dialog.Result;
-
-                //     if (result.Data is bool retry && retry)
-                //     {
-                //         _logger.LogInformation(
-                //             "User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.",
-                //             errorType,
-                //             ProjectId);
-
-                //         await Task.Delay(2000);
-                //         continue;
-                //     }
-                //     else
-                //     {
-                //         _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
-                //         NavManager.NavigateTo("/projects", forceLoad: true);
-                //         loadingSuccessful = true;
-                //     }
-                // }
-
-                #endregion
+                await ConvertMarkdownToHtml(singleProject.Description);
             }
 
-            // // -------------------------------
-            // // Initialize SignalR connection
-            // // -------------------------------
-            // try
-            // {
-            //     hubConnection = new HubConnectionBuilder()
-            //         .WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
-            //         .WithAutomaticReconnect()
-            //         .Build();
+            initializingPage = false;
+            StateHasChanged();
 
-            //     // Listen for project deleted notifications
-            //     hubConnection.On<Guid>(
-            //         SignalRConstants.ProjectEvents.ProjectDeleted,
-            //         OnProjectDeletedAsync);
-
-            //     // Listen for project updated notifications
-            //     hubConnection.On<Guid>(
-            //         SignalRConstants.ProjectEvents.ProjectModified,
-            //         OnProjectUpdatedAsync);
-
-            //     // Listen for project created notifications
-            //     hubConnection.On<Guid>(
-            //         SignalRConstants.ProjectEvents.ProjectCreated,
-            //         OnProjectCreatedAsync);
-
-            //     await hubConnection.StartAsync();
-
-            //     // Subscribe to notifications for the current project
-            //     if (hubConnection.State == HubConnectionState.Connected)
-            //     {
-            //         await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
-            //         _logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
-            //     }
-            // }
-            // catch (Exception ex)
-            // {
-            //     _logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
-            // }
-
-
+            // ALWAYS run navigation blocker after render if kiosk mode is active
+            if (ViewSettings.IsKioskMode)
+            {
+                await NavigationBlocker.Enable();
+            }
         }
     }
 
@@ -401,93 +188,4 @@
     {
         TreeNodeItemzSelectionService.ScrollToTreeViewNode(ProjectId);
     }
-
-    // #region SignalR Event Handlers including overall Dispose method
-    // /// <summary>
-    // /// Called when server broadcasts that this project was deleted.
-    // /// Receives only the ProjectId - we already have the project details.
-    // /// </summary>
-    // private async Task OnProjectDeletedAsync(Guid projectIdDeleted)
-    // {
-    //     // Only process if this is for the current project
-    //     if (projectIdDeleted != ProjectId)
-    //         return;
-
-    //     _logger.LogInformation(
-    //         $"Received notification: Project {projectIdDeleted} was deleted");
-
-    //     // Use the already-loaded project details from singleProject
-    //     var parameters = new DialogParameters<DeletedProjectDialog>
-    //     {
-    //         { x => x.ProjectId, projectIdDeleted },
-    //         { x => x.ProjectName, singleProject?.Name ?? "Unknown Project" }
-    //     };
-
-    //     var dialog = await DialogService.ShowAsync<DeletedProjectDialog>(
-    //         "Project Deleted",
-    //         parameters);
-
-    //     var result = await dialog.Result;
-
-    //     // Navigate away if user confirmed
-    //     if (!result.Canceled)
-    //     {
-    //         NavManager.NavigateTo("/Projects", forceLoad: true);
-    //     }
-    // }
-
-    // /// <summary>
-    // /// Called when server broadcasts that this project was updated.
-    // /// Receives only the ProjectId.
-    // /// </summary>
-    // private async Task OnProjectUpdatedAsync(Guid projectIdUpdated)
-    // {
-    //     if (projectIdUpdated != ProjectId)
-    //         return;
-
-    //     _logger.LogInformation(
-    //         $"Project {projectIdUpdated} was updated");
-
-    //     // Optionally refresh the project data if needed
-    //     // await LoadProjectDataAsync();
-    //     // StateHasChanged();
-    // }
-
-    // /// <summary>
-    // /// Called when server broadcasts that this project was created.
-    // /// Receives only the ProjectId.
-    // /// </summary>
-    // private async Task OnProjectCreatedAsync(Guid projectIdCreated)
-    // {
-    //     if (projectIdCreated != ProjectId)
-    //         return;
-
-    //     _logger.LogInformation(
-    //         $"Project {projectIdCreated} was created");
-    //     // Optionally refresh the project data if needed
-    //     // await LoadProjectDataAsync();
-    //     // StateHasChanged();
-    // }
-
-
-
-    // public async ValueTask DisposeAsync()
-    // {
-
-    //     // Cleanup SignalR connection
-    //     if (hubConnection is not null)
-    //     {
-    //         try
-    //         {
-    //             await hubConnection.InvokeAsync("UnsubscribeFromProjectAsync", ProjectId);
-    //             await hubConnection.DisposeAsync();
-    //         }
-    //         catch (Exception ex)
-    //         {
-    //             _logger.LogError($"Error disposing hub connection: {ex.Message}");
-    //         }
-    //     }
-    // }
-
-    // #endregion
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -7,175 +7,480 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.Project
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Components.Pages.SharedComponents
+@using OpenRose.WebUI.Constants
 @using OpenRose.WebUI.Services
+@using OpenRose.WebUI.Services.NotificationHub
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.SignalR.Client
 @inject NavigationBlockerService NavigationBlocker
+@inject NavigationManager NavManager
+@inject ProjectDeletionService DeletionService
 @inject ViewSettingsService ViewSettings
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<ProjectDetailsComponent> _logger
 
 <MudGrid>
-	@if (initializingPage)
-	{
-		<MudPaper Height="calc(100vh - 100px);" Width="100%">
-			<MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
-				<MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
-				<br />
-				<MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
-			</MudOverlay>
-		</MudPaper>
-	}
-	else
-	{
- 		<MudItem xs="12" sm="12">
-			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-				<MudCardContent Style="padding:6px">
+    @if (initializingPage)
+    {
+        <MudPaper Height="calc(100vh - 100px);" Width="100%">
+            <MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
+                <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
+                <br />
+                <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+            </MudOverlay>
+        </MudPaper>
+    }
+    else
+    {
+        <MudItem xs="12" sm="12">
+            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
+                <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
-						<!-- Left side: Title -->
-						<MudText Typo="Typo.inherit"
-								 Class="flex-grow-1 text-responsive-title"
-								 Align="Align.Left"
-								 Style="white-space:normal; overflow-wrap:break-word;">
-							<strong>@singleProject.Name</strong>
-						</MudText>
+                        <!-- Left side: Title -->
+                        <MudText Typo="Typo.inherit"
+                                 Class="flex-grow-1 text-responsive-title"
+                                 Align="Align.Left"
+                                 Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@singleProject.Name</strong>
+                        </MudText>
 
-						<div class="d-flex align-top flex-shrink-0">
+                        <div class="d-flex align-top flex-shrink-0">
 
-						<!-- Right side: Only Down button -->
-						<MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
-							<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-										   Color="Color.Success"
-										   Size="Size.Medium"
-										   IconSize="Size.Large"
-										   Variant="Variant.Filled"
-										   Class="mud-rounded-circle"
-										   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
-						</MudItem>
-						</div>
-					</div>
-				</MudCardContent>
-			</MudCard>
+                            <!-- Right side: Only Down button -->
+                            <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                                <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+                                               Color="Color.Success"
+                                               Size="Size.Medium"
+                                               IconSize="Size.Large"
+                                               Variant="Variant.Filled"
+                                               Class="mud-rounded-circle"
+                                               OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
+                            </MudItem>
+                        </div>
+                    </div>
+                </MudCardContent>
+            </MudCard>
 
-			<MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
-				<MudCardContent>
-@* 					<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
+                <MudCardContent>
+                    @* 					<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
 						<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
 							<MudText><strong>ID :</strong></MudText>
 							<CopyableText TextToCopy="@singleProject.Id.ToString()" />
 						</MudStack>
 						<MudText><strong>Status :</strong> @singleProject.Status</MudText>
 					</MudStack> *@
-					@if (!ViewSettings.IsKioskMode)
-					{
-                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
-                        <div style="
-                                    display:flex;
-                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
-                                    align-items:flex-start;
-                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
-                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
-                                    ">
-							<div style="display:flex; align-items:center; gap:6px;">
-								<strong>ID : </strong>
-								<CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
-								<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
-									<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
-								</MudTooltip>
-							</div>
-							@if (ViewSettings.ShowPropertiesInReadOnlyViews)
-							{
-								<div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleProject.Status </div>
-								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong>  <EstimationReadOnlyComponent RecordId="@ProjectId" /> </div>
-							}
-							</div>
-					</MudBreakpointProvider>
-					}
+                    @if (!ViewSettings.IsKioskMode)
+                    {
+                        <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                            <div style="
+                                            display:flex;
+                                            gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                            align-items:flex-start;
+                                            flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                            flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                            ">
+                                <div style="display:flex; align-items:center; gap:6px;">
+                                    <strong>ID : </strong>
+                                    <CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
+                                    <MudTooltip Text="Show in Tree View" Placement="Placement.Top">
+                                        <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
+                                    </MudTooltip>
+                                </div>
+                                @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                                {
+                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleProject.Status </div>
+                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong>  <EstimationReadOnlyComponent RecordId="@ProjectId" /> </div>
+                                }
+                            </div>
+                        </MudBreakpointProvider>
+                    }
 
-					<br />
-					<div class="custom-markdown-editor">
-						@if (!string.IsNullOrEmpty(singleProject.Description))
-						{
-							<div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
-						}
-					</div>
-				</MudCardContent>
-			</MudCard>
-		</MudItem>
-		<br />
-	}
+                    <br />
+                    <div class="custom-markdown-editor">
+                        @if (singleProject != null && !(string.IsNullOrEmpty(singleProject.Description)))
+                        {
+                            <div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
+                        }
+                    </div>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <br />
+    }
 </MudGrid>
 @if (_showOverlay)
 {
-	<MudPaper Height="calc(100vh - 100px);" Width="100%">
-		<MudOverlay Visible="@_showOverlay" DarkBackground="true" Absolute="true">
-			<MudContainer Class="d-flex flex-column justify-center align-center" Style="height: 100%;">
-				@* <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Moving ... </MudText>
+    <MudPaper Height="calc(100vh - 100px);" Width="100%">
+        <MudOverlay Visible="@_showOverlay" DarkBackground="true" Absolute="true">
+            <MudContainer Class="d-flex flex-column justify-center align-center" Style="height: 100%;">
+                @* <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Moving ... </MudText>
 			<br /> *@
-				<MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
-			</MudContainer>
-		</MudOverlay>
-	</MudPaper>
+                <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+            </MudContainer>
+        </MudOverlay>
+    </MudPaper>
 }
 @code {
-	[Parameter]
-	public Guid ProjectId { get; set; }
+    [Parameter]
+    public Guid ProjectId { get; set; }
 
-	[Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
+    [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
 
-	[Inject]
-	public IProjectService ProjectService { get; set; }
+    [Inject]
+    public IProjectService ProjectService { get; set; }
 
-	public GetProjectDTO singleProject { get; set; } = new();
-	public bool initializingPage { get; set; } = true;
-	public bool _showOverlay { get; set; } = false;
+    public GetProjectDTO singleProject { get; set; } = new();
+    public bool initializingPage { get; set; } = true;
+    public bool _showOverlay { get; set; } = false;
 
-	private MarkupString convertedMarkdown;
+    private MarkupString convertedMarkdown;
 
-	private Breakpoint bp;
+    private Breakpoint bp;
 
-	protected override async Task OnAfterRenderAsync(bool firstRender)
-	{
-		if (firstRender)
-		{
-			initializingPage = true;
-			StateHasChanged();
-			await Task.Delay(300);
-			singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
-			if (singleProject != null && singleProject.Description != null)
-			{
-				await ConvertMarkdownToHtml(singleProject.Description);
-			}
+    // //SignalR Hub Connection
+    // private HubConnection? hubConnection;
 
-			initializingPage = false;
-			StateHasChanged();
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            initializingPage = true;
+            StateHasChanged();
+            await Task.Delay(300);
 
-			// ALWAYS run navigation blocker after render if kiosk mode is active
-			if (ViewSettings.IsKioskMode)
-			{
-				await NavigationBlocker.Enable();
-			}
+            bool loadingSuccessful = false;
+            while (!loadingSuccessful)
+            {
+                try
+                {
 
-		}
-	}
+                    singleProject = await ProjectService.__Single_Project_By_GUID_ID__Async(ProjectId);
 
-	private async Task ConvertMarkdownToHtml(string markdown)
-	{
-		if (!string.IsNullOrEmpty(markdown))
-		{
-			var html = await JS.InvokeAsync<string>("markdownToHtml", markdown);
-			convertedMarkdown = (MarkupString)html;
-			StateHasChanged();
+                    if (singleProject == null)
+                    {
+                        throw new ApplicationException($"Either API Server is unavailable OR Project with ID {ProjectId} has been deleted.");
+                    }
 
-		}
-	}
+                    if (singleProject != null && singleProject.Description != null)
+                    {
+                        await ConvertMarkdownToHtml(singleProject.Description);
+                    }
 
-	private void findAndShowInTreeView()
-	{
-		TreeNodeItemzSelectionService.ScrollToTreeViewNode(ProjectId);
-	}
+                    initializingPage = false;
+                    StateHasChanged();
+
+                    // ALWAYS run navigation blocker after render if kiosk mode is active
+                    if (ViewSettings.IsKioskMode)
+                    {
+                        await NavigationBlocker.Enable();
+                    }
+
+                    // 🔑 MARK LOADING AS SUCCESSFUL
+                    loadingSuccessful = true;
+                }
+                catch (ApplicationException ex)
+                {
+                    // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                    _logger.LogWarning(
+                        ex,
+                        "Either API Server is unavailable OR requested project has been deleted.",
+                        ProjectId);
+
+                    initializingPage = true;
+
+                    // Show error dialog with retry option
+                    var retryOptions = new DialogOptions
+                    {
+                        CloseButton = false
+                    };
+
+                    var dialogResult = await DialogService.ShowMessageBox(
+                        title: "Connection Error",
+                        markupMessage: new MarkupString(
+                            $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+                            $"<p>Either API server is currently unreachable OR</p>" +
+                            $"<p>The requested project has been deleted.</p>" +
+                            $"<p><strong>Would you like to retry?</strong></p>"
+                        ),
+                        yesText: "Retry",
+                        noText: "Go to Home",
+                        options: retryOptions
+                    );
+
+                    // USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+                    if (dialogResult == true)
+                    {
+                        _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+                        // Wait 1 seconds before retrying to give server time to recover
+                        await Task.Delay(1000);
+                        // showLoadingMessage = true;
+                        // StateHasChanged();
+                        // Continue the loop to retry
+                        continue;
+                    }
+                    else
+                    {
+                        // USER CLICKED "GO TO Home Screen"
+                        _logger.LogInformation("User chose to go to home screen");
+                        NavManager.NavigateTo("/");
+                        loadingSuccessful = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // HANDLE ANY OTHER UNEXPECTED ERRORS
+                    // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
+                    bool isConnectionError = false;
+                    string errorType = "Unknown Error";
+
+                    if (ex is OperationCanceledException)
+                    {
+                        isConnectionError = true;
+                        errorType = "Connection Timeout";
+                    }
+                    else if (ex.InnerException is HttpRequestException)
+                    {
+                        isConnectionError = true;
+                        errorType = "Connection Error";
+                    }
+                    else if (ex.InnerException is OperationCanceledException)
+                    {
+                        isConnectionError = true;
+                        errorType = "Connection Timeout";
+                    }
+                    else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+                    {
+                        isConnectionError = true;
+                        errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
+                    }
+
+                    _logger.LogError(
+                        ex,
+                        "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+                        ProjectId,
+                        errorType,
+                        isConnectionError,
+                        ex.Message);
+
+                    var retryOptions = new DialogOptions
+                    {
+                        CloseButton = false
+                    };
+
+                    // If it's a connection error, treat it as such
+                    if (isConnectionError)
+                    {
+                        var dialogResult = await DialogService.ShowMessageBox(
+                            "Connection Error",
+                            markupMessage: new MarkupString(
+                                $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+                                $"<p>The API server is currently unreachable or not responding.</p>" +
+                                $"<p>The project data cannot be loaded at this moment.</p>" +
+                                $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
+                                $"<p><strong>Would you like to retry?</strong></p>"
+                            ),
+                            yesText: "Retry",
+                            noText: "Go to Projects List",
+                            options: retryOptions
+                        );
+
+                        if (dialogResult == true)
+                        {
+                            _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
+                            await Task.Delay(2000);
+                            continue;
+                        }
+                        else
+                        {
+                            _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+                            NavManager.NavigateTo("/projects", forceLoad: true);
+                            loadingSuccessful = true;
+                        }
+                    }
+                    else
+                    {
+                        // Show generic error message with retry for other unexpected errors
+                        var dialogResult = await DialogService.ShowMessageBox(
+                            "Error Loading Project",
+                            markupMessage: new MarkupString(
+                                $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
+                                $"<p>Error: {ex.Message}</p>" +
+                                $"<p><strong>Would you like to retry?</strong></p>"
+                            ),
+                            yesText: "Retry",
+                            noText: "Go to Projects List",
+                            options: retryOptions
+                        );
+
+                        if (dialogResult == true)
+                        {
+                            _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
+                            await Task.Delay(2000);
+                            continue;
+                        }
+                        else
+                        {
+                            _logger.LogInformation("User chose to go to projects list after error");
+                            NavManager.NavigateTo("/projects", forceLoad: true);
+                            loadingSuccessful = true;
+                        }
+                    }
+                }
+            }
+
+            // // -------------------------------
+            // // Initialize SignalR connection
+            // // -------------------------------
+            // try
+            // {
+            //     hubConnection = new HubConnectionBuilder()
+            //         .WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
+            //         .WithAutomaticReconnect()
+            //         .Build();
+
+            //     // Listen for project deleted notifications
+            //     hubConnection.On<Guid>(
+            //         SignalRConstants.ProjectEvents.ProjectDeleted,
+            //         OnProjectDeletedAsync);
+
+            //     // Listen for project updated notifications
+            //     hubConnection.On<Guid>(
+            //         SignalRConstants.ProjectEvents.ProjectModified,
+            //         OnProjectUpdatedAsync);
+
+            //     // Listen for project created notifications
+            //     hubConnection.On<Guid>(
+            //         SignalRConstants.ProjectEvents.ProjectCreated,
+            //         OnProjectCreatedAsync);
+
+            //     await hubConnection.StartAsync();
+
+            //     // Subscribe to notifications for the current project
+            //     if (hubConnection.State == HubConnectionState.Connected)
+            //     {
+            //         await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+            //         _logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+            //     }
+            // }
+            // catch (Exception ex)
+            // {
+            //     _logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
+            // }
+
+
+        }
+    }
+
+    private async Task ConvertMarkdownToHtml(string markdown)
+    {
+        if (!string.IsNullOrEmpty(markdown))
+        {
+            var html = await JS.InvokeAsync<string>("markdownToHtml", markdown);
+            convertedMarkdown = (MarkupString)html;
+            StateHasChanged();
+
+        }
+    }
+
+    private void findAndShowInTreeView()
+    {
+        TreeNodeItemzSelectionService.ScrollToTreeViewNode(ProjectId);
+    }
+
+    // #region SignalR Event Handlers including overall Dispose method
+    // /// <summary>
+    // /// Called when server broadcasts that this project was deleted.
+    // /// Receives only the ProjectId - we already have the project details.
+    // /// </summary>
+    // private async Task OnProjectDeletedAsync(Guid projectIdDeleted)
+    // {
+    //     // Only process if this is for the current project
+    //     if (projectIdDeleted != ProjectId)
+    //         return;
+
+    //     _logger.LogInformation(
+    //         $"Received notification: Project {projectIdDeleted} was deleted");
+
+    //     // Use the already-loaded project details from singleProject
+    //     var parameters = new DialogParameters<DeletedProjectDialog>
+    //     {
+    //         { x => x.ProjectId, projectIdDeleted },
+    //         { x => x.ProjectName, singleProject?.Name ?? "Unknown Project" }
+    //     };
+
+    //     var dialog = await DialogService.ShowAsync<DeletedProjectDialog>(
+    //         "Project Deleted",
+    //         parameters);
+
+    //     var result = await dialog.Result;
+
+    //     // Navigate away if user confirmed
+    //     if (!result.Canceled)
+    //     {
+    //         NavManager.NavigateTo("/Projects", forceLoad: true);
+    //     }
+    // }
+
+    // /// <summary>
+    // /// Called when server broadcasts that this project was updated.
+    // /// Receives only the ProjectId.
+    // /// </summary>
+    // private async Task OnProjectUpdatedAsync(Guid projectIdUpdated)
+    // {
+    //     if (projectIdUpdated != ProjectId)
+    //         return;
+
+    //     _logger.LogInformation(
+    //         $"Project {projectIdUpdated} was updated");
+
+    //     // Optionally refresh the project data if needed
+    //     // await LoadProjectDataAsync();
+    //     // StateHasChanged();
+    // }
+
+    // /// <summary>
+    // /// Called when server broadcasts that this project was created.
+    // /// Receives only the ProjectId.
+    // /// </summary>
+    // private async Task OnProjectCreatedAsync(Guid projectIdCreated)
+    // {
+    //     if (projectIdCreated != ProjectId)
+    //         return;
+
+    //     _logger.LogInformation(
+    //         $"Project {projectIdCreated} was created");
+    //     // Optionally refresh the project data if needed
+    //     // await LoadProjectDataAsync();
+    //     // StateHasChanged();
+    // }
+
+
+
+    // public async ValueTask DisposeAsync()
+    // {
+
+    //     // Cleanup SignalR connection
+    //     if (hubConnection is not null)
+    //     {
+    //         try
+    //         {
+    //             await hubConnection.InvokeAsync("UnsubscribeFromProjectAsync", ProjectId);
+    //             await hubConnection.DisposeAsync();
+    //         }
+    //         catch (Exception ex)
+    //         {
+    //             _logger.LogError($"Error disposing hub connection: {ex.Message}");
+    //         }
+    //     }
+    // }
+
+    // #endregion
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -679,8 +679,8 @@
                     else
                     {
                         _logger.LogInformation("User chose to go to home screen");
-                        NavManager.NavigateTo("/");
                         loadingSuccessful = true;
+                        NavManager.NavigateTo("/");
                     }
                 }
                 // catch (Exception ex)
@@ -1013,55 +1013,6 @@
             }
             catch (ApplicationException ex)
             {
-                // // // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
-                // // _logger.LogWarning(
-                // //     ex,
-                // //     "Either API Server is unavailable OR requested project has been deleted.",
-                // //     ProjectId);
-
-                // // showLoadingMessage = false;
-                // // StateHasChanged();
-
-                // // // Show error dialog with retry option
-                // // var retryOptions = new DialogOptions
-                // //     {
-                // //         CloseButton = false,
-                // //         BackdropClick = false,
-                // //         CloseOnEscapeKey = false
-                // //     };
-
-                // // var dialogResult = await DialogService.ShowMessageBox(
-                // //     title: "Connection Error",
-                // //     markupMessage: new MarkupString(
-                // //         $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
-                // //         $"<p>Either API server is currently unreachable OR</p>" +
-                // //         $"<p>The requested project has been deleted.</p>" +
-                // //         $"<p><strong>Would you like to retry?</strong></p>"
-                // //     ),
-                // //     yesText: "Retry",
-                // //     noText: "Go to Home",
-                // //     options: retryOptions
-                // // );
-
-                // // // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
-                // // if (dialogResult == true)
-                // // {
-                // //     _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
-                // //     // Wait 1 seconds before retrying to give server time to recover
-                // //     await Task.Delay(1000);
-                // //     showLoadingMessage = true;
-                // //     StateHasChanged();
-                // //     // Continue the loop to retry
-                // //     continue;
-                // // }
-                // // else
-                // // {
-                // //     // 🔑 USER CLICKED "GO TO Home Screen"
-                // //     _logger.LogInformation("User chose to go to home screen");
-                // //     NavManager.NavigateTo("/");
-                // //     loadingSuccessful = true;
-                // // }
-
                 // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
                 _logger.LogWarning(
                     ex,
@@ -1112,8 +1063,8 @@
                 else
                 {
                     _logger.LogInformation("User chose to go to home screen");
-                    NavManager.NavigateTo("/");
                     loadingSuccessful = true;
+                    NavManager.NavigateTo("/");
                 }
             }
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -989,8 +989,67 @@
         ViewSettings.ReadOnlyView = newValue;
         await SessionStorage.SetAsync("READONLYVIEW", newValue);
 
-        // Reload hierarchy because visibility depends on mode
-        InitialTreeItems = await LoadAllProjectHierarchyData(ProjectId);
+        bool loadingSuccessful = false;
+        while (!loadingSuccessful)
+        {
+            try
+            {
+                // Reload hierarchy because visibility depends on mode
+                InitialTreeItems = await LoadAllProjectHierarchyData(ProjectId);
+                loadingSuccessful = true;
+            }
+            catch (ApplicationException ex)
+            {
+                // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                _logger.LogWarning(
+                    ex,
+                    "Either API Server is unavailable OR requested project has been deleted.",
+                    ProjectId);
+
+                showLoadingMessage = false;
+                StateHasChanged();
+
+                // Show error dialog with retry option
+                var retryOptions = new DialogOptions
+                    {
+                        CloseButton = false,
+                        BackdropClick = false,
+                        CloseOnEscapeKey = false
+                    };
+
+                var dialogResult = await DialogService.ShowMessageBox(
+                    title: "Connection Error",
+                    markupMessage: new MarkupString(
+                        $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+                        $"<p>Either API server is currently unreachable OR</p>" +
+                        $"<p>The requested project has been deleted.</p>" +
+                        $"<p><strong>Would you like to retry?</strong></p>"
+                    ),
+                    yesText: "Retry",
+                    noText: "Go to Home",
+                    options: retryOptions
+                );
+
+                // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+                if (dialogResult == true)
+                {
+                    _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+                    // Wait 1 seconds before retrying to give server time to recover
+                    await Task.Delay(1000);
+                    showLoadingMessage = true;
+                    StateHasChanged();
+                    // Continue the loop to retry
+                    continue;
+                }
+                else
+                {
+                    // 🔑 USER CLICKED "GO TO Home Screen"
+                    _logger.LogInformation("User chose to go to home screen");
+                    NavManager.NavigateTo("/");
+                    loadingSuccessful = true;
+                }
+            }
+        }
 
         // Hide Parking Lot only if empty and in read-only mode
         RemoveParkingLotIfEmpty(InitialTreeItems);

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -643,13 +643,13 @@
                         ["NoText"] = "Go to Home"
                     };
 
-                    // Show error dialog with retry option
-                    var retryOptions = new DialogOptions
-                    {
-                        CloseButton = false,
-                        BackdropClick = false,
-                        CloseOnEscapeKey = false
-                    };
+                    // // Show error dialog with retry option
+                    // var retryOptions = new DialogOptions
+                    // {
+                    //     CloseButton = false,
+                    //     BackdropClick = false,
+                    //     CloseOnEscapeKey = false
+                    // };
 
                     var options = new DialogOptions
                     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -629,7 +629,19 @@
                         ProjectId);
 
                     showLoadingMessage = false;
-                    StateHasChanged();
+                    // StateHasChanged();
+
+                    var parameters = new DialogParameters
+                    {
+                        ["Title"] = "Connection Error",
+                        ["MessageHtml"] =
+                            "<p style='color:red;'><strong>Unable to obtain Project Data</strong></p>" +
+                            "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+                            "<p>The requested project has been deleted.</p>" +
+                            "<p><strong>Would you like to retry?</strong></p>",
+                        ["YesText"] = "Retry",
+                        ["NoText"] = "Go to Home"
+                    };
 
                     // Show error dialog with retry option
                     var retryOptions = new DialogOptions
@@ -639,143 +651,143 @@
                         CloseOnEscapeKey = false
                     };
 
-                    var dialogResult = await DialogService.ShowMessageBox(
-                        title: "Connection Error",
-                        markupMessage: new MarkupString(
-                            $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
-                            $"<p>Either API server is currently unreachable OR</p>" +
-                            $"<p>The requested project has been deleted.</p>" +
-                            $"<p><strong>Would you like to retry?</strong></p>"
-                        ),
-                        yesText: "Retry",
-                        noText: "Go to Home",
-                        options: retryOptions
-                    );
-
-                    // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
-                    if (dialogResult == true)
-                    {
-                        _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
-                        // Wait 1 seconds before retrying to give server time to recover
-                        await Task.Delay(1000);
-                        showLoadingMessage = true;
-                        StateHasChanged();
-                        // Continue the loop to retry
-                        continue;
-                    }
-                    else
-                    {
-                        // 🔑 USER CLICKED "GO TO Home Screen"
-                        _logger.LogInformation("User chose to go to home screen");
-                        NavManager.NavigateTo("/");
-                        loadingSuccessful = true;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // 🔑 HANDLE ANY OTHER UNEXPECTED ERRORS
-                    // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
-                    bool isConnectionError = false;
-                    string errorType = "Unknown Error";
-
-                    if (ex is OperationCanceledException)
-                    {
-                        isConnectionError = true;
-                        errorType = "Connection Timeout";
-                    }
-                    else if (ex.InnerException is HttpRequestException)
-                    {
-                        isConnectionError = true;
-                        errorType = "Connection Error";
-                    }
-                    else if (ex.InnerException is OperationCanceledException)
-                    {
-                        isConnectionError = true;
-                        errorType = "Connection Timeout";
-                    }
-                    else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
-                    {
-                        isConnectionError = true;
-                        errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
-                    }
-
-                    _logger.LogError(
-                        ex,
-                        "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
-                        ProjectId,
-                        errorType,
-                        isConnectionError,
-                        ex.Message);
-
-                    showLoadingMessage = false;
-                    StateHasChanged();
-
-                    var retryOptions = new DialogOptions
+                    var options = new DialogOptions
                     {
                         CloseButton = false,
                         BackdropClick = false,
                         CloseOnEscapeKey = false
                     };
 
-                    // If it's a connection error, treat it as such
-                    if (isConnectionError)
-                    {
-                        var dialogResult = await DialogService.ShowMessageBox(
-                            "Connection Error",
-                            markupMessage: new MarkupString(
-                                $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
-                                $"<p>The API server is currently unreachable or not responding.</p>" +
-                                $"<p>The project data cannot be loaded at this moment.</p>" +
-                                $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
-                                $"<p><strong>Would you like to retry?</strong></p>"
-                            ),
-                            yesText: "Retry",
-                            noText: "Go to Projects List",
-                            options: retryOptions
-                        );
+                    var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+                        "Connection Error",
+                        parameters,
+                        options);
 
-                        if (dialogResult == true)
-                        {
-                            _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
-                            await Task.Delay(2000);
-                            continue;
-                        }
-                        else
-                        {
-                            _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
-                            NavManager.NavigateTo("/projects", forceLoad: true);
-                            loadingSuccessful = true;
-                        }
+                    var dialogResult = await dialog.Result;
+
+                    if (dialogResult != null && dialogResult.Data is bool retry && retry)
+                    {
+                        _logger.LogInformation(
+                            "User chose to retry loading project {ProjectId}. Waiting 1 second before retry.",
+                            ProjectId);
+
+                        showLoadingMessage = true;
+
+                        await Task.Delay(1000);
+                        continue;   // retry loop
                     }
                     else
                     {
-                        // Show generic error message with retry for other unexpected errors
-                        var dialogResult = await DialogService.ShowMessageBox(
-                            "Error Loading Project",
-                            markupMessage: new MarkupString(
-                                $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
-                                $"<p>Error: {ex.Message}</p>" +
-                                $"<p><strong>Would you like to retry?</strong></p>"
-                            ),
-                            yesText: "Retry",
-                            noText: "Go to Projects List",
-                            options: retryOptions
-                        );
-
-                        if (dialogResult == true)
-                        {
-                            _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
-                            await Task.Delay(2000);
-                            continue;
-                        }
-                        else
-                        {
-                            _logger.LogInformation("User chose to go to projects list after error");
-                            NavManager.NavigateTo("/projects", forceLoad: true);
-                            loadingSuccessful = true;
-                        }
+                        _logger.LogInformation("User chose to go to home screen");
+                        NavManager.NavigateTo("/");
+                        loadingSuccessful = true;
                     }
                 }
+                // catch (Exception ex)
+                // {
+                //     // 🔑 HANDLE ANY OTHER UNEXPECTED ERRORS
+                //     // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
+                //     bool isConnectionError = false;
+                //     string errorType = "Unknown Error";
+
+                //     if (ex is OperationCanceledException)
+                //     {
+                //         isConnectionError = true;
+                //         errorType = "Connection Timeout";
+                //     }
+                //     else if (ex.InnerException is HttpRequestException)
+                //     {
+                //         isConnectionError = true;
+                //         errorType = "Connection Error";
+                //     }
+                //     else if (ex.InnerException is OperationCanceledException)
+                //     {
+                //         isConnectionError = true;
+                //         errorType = "Connection Timeout";
+                //     }
+                //     else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+                //     {
+                //         isConnectionError = true;
+                //         errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
+                //     }
+
+                //     _logger.LogError(
+                //         ex,
+                //         "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+                //         ProjectId,
+                //         errorType,
+                //         isConnectionError,
+                //         ex.Message);
+
+                //     showLoadingMessage = false;
+                //     StateHasChanged();
+
+                //     var retryOptions = new DialogOptions
+                //     {
+                //         CloseButton = false,
+                //         BackdropClick = false,
+                //         CloseOnEscapeKey = false
+                //     };
+
+                //     // If it's a connection error, treat it as such
+                //     if (isConnectionError)
+                //     {
+                //         var dialogResult = await DialogService.ShowMessageBox(
+                //             "Connection Error",
+                //             markupMessage: new MarkupString(
+                //                 $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+                //                 $"<p>The API server is currently unreachable or not responding.</p>" +
+                //                 $"<p>The project data cannot be loaded at this moment.</p>" +
+                //                 $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
+                //                 $"<p><strong>Would you like to retry?</strong></p>"
+                //             ),
+                //             yesText: "Retry",
+                //             noText: "Go to Projects List",
+                //             options: retryOptions
+                //         );
+
+                //         if (dialogResult == true)
+                //         {
+                //             _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
+                //             await Task.Delay(2000);
+                //             continue;
+                //         }
+                //         else
+                //         {
+                //             _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+                //             NavManager.NavigateTo("/projects", forceLoad: true);
+                //             loadingSuccessful = true;
+                //         }
+                //     }
+                //     else
+                //     {
+                //         // Show generic error message with retry for other unexpected errors
+                //         var dialogResult = await DialogService.ShowMessageBox(
+                //             "Error Loading Project",
+                //             markupMessage: new MarkupString(
+                //                 $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
+                //                 $"<p>Error: {ex.Message}</p>" +
+                //                 $"<p><strong>Would you like to retry?</strong></p>"
+                //             ),
+                //             yesText: "Retry",
+                //             noText: "Go to Projects List",
+                //             options: retryOptions
+                //         );
+
+                //         if (dialogResult == true)
+                //         {
+                //             _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
+                //             await Task.Delay(2000);
+                //             continue;
+                //         }
+                //         else
+                //         {
+                //             _logger.LogInformation("User chose to go to projects list after error");
+                //             NavManager.NavigateTo("/projects", forceLoad: true);
+                //             loadingSuccessful = true;
+                //         }
+                //     }
+                // }
             }
 
             // 🔑 INITIALIZE SIGNALR CONNECTION TO THE HUB (Only if project loaded successfully)
@@ -997,9 +1009,59 @@
                 // Reload hierarchy because visibility depends on mode
                 InitialTreeItems = await LoadAllProjectHierarchyData(ProjectId);
                 loadingSuccessful = true;
+                showLoadingMessage = false;
             }
             catch (ApplicationException ex)
             {
+                // // // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                // // _logger.LogWarning(
+                // //     ex,
+                // //     "Either API Server is unavailable OR requested project has been deleted.",
+                // //     ProjectId);
+
+                // // showLoadingMessage = false;
+                // // StateHasChanged();
+
+                // // // Show error dialog with retry option
+                // // var retryOptions = new DialogOptions
+                // //     {
+                // //         CloseButton = false,
+                // //         BackdropClick = false,
+                // //         CloseOnEscapeKey = false
+                // //     };
+
+                // // var dialogResult = await DialogService.ShowMessageBox(
+                // //     title: "Connection Error",
+                // //     markupMessage: new MarkupString(
+                // //         $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+                // //         $"<p>Either API server is currently unreachable OR</p>" +
+                // //         $"<p>The requested project has been deleted.</p>" +
+                // //         $"<p><strong>Would you like to retry?</strong></p>"
+                // //     ),
+                // //     yesText: "Retry",
+                // //     noText: "Go to Home",
+                // //     options: retryOptions
+                // // );
+
+                // // // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+                // // if (dialogResult == true)
+                // // {
+                // //     _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+                // //     // Wait 1 seconds before retrying to give server time to recover
+                // //     await Task.Delay(1000);
+                // //     showLoadingMessage = true;
+                // //     StateHasChanged();
+                // //     // Continue the loop to retry
+                // //     continue;
+                // // }
+                // // else
+                // // {
+                // //     // 🔑 USER CLICKED "GO TO Home Screen"
+                // //     _logger.LogInformation("User chose to go to home screen");
+                // //     NavManager.NavigateTo("/");
+                // //     loadingSuccessful = true;
+                // // }
+
                 // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
                 _logger.LogWarning(
                     ex,
@@ -1007,43 +1069,48 @@
                     ProjectId);
 
                 showLoadingMessage = false;
-                StateHasChanged();
+                // StateHasChanged();
 
-                // Show error dialog with retry option
-                var retryOptions = new DialogOptions
-                    {
-                        CloseButton = false,
-                        BackdropClick = false,
-                        CloseOnEscapeKey = false
-                    };
-
-                var dialogResult = await DialogService.ShowMessageBox(
-                    title: "Connection Error",
-                    markupMessage: new MarkupString(
-                        $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
-                        $"<p>Either API server is currently unreachable OR</p>" +
-                        $"<p>The requested project has been deleted.</p>" +
-                        $"<p><strong>Would you like to retry?</strong></p>"
-                    ),
-                    yesText: "Retry",
-                    noText: "Go to Home",
-                    options: retryOptions
-                );
-
-                // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
-                if (dialogResult == true)
+                var parameters = new DialogParameters
                 {
-                    _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
-                    // Wait 1 seconds before retrying to give server time to recover
-                    await Task.Delay(1000);
+                    ["Title"] = "Connection Error",
+                    ["MessageHtml"] =
+                        "<p style='color:red;'><strong>Unable to obtain Project Data</strong></p>" +
+                        "<p>Either API server is currently unreachable</p> <p> OR</p>" +
+                        "<p>The requested project has been deleted.</p>" +
+                        "<p><strong>Would you like to retry?</strong></p>",
+                    ["YesText"] = "Retry",
+                    ["NoText"] = "Go to Home"
+                };
+
+                var options = new DialogOptions
+                {
+                    CloseButton = false,
+                    BackdropClick = false,
+                    CloseOnEscapeKey = false
+                };
+
+                var dialog = await DialogService.ShowAsync<ConnectionAndDataNotFoundErrorDialog>(
+                    "Connection Error",
+                    parameters,
+                    options);
+
+                var dialogResult = await dialog.Result;
+
+                if (dialogResult != null && dialogResult.Data is bool retry && retry)
+                {
+                    _logger.LogInformation(
+                        "User chose to retry loading project {ProjectId}. Waiting 1 second before retry.",
+                        ProjectId);
+
                     showLoadingMessage = true;
                     StateHasChanged();
-                    // Continue the loop to retry
-                    continue;
+
+                    await Task.Delay(1000);
+                    continue;   // retry loop
                 }
                 else
                 {
-                    // 🔑 USER CLICKED "GO TO Home Screen"
                     _logger.LogInformation("User chose to go to home screen");
                     NavManager.NavigateTo("/");
                     loadingSuccessful = true;

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -9,6 +9,7 @@
 @using OpenRose.WebUI.Client.Services.Hierarchy
 @using OpenRose.WebUI.Client.Services.Project
 @using OpenRose.WebUI.Client.SharedModels
+@using OpenRose.WebUI.Components.Dialogs
 @using OpenRose.WebUI.Components.EventServices
 @using OpenRose.WebUI.Components.Pages.Itemz
 @using OpenRose.WebUI.Components.Pages.ItemzType
@@ -16,7 +17,9 @@
 @using OpenRose.WebUI.Helper.TreeViewNodes
 @using OpenRose.WebUI.Components.FindServices
 @using OpenRose.WebUI.Services
+@using OpenRose.WebUI.Services.NotificationHub
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.SignalR.Client
 @using System.Collections.ObjectModel
 @inject IServiceProvider serviceProvider
 @inject NavigationManager NavManager
@@ -25,9 +28,11 @@
 @inject FullScreenService FullScreenService
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ILogger<ProjectTreeView> _logger
 @inject TreeNodeItemzSelectionService ItemzSelectionService
 @inject ViewSettingsService ViewSettings
 @inject ProtectedSessionStorage SessionStorage
+@inject ProjectDeletionService DeletionService
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             OnDoubleClicked="@OnDoubleClicked"
@@ -175,6 +180,9 @@
 
 
     public MudTreeView<Guid> projectMudTreeView;
+
+    //SignalR Hub Connection
+    private HubConnection? hubConnection;
 
     private bool showLoadingMessage = true;
 
@@ -556,57 +564,251 @@
                 await SessionStorage.SetAsync("SHOWPROPERTIESINREADONLYVIEWS", false);
             }
 
-            // Load initial data
-            InitialTreeItems = await LoadInitialData(ProjectId);
-            StateHasChanged();
-
-            // Load entire hierarchy
-            InitialTreeItems = await LoadAllProjectHierarchyData(ProjectId);
-
-            if (ViewSettings.ReadOnlyView)
+            // 🔑 TRY TO LOAD PROJECT DATA - DISTINGUISH BETWEEN DIFFERENT ERROR TYPES
+            bool loadingSuccessful = false;
+            while (!loadingSuccessful)
             {
-                // Apply Parking Lot hiding logic
-                RemoveParkingLotIfEmpty(InitialTreeItems);
+                try
+                {
+                    // Load initial data
+                    InitialTreeItems = await LoadInitialData(ProjectId);
+                    StateHasChanged();
+
+                    // Load entire hierarchy
+                    InitialTreeItems = await LoadAllProjectHierarchyData(ProjectId);
+
+                    if (ViewSettings.ReadOnlyView)
+                    {
+                        // Apply Parking Lot hiding logic
+                        RemoveParkingLotIfEmpty(InitialTreeItems);
+                    }
+
+                    // Build linear list once after full hierarchy is loaded
+                    _linearIds = InitialTreeItems.Flatten()
+                                                 .Select(x => x.Value)
+                                                 .ToList();
+
+                    _currentIndex = _linearIds.FindIndex(id => id == _selectedValue);
+
+                    // After building _linearIds in OnAfterRenderAsync
+                    if (_selectedValue == Guid.Empty && _linearIds.Count > 0)
+                    {
+                        _selectedValue = _linearIds[0]; // root project node
+                        _currentIndex = 0;
+
+                        // Keep tree in sync
+                        projectMudTreeView.SelectedValue = _selectedValue;
+
+                        // Update right-hand side content immediately
+                        await UpdateSelectedItem(_selectedValue);
+                    }
+
+                    showLoadingMessage = false;
+                    StateHasChanged();
+
+                    if (AutoSelectedRecordId.HasValue)
+                    {
+                        // Select the node after the first render
+                        await HandleItemzSelectedAsync(AutoSelectedRecordId.Value);
+                        AutoSelectedRecordId = null;
+                    }
+
+                    await JS.InvokeVoidAsync("initializeResizable");
+                    StateHasChanged();
+
+                    // 🔑 MARK LOADING AS SUCCESSFUL
+                    loadingSuccessful = true;
+                }
+                catch (ApplicationException ex)
+                {
+                    // 🔑 API SERVER IS UNREACHABLE (Network/Connection error)
+                    _logger.LogWarning(
+                        ex,
+                        "Either API Server is unavailable OR requested project has been deleted.",
+                        ProjectId);
+
+                    showLoadingMessage = false;
+                    StateHasChanged();
+
+                    // Show error dialog with retry option
+                    var retryOptions = new DialogOptions
+                    {
+                        CloseButton = false
+                    };
+
+                    var dialogResult = await DialogService.ShowMessageBox(
+                        title: "Connection Error",
+                        markupMessage: new MarkupString(
+                            $"<p style=\"color: red;\"><strong>Unable to obtain Project Data</strong></p>" +
+                            $"<p>Either API server is currently unreachable OR</p>" +
+                            $"<p>The requested project has been deleted.</p>" +
+                            $"<p><strong>Would you like to retry?</strong></p>"
+                        ),
+                        yesText: "Retry",
+                        noText: "Go to Home",
+                        options: retryOptions
+                    );
+
+                    // 🔑 USER CLICKED RETRY - LOOP CONTINUES AND TRIES AGAIN
+                    if (dialogResult == true)
+                    {
+                        _logger.LogInformation("User chose to retry loading project {ProjectId}. Waiting 2 seconds before retry.", ProjectId);
+                        // Wait 1 seconds before retrying to give server time to recover
+                        await Task.Delay(1000);
+                        showLoadingMessage = true;
+                        StateHasChanged();
+                        // Continue the loop to retry
+                        continue;
+                    }
+                    else
+                    {
+                        // 🔑 USER CLICKED "GO TO Home Screen"
+                        _logger.LogInformation("User chose to go to home screen");
+                        NavManager.NavigateTo("/");
+                        loadingSuccessful = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // 🔑 HANDLE ANY OTHER UNEXPECTED ERRORS
+                    // Check if this is a connection error wrapped in AggregateException or OperationCanceledException
+                    bool isConnectionError = false;
+                    string errorType = "Unknown Error";
+
+                    if (ex is OperationCanceledException)
+                    {
+                        isConnectionError = true;
+                        errorType = "Connection Timeout";
+                    }
+                    else if (ex.InnerException is HttpRequestException)
+                    {
+                        isConnectionError = true;
+                        errorType = "Connection Error";
+                    }
+                    else if (ex.InnerException is OperationCanceledException)
+                    {
+                        isConnectionError = true;
+                        errorType = "Connection Timeout";
+                    }
+                    else if (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(ie => ie is HttpRequestException || ie is OperationCanceledException))
+                    {
+                        isConnectionError = true;
+                        errorType = aggEx.InnerExceptions.OfType<OperationCanceledException>().Any() ? "Connection Timeout" : "Connection Error";
+                    }
+
+                    _logger.LogError(
+                        ex,
+                        "Error loading project {ProjectId}. Error Type: {ErrorType}. Is Connection Error: {IsConnectionError}. Message: {Message}",
+                        ProjectId,
+                        errorType,
+                        isConnectionError,
+                        ex.Message);
+
+                    showLoadingMessage = false;
+                    StateHasChanged();
+
+                    var retryOptions = new DialogOptions
+                    {
+                        CloseButton = false
+                    };
+
+                    // If it's a connection error, treat it as such
+                    if (isConnectionError)
+                    {
+                        var dialogResult = await DialogService.ShowMessageBox(
+                            "Connection Error",
+                            markupMessage: new MarkupString(
+                                $"<p style=\"color: red;\"><strong>Unable to Connect to Server ({errorType})</strong></p>" +
+                                $"<p>The API server is currently unreachable or not responding.</p>" +
+                                $"<p>The project data cannot be loaded at this moment.</p>" +
+                                $"<p style=\"color: gray; font-size: 0.9em;\">Error: {ex.Message}</p>" +
+                                $"<p><strong>Would you like to retry?</strong></p>"
+                            ),
+                            yesText: "Retry",
+                            noText: "Go to Projects List",
+                            options: retryOptions
+                        );
+
+                        if (dialogResult == true)
+                        {
+                            _logger.LogInformation("User chose to retry after {ErrorType} for project {ProjectId}. Waiting 2 seconds before retry.", errorType, ProjectId);
+                            await Task.Delay(2000);
+                            continue;
+                        }
+                        else
+                        {
+                            _logger.LogInformation("User chose to go to projects list after {ErrorType}", errorType);
+                            NavManager.NavigateTo("/projects", forceLoad: true);
+                            loadingSuccessful = true;
+                        }
+                    }
+                    else
+                    {
+                        // Show generic error message with retry for other unexpected errors
+                        var dialogResult = await DialogService.ShowMessageBox(
+                            "Error Loading Project",
+                            markupMessage: new MarkupString(
+                                $"<p style=\"color: red;\"><strong>An Unexpected Error Occurred</strong></p>" +
+                                $"<p>Error: {ex.Message}</p>" +
+                                $"<p><strong>Would you like to retry?</strong></p>"
+                            ),
+                            yesText: "Retry",
+                            noText: "Go to Projects List",
+                            options: retryOptions
+                        );
+
+                        if (dialogResult == true)
+                        {
+                            _logger.LogInformation("User chose to retry after error for project {ProjectId}", ProjectId);
+                            await Task.Delay(2000);
+                            continue;
+                        }
+                        else
+                        {
+                            _logger.LogInformation("User chose to go to projects list after error");
+                            NavManager.NavigateTo("/projects", forceLoad: true);
+                            loadingSuccessful = true;
+                        }
+                    }
+                }
             }
 
-            // Build linear list once after full hierarchy is loaded
-            _linearIds = InitialTreeItems.Flatten()
-                                         .Select(x => x.Value)
-                                         .ToList();
-
-            _currentIndex = _linearIds.FindIndex(id => id == _selectedValue);
-
-            // After building _linearIds in OnAfterRenderAsync
-            if (_selectedValue == Guid.Empty && _linearIds.Count > 0)
+            // 🔑 INITIALIZE SIGNALR CONNECTION TO THE HUB (Only if project loaded successfully)
+            if (loadingSuccessful && InitialTreeItems.Count > 0)
             {
-                _selectedValue = _linearIds[0]; // root project node
-                _currentIndex = 0;
+                try
+                {
+                    hubConnection = new HubConnectionBuilder()
+                        .WithUrl(NavManager.ToAbsoluteUri("/projectNotificationHub"))
+                        .WithAutomaticReconnect()
+                        .Build();
 
-                // Keep tree in sync
-                projectMudTreeView.SelectedValue = _selectedValue;
+                    // Listen for project deleted notifications - only receive ProjectId
+                    hubConnection.On<Guid>(
+                        "ProjectDeleted",
+                        OnProjectDeletedAsync);
 
-                // Update right-hand side content immediately
-                await UpdateSelectedItem(_selectedValue);
+                    // Listen for project updated notifications - only receive ProjectId
+                    hubConnection.On<Guid>(
+                        "ProjectUpdated",
+                        OnProjectUpdatedAsync);
 
+                    await hubConnection.StartAsync();
+
+                    // Subscribe to notifications for the current project
+                    if (hubConnection.State == HubConnectionState.Connected)
+                    {
+                        await hubConnection.InvokeAsync("SubscribeToProjectAsync", ProjectId);
+                        _logger.LogInformation($"Subscribed to notifications for project {ProjectId}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError($"Failed to connect to ProjectNotificationHub: {ex.Message}");
+                }
+
+                StateHasChanged();
             }
-
-            showLoadingMessage = false;
-            StateHasChanged();
-
-            if (AutoSelectedRecordId.HasValue)
-            {
-                // Select the node after the first render
-
-                // This Task.Delay is important to allow full
-                // rendering which could take some time for large project.
-                // await Task.Delay(500);
-
-                await HandleItemzSelectedAsync(AutoSelectedRecordId.Value);
-                AutoSelectedRecordId = null;
-            }
-
-            await JS.InvokeVoidAsync("initializeResizable");
-            StateHasChanged();
         }
     }
 
@@ -953,7 +1155,58 @@
 
         return endText;
     }
-    public void Dispose()
+
+    /// <summary>
+    /// Called when server broadcasts that this project was deleted.
+    /// Receives only the ProjectId - we already have the project details.
+    /// </summary>
+    private async Task OnProjectDeletedAsync(Guid projectIdDeleted)
+    {
+        // Only process if this is for the current project
+        if (projectIdDeleted != ProjectId)
+            return;
+
+        _logger.LogInformation(
+            $"Received notification: Project {projectIdDeleted} was deleted");
+
+        // Use the already-loaded project details from singleProject
+        var parameters = new DialogParameters<DeletedProjectDialog>
+        {
+            { x => x.ProjectId, projectIdDeleted },
+            { x => x.ProjectName, singleProject?.Name ?? "Unknown Project" }
+        };
+
+        var dialog = await DialogService.ShowAsync<DeletedProjectDialog>(
+            "Project Deleted",
+            parameters);
+
+        var result = await dialog.Result;
+
+        // Navigate away if user confirmed
+        if (!result.Canceled)
+        {
+            NavManager.NavigateTo("/Projects", forceLoad: true);
+        }
+    }
+
+    /// <summary>
+    /// Called when server broadcasts that this project was updated.
+    /// Receives only the ProjectId.
+    /// </summary>
+    private async Task OnProjectUpdatedAsync(Guid projectIdUpdated)
+    {
+        if (projectIdUpdated != ProjectId)
+            return;
+
+        _logger.LogInformation(
+            $"Project {projectIdUpdated} was updated");
+
+        // Optionally refresh the project data if needed
+        // await LoadProjectDataAsync();
+        // StateHasChanged();
+    }
+
+    public async ValueTask DisposeAsync()
     {
         // Always unsubscribe to avoid memory leaks
         ItemzSelectionService.OnTreeNodeItemzSelected -= HandleItemzSelectedAsync;
@@ -962,6 +1215,20 @@
         ItemzSelectionService.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
         ItemzSelectionService.OnTreeNodeItemzDeleted -= HandleItemzDeleted;
         ItemzSelectionService.OnCreatedNewItemzType -= HandleCreatedNewItemzTypeAsync;
+
+        // Cleanup SignalR connection
+        if (hubConnection is not null)
+        {
+            try
+            {
+                await hubConnection.InvokeAsync("UnsubscribeFromProjectAsync", ProjectId);
+                await hubConnection.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error disposing hub connection: {ex.Message}");
+            }
+        }
     }
 
  }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -634,7 +634,9 @@
                     // Show error dialog with retry option
                     var retryOptions = new DialogOptions
                     {
-                        CloseButton = false
+                        CloseButton = false,
+                        BackdropClick = false,
+                        CloseOnEscapeKey = false
                     };
 
                     var dialogResult = await DialogService.ShowMessageBox(
@@ -710,7 +712,9 @@
 
                     var retryOptions = new DialogOptions
                     {
-                        CloseButton = false
+                        CloseButton = false,
+                        BackdropClick = false,
+                        CloseOnEscapeKey = false
                     };
 
                     // If it's a connection error, treat it as such

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -16,6 +16,7 @@
 @using OpenRose.WebUI.Components.Pages.Common
 @using OpenRose.WebUI.Helper.TreeViewNodes
 @using OpenRose.WebUI.Components.FindServices
+@using OpenRose.WebUI.Constants
 @using OpenRose.WebUI.Services
 @using OpenRose.WebUI.Services.NotificationHub
 @using Microsoft.AspNetCore.Components.Forms
@@ -779,19 +780,24 @@
                 try
                 {
                     hubConnection = new HubConnectionBuilder()
-                        .WithUrl(NavManager.ToAbsoluteUri("/projectNotificationHub"))
+                        .WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.ProjectNotificationHub))
                         .WithAutomaticReconnect()
                         .Build();
 
-                    // Listen for project deleted notifications - only receive ProjectId
+                    // Listen for project deleted notifications
                     hubConnection.On<Guid>(
-                        "ProjectDeleted",
+                        SignalRConstants.ProjectEvents.ProjectDeleted,
                         OnProjectDeletedAsync);
 
-                    // Listen for project updated notifications - only receive ProjectId
+                    // Listen for project updated notifications
                     hubConnection.On<Guid>(
-                        "ProjectUpdated",
+                        SignalRConstants.ProjectEvents.ProjectModified,
                         OnProjectUpdatedAsync);
+
+                    // Listen for project created notifications
+                    hubConnection.On<Guid>(
+                        SignalRConstants.ProjectEvents.ProjectCreated,
+                        OnProjectCreatedAsync);
 
                     await hubConnection.StartAsync();
 
@@ -1201,6 +1207,22 @@
         _logger.LogInformation(
             $"Project {projectIdUpdated} was updated");
 
+        // Optionally refresh the project data if needed
+        // await LoadProjectDataAsync();
+        // StateHasChanged();
+    }
+
+    /// <summary>
+    /// Called when server broadcasts that this project was created.
+    /// Receives only the ProjectId.
+    /// </summary>
+    private async Task OnProjectCreatedAsync(Guid projectIdCreated)
+    {
+        if (projectIdCreated != ProjectId)
+            return;
+
+        _logger.LogInformation(
+            $"Project {projectIdCreated} was created");
         // Optionally refresh the project data if needed
         // await LoadProjectDataAsync();
         // StateHasChanged();

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/SignalRHub/SignalRMonitoringDashboard.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/SignalRHub/SignalRMonitoringDashboard.razor
@@ -1,0 +1,140 @@
+﻿@* 
+ * OpenRose - Requirements Management
+ * Licensed under the Apache License, Version 2.0. 
+ * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+*@
+
+@page "/HubHealth"
+
+@using OpenRose.WebUI.Constants
+@using Microsoft.AspNetCore.SignalR.Client
+@inject NavigationManager NavManager
+@inject ILogger<SignalRMonitoringDashboard> _logger
+@implements IAsyncDisposable
+
+<MudPaper Class="pa-4 mb-4">
+    <MudStack Spacing="3">
+        <MudText Typo="Typo.h5">SignalR Hub Monitoring</MudText>
+
+        @if (healthMetrics != null)
+        {
+            <MudGrid>
+                <MudItem xs="12" sm="6" md="3">
+                    <MudCard>
+                        <MudCardContent>
+                            <MudText Typo="Typo.caption">Total Connections</MudText>
+                            <MudText Typo="Typo.h4" Color="Color.Primary">
+                                @healthMetrics.TotalConnections
+                            </MudText>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+
+                <MudItem xs="12" sm="6" md="3">
+                    <MudCard>
+                        <MudCardContent>
+                            <MudText Typo="Typo.caption">Connected Users</MudText>
+                            <MudText Typo="Typo.h4" Color="Color.Info">
+                                @healthMetrics.ConnectedUsers
+                            </MudText>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+
+                <MudItem xs="12" sm="6" md="3">
+                    <MudCard>
+                        <MudCardContent>
+                            <MudText Typo="Typo.caption">Health Status</MudText>
+                            <MudChip T="string" Color="@(healthMetrics.IsHealthy ? Color.Success : Color.Error)" 
+                                     Variant="Variant.Filled">
+                                @(healthMetrics.IsHealthy ? "Healthy" : "Warning")
+                            </MudChip>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+
+                <MudItem xs="12" sm="6" md="3">
+                    <MudCard>
+                        <MudCardContent>
+                            <MudText Typo="Typo.caption">Last Check</MudText>
+                            <MudText Typo="Typo.body2">
+                                @healthMetrics.LastCheckAt.ToString("HH:mm:ss")
+                            </MudText>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+            </MudGrid>
+
+            <MudText Typo="Typo.subtitle2">Active Hubs</MudText>
+            <MudList T="string">
+                @foreach (var hub in healthMetrics.HubInstances)
+                {
+                    <MudListItem Icon="@Icons.Material.Filled.Check" IconColor="Color.Success">
+                        @hub
+                    </MudListItem>
+                }
+            </MudList>
+        }
+
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="RefreshMetrics">
+            Refresh Metrics
+        </MudButton>
+    </MudStack>
+</MudPaper>
+
+@code {
+    private HubConnection? monitoringHub;
+    private SignalRHealthMetrics? healthMetrics;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            monitoringHub = new HubConnectionBuilder()
+                .WithUrl(NavManager.ToAbsoluteUri(SignalRConstants.HubPaths.MonitoringHub))
+                .WithAutomaticReconnect()
+                .Build();
+
+            await monitoringHub.StartAsync();
+
+            await RefreshMetrics();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to connect to monitoring hub: {ex.Message}");
+        }
+    }
+
+    private async Task RefreshMetrics()
+    {
+        try
+        {
+            if (monitoringHub?.State == HubConnectionState.Connected)
+            {
+                healthMetrics = await monitoringHub.InvokeAsync<SignalRHealthMetrics>("GetHealthMetrics");
+                StateHasChanged();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to refresh metrics: {ex.Message}");
+        }
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (monitoringHub is not null)
+        {
+            await monitoringHub.DisposeAsync();
+        }
+    }
+
+    public class SignalRHealthMetrics
+    {
+        public int TotalConnections { get; set; }
+        public int ConnectedUsers { get; set; }
+        public string[] HubInstances { get; set; } = Array.Empty<string>();
+        public DateTime LastCheckAt { get; set; }
+        public bool IsHealthy { get; set; }
+    }
+}

--- a/OpenRose.Web/OpenRose.WebUI/Constants/SignalRConstants.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Constants/SignalRConstants.cs
@@ -22,6 +22,7 @@ namespace OpenRose.WebUI.Constants
 			public const string BaselineNotificationHub = "/baselineNotificationHub";
 			public const string EstimationNotificationHub = "/estimationNotificationHub";
 			public const string TraceabilityNotificationHub = "/traceabilityNotificationHub";
+			public const string MonitoringHub = "/signalRMonitoringHub"; 
 		}
 
 		/// <summary>

--- a/OpenRose.Web/OpenRose.WebUI/Constants/SignalRConstants.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Constants/SignalRConstants.cs
@@ -1,0 +1,136 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+namespace OpenRose.WebUI.Constants
+{
+	/// <summary>
+	/// SignalR Hub and Event Constants
+	/// This file centralizes all SignalR configuration and event names
+	/// to prevent hard-coded strings and ensure consistency across the application.
+	/// Any changes here automatically propagate to all consumers.
+	/// </summary>
+	public static class SignalRConstants
+	{
+		/// <summary>
+		/// SignalR Hub Paths
+		/// </summary>
+		public static class HubPaths
+		{
+			public const string ProjectNotificationHub = "/projectNotificationHub";
+			public const string RequirementNotificationHub = "/requirementNotificationHub";
+			public const string BaselineNotificationHub = "/baselineNotificationHub";
+			public const string EstimationNotificationHub = "/estimationNotificationHub";
+			public const string TraceabilityNotificationHub = "/traceabilityNotificationHub";
+		}
+
+		/// <summary>
+		/// Project-related Events
+		/// </summary>
+		public static class ProjectEvents
+		{
+			public const string ProjectCreated = "ProjectCreated";
+			public const string ProjectDeleted = "ProjectDeleted";
+			public const string ProjectModified = "ProjectModified";
+		}
+
+		/// <summary>
+		/// Requirement Item Type Events
+		/// </summary>
+		public static class RequirementItemTypeEvents
+		{
+			public const string ItemzTypeCreated = "ItemzTypeCreated";
+			public const string ItemzTypeDeleted = "ItemzTypeDeleted";
+			public const string ItemzTypeModified = "ItemzTypeModified";
+			public const string ItemzTypeMoved = "ItemzTypeMoved";
+		}
+
+		/// <summary>
+		/// Requirement Item Events
+		/// </summary>
+		public static class RequirementItemEvents
+		{
+			public const string ItemzCreated = "ItemzCreated";
+			public const string ItemzDeleted = "ItemzDeleted";
+			public const string ItemzModified = "ItemzModified";
+			public const string ItemzMoved = "ItemzMoved";
+		}
+
+		/// <summary>
+		/// Baseline Events
+		/// </summary>
+		public static class BaselineEvents
+		{
+			public const string BaselineCreated = "BaselineCreated";
+			public const string BaselineDeleted = "BaselineDeleted";
+			public const string BaselineModified = "BaselineModified";
+		}
+
+		/// <summary>
+		/// Baseline Item Type Events
+		/// </summary>
+		public static class BaselineItemTypeEvents
+		{
+			public const string BaselineItemzTypeCreated = "BaselineItemzTypeCreated";
+			public const string BaselineItemzTypeDeleted = "BaselineItemzTypeDeleted";
+			public const string BaselineItemzTypeModified = "BaselineItemzTypeModified";
+		}
+
+		/// <summary>
+		/// Baseline Item Events
+		/// </summary>
+		public static class BaselineItemEvents
+		{
+			public const string BaselineItemzCreated = "BaselineItemzCreated";
+			public const string BaselineItemzDeleted = "BaselineItemzDeleted";
+			public const string BaselineItemzModified = "BaselineItemzModified";
+		}
+
+		/// <summary>
+		/// Estimation Events
+		/// </summary>
+		public static class EstimationEvents
+		{
+			public const string ProjectEstimationUpdated = "ProjectEstimationUpdated";
+			public const string ItemzTypeEstimationUpdated = "ItemzTypeEstimationUpdated";
+			public const string ItemzEstimationUpdated = "ItemzEstimationUpdated";
+		}
+
+		/// <summary>
+		/// Traceability Events
+		/// </summary>
+		public static class TraceabilityEvents
+		{
+			public const string TraceabilityLinkCreated = "TraceabilityLinkCreated";
+			public const string TraceabilityLinkDeleted = "TraceabilityLinkDeleted";
+		}
+
+		/// <summary>
+		/// SignalR Group Name Patterns
+		/// Use these to organize clients into groups for targeted notifications
+		/// </summary>
+		public static class GroupNamePatterns
+		{
+			public const string ProjectGroup = "project-{0}";
+			public const string ItemzTypeGroup = "itemztype-{0}";
+			public const string ItemzGroup = "itemz-{0}";
+			public const string BaselineGroup = "baseline-{0}";
+			public const string ProjectEstimationGroup = "projectestimation-{0}";
+			public const string ItemzTypeEstimationGroup = "itemztypeestimation-{0}";
+			public const string ItemzEstimationGroup = "itemzestimation-{0}";
+			public const string TraceabilityGroup = "traceability-{0}-{1}";
+
+			/// <summary>
+			/// Helper method to generate group names
+			/// </summary>
+			public static string GetProjectGroup(Guid projectId) => string.Format(ProjectGroup, projectId);
+			public static string GetItemzTypeGroup(Guid itemzTypeId) => string.Format(ItemzTypeGroup, itemzTypeId);
+			public static string GetItemzGroup(Guid itemzId) => string.Format(ItemzGroup, itemzId);
+			public static string GetBaselineGroup(Guid baselineId) => string.Format(BaselineGroup, baselineId);
+			public static string GetProjectEstimationGroup(Guid projectId) => string.Format(ProjectEstimationGroup, projectId);
+			public static string GetItemzTypeEstimationGroup(Guid itemzTypeId) => string.Format(ItemzTypeEstimationGroup, itemzTypeId);
+			public static string GetItemzEstimationGroup(Guid itemzId) => string.Format(ItemzEstimationGroup, itemzId);
+			public static string GetTraceabilityGroup(Guid fromItemzId, Guid toItemzId) => string.Format(TraceabilityGroup, fromItemzId, toItemzId);
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/OpenRose.WebUI.csproj
+++ b/OpenRose.Web/OpenRose.WebUI/OpenRose.WebUI.csproj
@@ -15,6 +15,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\OpenRose.WebUI.Client\OpenRose.WebUI.Client.csproj" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.13" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.16" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.13" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.13" />
 		<PackageReference Include="MudBlazor" Version="8.15.0" />

--- a/OpenRose.Web/OpenRose.WebUI/Program.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Program.cs
@@ -347,10 +347,10 @@ app.UseAntiforgery();
 
 // Map SignalR Hubs using constants
 app.MapHub<ProjectNotificationHub>(SignalRConstants.HubPaths.ProjectNotificationHub);
-//app.MapHub<RequirementNotificationHub>(SignalRConstants.HubPaths.RequirementNotificationHub);
-//app.MapHub<BaselineNotificationHub>(SignalRConstants.HubPaths.BaselineNotificationHub);
-//app.MapHub<EstimationNotificationHub>(SignalRConstants.HubPaths.EstimationNotificationHub);
-//app.MapHub<TraceabilityNotificationHub>(SignalRConstants.HubPaths.TraceabilityNotificationHub);
+app.MapHub<RequirementNotificationHub>(SignalRConstants.HubPaths.RequirementNotificationHub);
+app.MapHub<BaselineNotificationHub>(SignalRConstants.HubPaths.BaselineNotificationHub);
+app.MapHub<EstimationNotificationHub>(SignalRConstants.HubPaths.EstimationNotificationHub);
+app.MapHub<TraceabilityNotificationHub>(SignalRConstants.HubPaths.TraceabilityNotificationHub);
 app.MapHub<SignalRMonitoringHub>(SignalRConstants.HubPaths.MonitoringHub);
 
 app.MapRazorComponents<App>()

--- a/OpenRose.Web/OpenRose.WebUI/Program.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Program.cs
@@ -30,6 +30,7 @@ using OpenRose.WebUI.Components;
 using OpenRose.WebUI.Components.EventServices;
 using OpenRose.WebUI.Components.FindServices;
 using OpenRose.WebUI.Configuration;
+using OpenRose.WebUI.Constants;
 using OpenRose.WebUI.Services;
 using OpenRose.WebUI.Services.NotificationHub;
 using OpenRose.WebUI.Services.StartUpConfiguration;
@@ -344,8 +345,12 @@ app.MapStaticAssets();
 app.UseAntiforgery();
 
 
-// Map the SignalR Hub - This uses the existing Blazor Server circuit
-app.MapHub<ProjectNotificationHub>("/projectNotificationHub");
+// Map SignalR Hubs using constants
+app.MapHub<ProjectNotificationHub>(SignalRConstants.HubPaths.ProjectNotificationHub);
+//app.MapHub<RequirementNotificationHub>(SignalRConstants.HubPaths.RequirementNotificationHub);
+//app.MapHub<BaselineNotificationHub>(SignalRConstants.HubPaths.BaselineNotificationHub);
+//app.MapHub<EstimationNotificationHub>(SignalRConstants.HubPaths.EstimationNotificationHub);
+//app.MapHub<TraceabilityNotificationHub>(SignalRConstants.HubPaths.TraceabilityNotificationHub);
 
 
 app.MapRazorComponents<App>()

--- a/OpenRose.Web/OpenRose.WebUI/Program.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Program.cs
@@ -31,6 +31,7 @@ using OpenRose.WebUI.Components.EventServices;
 using OpenRose.WebUI.Components.FindServices;
 using OpenRose.WebUI.Configuration;
 using OpenRose.WebUI.Services;
+using OpenRose.WebUI.Services.NotificationHub;
 using OpenRose.WebUI.Services.StartUpConfiguration;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -57,6 +58,15 @@ else
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
+
+// Add SignalR for real-time notifications
+builder.Services.AddSignalR();
+
+// Register Notification Services
+builder.Services.AddScoped<IProjectNotificationService, ProjectNotificationService>();
+builder.Services.AddScoped<ProjectDeletionService>();
+builder.Services.AddScoped<ProjectCreationService>();
+builder.Services.AddScoped<ProjectUpdateService>();
 
 
 builder.Services.AddControllers();
@@ -332,6 +342,11 @@ startupConfigurationManager.ConfigureAndLogStartupSettings();
 
 app.MapStaticAssets();
 app.UseAntiforgery();
+
+
+// Map the SignalR Hub - This uses the existing Blazor Server circuit
+app.MapHub<ProjectNotificationHub>("/projectNotificationHub");
+
 
 app.MapRazorComponents<App>()
 	.AddInteractiveServerRenderMode()

--- a/OpenRose.Web/OpenRose.WebUI/Program.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Program.cs
@@ -351,7 +351,7 @@ app.MapHub<ProjectNotificationHub>(SignalRConstants.HubPaths.ProjectNotification
 //app.MapHub<BaselineNotificationHub>(SignalRConstants.HubPaths.BaselineNotificationHub);
 //app.MapHub<EstimationNotificationHub>(SignalRConstants.HubPaths.EstimationNotificationHub);
 //app.MapHub<TraceabilityNotificationHub>(SignalRConstants.HubPaths.TraceabilityNotificationHub);
-
+app.MapHub<SignalRMonitoringHub>(SignalRConstants.HubPaths.MonitoringHub);
 
 app.MapRazorComponents<App>()
 	.AddInteractiveServerRenderMode()

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/BaselineNotificationHub.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/BaselineNotificationHub.cs
@@ -1,0 +1,87 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// SignalR Hub for broadcasting baseline-related notifications to connected clients.
+	/// This uses the EXISTING SignalR circuit between Blazor Server and browsers.
+	/// 
+	/// When a user deletes/updates/creates a baseline via the WebUI,
+	/// this hub broadcasts the notification to all other connected users
+	/// viewing that same baseline.
+	/// </summary>
+	public class BaselineNotificationHub : Hub
+	{
+		private readonly ILogger<BaselineNotificationHub> _logger;
+
+		public BaselineNotificationHub(ILogger<BaselineNotificationHub> logger)
+		{
+			_logger = logger;
+		}
+
+		/// <summary>
+		/// Called by browser clients to join a group for a specific baseline.
+		/// This way, when a baseline is deleted/updated, we only notify users viewing that baseline.
+		/// 
+		/// Example: User views baseline 123abc, calls SubscribeToBaselineAsync(123abc)
+		/// Now this connection is added to group "baseline-123abc"
+		/// When baseline 123abc is deleted, notification is sent to "baseline-123abc" group
+		/// </summary>
+		/// <param name="baselineId">The GUID of the baseline to subscribe to notifications for</param>
+		public async Task SubscribeToBaselineAsync(Guid baselineId)
+		{
+			var groupName = $"baseline-{baselineId}";
+			await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) subscribed to baseline {BaselineId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				baselineId);
+		}
+
+		/// <summary>
+		/// Called when user leaves the baseline view or navigates away.
+		/// Removes the connection from the baseline's notification group.
+		/// </summary>
+		/// <param name="baselineId">The GUID of the baseline to unsubscribe from</param>
+		public async Task UnsubscribeFromBaselineAsync(Guid baselineId)
+		{
+			var groupName = $"baseline-{baselineId}";
+			await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) unsubscribed from baseline {BaselineId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				baselineId);
+		}
+
+		public override async Task OnConnectedAsync()
+		{
+			_logger.LogInformation(
+				"Client connected: {ConnectionId}, User: {UserId}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous");
+
+			await base.OnConnectedAsync();
+		}
+
+		public override async Task OnDisconnectedAsync(Exception? exception)
+		{
+			_logger.LogInformation(
+				"Client disconnected: {ConnectionId}, User: {UserId}, Reason: {Reason}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous",
+				exception?.Message ?? "Normal disconnection");
+
+			await base.OnDisconnectedAsync(exception);
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/EstimationNotificationHub.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/EstimationNotificationHub.cs
@@ -1,0 +1,87 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// SignalR Hub for broadcasting estimation-related notifications to connected clients.
+	/// This uses the EXISTING SignalR circuit between Blazor Server and browsers.
+	/// 
+	/// When a user deletes/updates/creates a estimation via the WebUI,
+	/// this hub broadcasts the notification to all other connected users
+	/// viewing that same estimation.
+	/// </summary>
+	public class EstimationNotificationHub : Hub
+	{
+		private readonly ILogger<EstimationNotificationHub> _logger;
+
+		public EstimationNotificationHub(ILogger<EstimationNotificationHub> logger)
+		{
+			_logger = logger;
+		}
+
+		/// <summary>
+		/// Called by browser clients to join a group for a specific estimation.
+		/// This way, when a estimation is deleted/updated, we only notify users viewing that estimation.
+		/// 
+		/// Example: User views estimation 123abc, calls SubscribeToEstimationAsync(123abc)
+		/// Now this connection is added to group "estimation-123abc"
+		/// When estimation 123abc is deleted, notification is sent to "estimation-123abc" group
+		/// </summary>
+		/// <param name="estimationId">The GUID of the estimation to subscribe to notifications for</param>
+		public async Task SubscribeToEstimationAsync(Guid estimationId)
+		{
+			var groupName = $"estimation-{estimationId}";
+			await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) subscribed to estimation {EstimationId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				estimationId);
+		}
+
+		/// <summary>
+		/// Called when user leaves the estimation view or navigates away.
+		/// Removes the connection from the estimation's notification group.
+		/// </summary>
+		/// <param name="estimationId">The GUID of the estimation to unsubscribe from</param>
+		public async Task UnsubscribeFromEstimationAsync(Guid estimationId)
+		{
+			var groupName = $"estimation-{estimationId}";
+			await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) unsubscribed from estimation {EstimationId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				estimationId);
+		}
+
+		public override async Task OnConnectedAsync()
+		{
+			_logger.LogInformation(
+				"Client connected: {ConnectionId}, User: {UserId}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous");
+
+			await base.OnConnectedAsync();
+		}
+
+		public override async Task OnDisconnectedAsync(Exception? exception)
+		{
+			_logger.LogInformation(
+				"Client disconnected: {ConnectionId}, User: {UserId}, Reason: {Reason}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous",
+				exception?.Message ?? "Normal disconnection");
+
+			await base.OnDisconnectedAsync(exception);
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/IProjectNotificationService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/IProjectNotificationService.cs
@@ -1,0 +1,35 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// Interface for broadcasting project notifications to connected clients via SignalR.
+	/// 
+	/// Only passes ProjectId - clients have all needed details already loaded.
+	/// </summary>
+	public interface IProjectNotificationService
+	{
+		/// <summary>
+		/// Notify all connected users viewing a specific project that it has been deleted.
+		/// </summary>
+		/// <param name="projectId">The GUID of the deleted project</param>
+		Task NotifyProjectDeletedAsync(Guid projectId);
+
+		/// <summary>
+		/// Notify all connected users that a new project has been created.
+		/// </summary>
+		/// <param name="projectId">The GUID of the newly created project</param>
+		Task NotifyProjectCreatedAsync(Guid projectId);
+
+		/// <summary>
+		/// Notify all connected users viewing a specific project that it has been updated.
+		/// </summary>
+		/// <param name="projectId">The GUID of the updated project</param>
+		Task NotifyProjectUpdatedAsync(Guid projectId);
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectCreationService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectCreationService.cs
@@ -1,0 +1,83 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using OpenRose.WebUI.Client.Services.Project;
+using OpenRose.WebUI.Client.SharedModels;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// Service to handle project creation with real-time notification broadcasting.
+	/// This service ensures that when a project is created via the WebUI,
+	/// all other connected users are immediately notified so they can see the new project.
+	/// </summary>
+	public class ProjectCreationService
+	{
+		private readonly IProjectService _projectService;
+		private readonly IProjectNotificationService _notificationService;
+		private readonly ILogger<ProjectCreationService> _logger;
+
+		public ProjectCreationService(
+			IProjectService projectService,
+			IProjectNotificationService notificationService,
+			ILogger<ProjectCreationService> logger)
+		{
+			_projectService = projectService ?? throw new ArgumentNullException(nameof(projectService));
+			_notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		/// <summary>
+		/// Create a new project and notify all connected users that a new project exists.
+		/// 
+		/// Process:
+		/// 1. Call API to create the project
+		/// 2. If successful, broadcast creation notification via SignalR to all users
+		/// 3. All connected users will receive notification of the new project
+		/// </summary>
+		/// <param name="createProjectDTO">The project details to create</param>
+		/// <returns>The created project DTO if successful, null otherwise</returns>
+		public async Task<GetProjectDTO?> CreateProjectWithNotificationAsync(GetProjectDTO createProjectDTO)
+		{
+			try
+			{
+				_logger.LogInformation(
+					"Attempting to create new project: {ProjectName}",
+					createProjectDTO?.Name ?? "Unknown");
+
+				// Step 1: Call the API to create the project
+				var createdProject = await _projectService.__POST_Create_Project__Async(createProjectDTO);
+
+				if (createdProject != null)
+				{
+					_logger.LogInformation(
+						"Successfully created project {ProjectId} ({ProjectName})",
+						createdProject.Id,
+						createdProject.Name);
+
+					// Step 2: BROADCAST NOTIFICATION - Only pass ProjectId
+					// All users will receive notification and can refresh their project lists
+					await _notificationService.NotifyProjectCreatedAsync(createdProject.Id);
+
+					return createdProject;
+				}
+				else
+				{
+					_logger.LogWarning(
+						"Failed to create project - API returned null");
+					return null;
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Exception occurred while creating project");
+				return null;
+			}
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectDeletionService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectDeletionService.cs
@@ -1,0 +1,73 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using OpenRose.WebUI.Client.Services.Project;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// Service to handle project deletion with real-time notification broadcasting.
+	/// This service ensures that when a project is deleted via the WebUI,
+	/// all other connected users viewing that project are immediately notified.
+	/// </summary>
+	public class ProjectDeletionService
+	{
+		private readonly IProjectService _projectService;
+		private readonly IProjectNotificationService _notificationService;
+		private readonly ILogger<ProjectDeletionService> _logger;
+
+		public ProjectDeletionService(
+			IProjectService projectService,
+			IProjectNotificationService notificationService,
+			ILogger<ProjectDeletionService> logger)
+		{
+			_projectService = projectService ?? throw new ArgumentNullException(nameof(projectService));
+			_notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		/// <summary>
+		/// Delete a project via the API and notify all connected users viewing that project.
+		/// 
+		/// Process:
+		/// 1. Call API to delete the project
+		/// 2. If successful, broadcast deletion notification via SignalR
+		/// 3. All other users viewing this project will receive the notification
+		/// </summary>
+		/// <param name="projectId">The GUID of the project to delete</param>
+		/// <returns>True if deletion was successful, false otherwise</returns>
+		public async Task<bool> DeleteProjectWithNotificationAsync(Guid projectId)
+		{
+			try
+			{
+				_logger.LogInformation(
+					"Attempting to delete project {ProjectId}",
+					projectId);
+
+				// Step 1: Call the API to delete the project
+				await _projectService.__DELETE_Project_By_GUID_ID__Async(projectId);
+
+				_logger.LogInformation(
+					"Successfully deleted project {ProjectId}",
+					projectId);
+
+				// Step 2: BROADCAST NOTIFICATION - Only pass ProjectId
+				// Clients have all details already loaded and will use that information
+				await _notificationService.NotifyProjectDeletedAsync(projectId);
+
+				return true;
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Exception occurred while deleting project {ProjectId}",
+					projectId);
+				return false;
+			}
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectNotificationHub.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectNotificationHub.cs
@@ -1,0 +1,87 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// SignalR Hub for broadcasting project-related notifications to connected clients.
+	/// This uses the EXISTING SignalR circuit between Blazor Server and browsers.
+	/// 
+	/// When a user deletes/updates/creates a project via the WebUI,
+	/// this hub broadcasts the notification to all other connected users
+	/// viewing that same project.
+	/// </summary>
+	public class ProjectNotificationHub : Hub
+	{
+		private readonly ILogger<ProjectNotificationHub> _logger;
+
+		public ProjectNotificationHub(ILogger<ProjectNotificationHub> logger)
+		{
+			_logger = logger;
+		}
+
+		/// <summary>
+		/// Called by browser clients to join a group for a specific project.
+		/// This way, when a project is deleted/updated, we only notify users viewing that project.
+		/// 
+		/// Example: User views project 123abc, calls SubscribeToProjectAsync(123abc)
+		/// Now this connection is added to group "project-123abc"
+		/// When project 123abc is deleted, notification is sent to "project-123abc" group
+		/// </summary>
+		/// <param name="projectId">The GUID of the project to subscribe to notifications for</param>
+		public async Task SubscribeToProjectAsync(Guid projectId)
+		{
+			var groupName = $"project-{projectId}";
+			await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) subscribed to project {ProjectId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				projectId);
+		}
+
+		/// <summary>
+		/// Called when user leaves the project view or navigates away.
+		/// Removes the connection from the project's notification group.
+		/// </summary>
+		/// <param name="projectId">The GUID of the project to unsubscribe from</param>
+		public async Task UnsubscribeFromProjectAsync(Guid projectId)
+		{
+			var groupName = $"project-{projectId}";
+			await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) unsubscribed from project {ProjectId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				projectId);
+		}
+
+		public override async Task OnConnectedAsync()
+		{
+			_logger.LogInformation(
+				"Client connected: {ConnectionId}, User: {UserId}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous");
+
+			await base.OnConnectedAsync();
+		}
+
+		public override async Task OnDisconnectedAsync(Exception? exception)
+		{
+			_logger.LogInformation(
+				"Client disconnected: {ConnectionId}, User: {UserId}, Reason: {Reason}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous",
+				exception?.Message ?? "Normal disconnection");
+
+			await base.OnDisconnectedAsync(exception);
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectNotificationService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectNotificationService.cs
@@ -1,0 +1,117 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// Service to send project notifications to connected clients via SignalR.
+	/// Only passes ProjectId - clients have all needed details already loaded.
+	/// 
+	/// This service is responsible for broadcasting notifications when:
+	/// - A project is deleted
+	/// - A project is created
+	/// - A project is updated
+	/// </summary>
+	public class ProjectNotificationService : IProjectNotificationService
+	{
+		private readonly IHubContext<ProjectNotificationHub> _hubContext;
+		private readonly ILogger<ProjectNotificationService> _logger;
+
+		public ProjectNotificationService(
+			IHubContext<ProjectNotificationHub> hubContext,
+			ILogger<ProjectNotificationService> logger)
+		{
+			_hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		/// <summary>
+		/// Broadcast project deletion notification to all users viewing that specific project.
+		/// </summary>
+		/// <param name="projectId">The GUID of the deleted project</param>
+		public async Task NotifyProjectDeletedAsync(Guid projectId)
+		{
+			try
+			{
+				var groupName = $"project-{projectId}";
+
+				// Send only the ProjectId - clients have all details already
+				await _hubContext.Clients.Group(groupName)
+					.SendAsync("ProjectDeleted", projectId);
+
+				_logger.LogInformation(
+					"Broadcasted ProjectDeleted notification for project {ProjectId}",
+					projectId);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Error broadcasting ProjectDeleted notification for project {ProjectId}",
+					projectId);
+				throw;
+			}
+		}
+
+		/// <summary>
+		/// Broadcast project creation notification to all connected clients.
+		/// Since all users may need to see new projects in their list,
+		/// we send to ALL clients rather than a specific group.
+		/// </summary>
+		/// <param name="projectId">The GUID of the newly created project</param>
+		public async Task NotifyProjectCreatedAsync(Guid projectId)
+		{
+			try
+			{
+				// Send to all connected clients (new project visible in all project lists)
+				await _hubContext.Clients.All
+					.SendAsync("ProjectCreated", projectId);
+
+				_logger.LogInformation(
+					"Broadcasted ProjectCreated notification for project {ProjectId}",
+					projectId);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Error broadcasting ProjectCreated notification for project {ProjectId}",
+					projectId);
+				throw;
+			}
+		}
+
+		/// <summary>
+		/// Broadcast project update notification to all users viewing that specific project.
+		/// </summary>
+		/// <param name="projectId">The GUID of the updated project</param>
+		public async Task NotifyProjectUpdatedAsync(Guid projectId)
+		{
+			try
+			{
+				var groupName = $"project-{projectId}";
+
+				// Send only the ProjectId - clients have all details already
+				await _hubContext.Clients.Group(groupName)
+					.SendAsync("ProjectUpdated", projectId);
+
+				_logger.LogInformation(
+					"Broadcasted ProjectUpdated notification for project {ProjectId}",
+					projectId);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Error broadcasting ProjectUpdated notification for project {ProjectId}",
+					projectId);
+				throw;
+			}
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectNotificationService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectNotificationService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
 using Microsoft.AspNetCore.SignalR;
+using OpenRose.WebUI.Constants;
 using System;
 using System.Threading.Tasks;
 
@@ -38,21 +39,23 @@ namespace OpenRose.WebUI.Services.NotificationHub
 		{
 			try
 			{
-				var groupName = $"project-{projectId}";
+				var groupName = SignalRConstants.GroupNamePatterns.GetProjectGroup(projectId);
 
 				// Send only the ProjectId - clients have all details already
 				await _hubContext.Clients.Group(groupName)
-					.SendAsync("ProjectDeleted", projectId);
+					.SendAsync(SignalRConstants.ProjectEvents.ProjectDeleted, projectId);
 
 				_logger.LogInformation(
-					"Broadcasted ProjectDeleted notification for project {ProjectId}",
+					"Broadcasted {EventName} notification for project {ProjectId}",
+					SignalRConstants.ProjectEvents.ProjectDeleted,
 					projectId);
 			}
 			catch (Exception ex)
 			{
 				_logger.LogError(
 					ex,
-					"Error broadcasting ProjectDeleted notification for project {ProjectId}",
+					"Error broadcasting {EventName} notification for project {ProjectId}",
+					SignalRConstants.ProjectEvents.ProjectDeleted,
 					projectId);
 				throw;
 			}
@@ -70,17 +73,19 @@ namespace OpenRose.WebUI.Services.NotificationHub
 			{
 				// Send to all connected clients (new project visible in all project lists)
 				await _hubContext.Clients.All
-					.SendAsync("ProjectCreated", projectId);
+					.SendAsync(SignalRConstants.ProjectEvents.ProjectCreated, projectId);
 
 				_logger.LogInformation(
-					"Broadcasted ProjectCreated notification for project {ProjectId}",
+					"Broadcasted {EventName} notification for project {ProjectId}",
+					SignalRConstants.ProjectEvents.ProjectCreated,
 					projectId);
 			}
 			catch (Exception ex)
 			{
 				_logger.LogError(
 					ex,
-					"Error broadcasting ProjectCreated notification for project {ProjectId}",
+					"Error broadcasting {EventName} notification for project {ProjectId}",
+					SignalRConstants.ProjectEvents.ProjectCreated,
 					projectId);
 				throw;
 			}
@@ -94,21 +99,23 @@ namespace OpenRose.WebUI.Services.NotificationHub
 		{
 			try
 			{
-				var groupName = $"project-{projectId}";
+				var groupName = SignalRConstants.GroupNamePatterns.GetProjectGroup(projectId);
 
 				// Send only the ProjectId - clients have all details already
 				await _hubContext.Clients.Group(groupName)
-					.SendAsync("ProjectUpdated", projectId);
+					.SendAsync(SignalRConstants.ProjectEvents.ProjectModified, projectId);
 
 				_logger.LogInformation(
-					"Broadcasted ProjectUpdated notification for project {ProjectId}",
+					"Broadcasted {EventName} notification for project {ProjectId}",
+					SignalRConstants.ProjectEvents.ProjectModified,
 					projectId);
 			}
 			catch (Exception ex)
 			{
 				_logger.LogError(
 					ex,
-					"Error broadcasting ProjectUpdated notification for project {ProjectId}",
+					"Error broadcasting {EventName} notification for project {ProjectId}",
+					SignalRConstants.ProjectEvents.ProjectModified,
 					projectId);
 				throw;
 			}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectUpdateService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/ProjectUpdateService.cs
@@ -1,0 +1,85 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using OpenRose.WebUI.Client.Services.Project;
+using OpenRose.WebUI.Client.SharedModels;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// Service to handle project updates with real-time notification broadcasting.
+	/// This service ensures that when a project is updated via the WebUI,
+	/// all other connected users viewing that project are immediately notified of the changes.
+	/// </summary>
+	public class ProjectUpdateService
+	{
+		private readonly IProjectService _projectService;
+		private readonly IProjectNotificationService _notificationService;
+		private readonly ILogger<ProjectUpdateService> _logger;
+
+		public ProjectUpdateService(
+			IProjectService projectService,
+			IProjectNotificationService notificationService,
+			ILogger<ProjectUpdateService> logger)
+		{
+			_projectService = projectService ?? throw new ArgumentNullException(nameof(projectService));
+			_notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		/// <summary>
+		/// Update a project and notify all connected users viewing that project.
+		/// 
+		/// Process:
+		/// 1. Call API to update the project
+		/// 2. If successful, broadcast update notification via SignalR to users viewing this project
+		/// 3. All other users viewing this project will receive the notification
+		/// </summary>
+		/// <param name="projectId">The GUID of the project to update</param>
+		/// <param name="updateProjectDTO">The updated project details</param>
+		/// <returns>The updated project DTO if successful, null otherwise</returns>
+		public async Task<GetProjectDTO?> UpdateProjectWithNotificationAsync(Guid projectId, GetProjectDTO updateProjectDTO)
+		{
+			try
+			{
+				_logger.LogInformation(
+					"Attempting to update project {ProjectId}",
+					projectId);
+
+				// Step 1: Call the API to update the project
+				var updatedProject = await _projectService.__PUT_Update_Project_By_GUID_ID__Async(projectId, updateProjectDTO);
+
+				if (updatedProject != null)
+				{
+					_logger.LogInformation(
+						"Successfully updated project {ProjectId}",
+						projectId);
+
+					// Step 2: BROADCAST NOTIFICATION - Only pass ProjectId
+					// Users viewing this project will receive the update notification
+					await _notificationService.NotifyProjectUpdatedAsync(projectId);
+
+					return updatedProject;
+				}
+				else
+				{
+					_logger.LogWarning(
+						"Failed to update project {ProjectId} - API returned null",
+						projectId);
+					return null;
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Exception occurred while updating project {ProjectId}",
+					projectId);
+				return null;
+			}
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/RequirementNotificationHub.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/RequirementNotificationHub.cs
@@ -1,0 +1,87 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// SignalR Hub for broadcasting requirement-related notifications to connected clients.
+	/// This uses the EXISTING SignalR circuit between Blazor Server and browsers.
+	/// 
+	/// When a user deletes/updates/creates a requirement via the WebUI,
+	/// this hub broadcasts the notification to all other connected users
+	/// viewing that same requirement.
+	/// </summary>
+	public class RequirementNotificationHub : Hub
+	{
+		private readonly ILogger<RequirementNotificationHub> _logger;
+
+		public RequirementNotificationHub(ILogger<RequirementNotificationHub> logger)
+		{
+			_logger = logger;
+		}
+
+		/// <summary>
+		/// Called by browser clients to join a group for a specific requirement.
+		/// This way, when a requirement is deleted/updated, we only notify users viewing that requirement.
+		/// 
+		/// Example: User views requirement 123abc, calls SubscribeToRequirementAsync(123abc)
+		/// Now this connection is added to group "requirement-123abc"
+		/// When requirement 123abc is deleted, notification is sent to "requirement-123abc" group
+		/// </summary>
+		/// <param name="requirementId">The GUID of the requirement to subscribe to notifications for</param>
+		public async Task SubscribeToRequirementAsync(Guid requirementId)
+		{
+			var groupName = $"requirement-{requirementId}";
+			await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) subscribed to requirement {RequirementId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				requirementId);
+		}
+
+		/// <summary>
+		/// Called when user leaves the requirement view or navigates away.
+		/// Removes the connection from the requirement's notification group.
+		/// </summary>
+		/// <param name="requirementId">The GUID of the requirement to unsubscribe from</param>
+		public async Task UnsubscribeFromRequirementAsync(Guid requirementId)
+		{
+			var groupName = $"requirement-{requirementId}";
+			await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) unsubscribed from requirement {RequirementId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				requirementId);
+		}
+
+		public override async Task OnConnectedAsync()
+		{
+			_logger.LogInformation(
+				"Client connected: {ConnectionId}, User: {UserId}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous");
+
+			await base.OnConnectedAsync();
+		}
+
+		public override async Task OnDisconnectedAsync(Exception? exception)
+		{
+			_logger.LogInformation(
+				"Client disconnected: {ConnectionId}, User: {UserId}, Reason: {Reason}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous",
+				exception?.Message ?? "Normal disconnection");
+
+			await base.OnDisconnectedAsync(exception);
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/SignalRMonitoringHub.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/SignalRMonitoringHub.cs
@@ -1,0 +1,159 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// Monitoring hub for SignalR health and connection tracking
+	/// Provides real-time metrics about SignalR connections and events
+	/// </summary>
+	public class SignalRMonitoringHub : Hub
+	{
+		private readonly ILogger<SignalRMonitoringHub> _logger;
+		private static readonly ConcurrentDictionary<string, ConnectionInfo> ActiveConnections =
+			new ConcurrentDictionary<string, ConnectionInfo>();
+
+		public SignalRMonitoringHub(ILogger<SignalRMonitoringHub> logger)
+		{
+			_logger = logger;
+		}
+
+		public override async Task OnConnectedAsync()
+		{
+			var connectionInfo = new ConnectionInfo
+			{
+				ConnectionId = Context.ConnectionId,
+				UserId = Context.User?.Identity?.Name ?? "Anonymous",
+				ConnectedAt = DateTime.UtcNow,
+				IpAddress = Context.GetHttpContext()?.Connection?.RemoteIpAddress?.ToString() ?? "Unknown"
+			};
+
+			ActiveConnections.TryAdd(Context.ConnectionId, connectionInfo);
+
+			_logger.LogInformation(
+				"Client connected to monitoring hub. ConnectionId: {ConnectionId}, User: {UserId}, IP: {IpAddress}",
+				Context.ConnectionId,
+				connectionInfo.UserId,
+				connectionInfo.IpAddress);
+
+			await base.OnConnectedAsync();
+		}
+
+		public override async Task OnDisconnectedAsync(Exception? exception)
+		{
+			ActiveConnections.TryRemove(Context.ConnectionId, out _);
+
+			_logger.LogInformation(
+				"Client disconnected from monitoring hub. ConnectionId: {ConnectionId}, Reason: {Reason}",
+				Context.ConnectionId,
+				exception?.Message ?? "Normal disconnection");
+
+			await base.OnDisconnectedAsync(exception);
+		}
+
+		/// <summary>
+		/// Get current SignalR health metrics
+		/// </summary>
+		public SignalRHealthMetrics GetHealthMetrics()
+		{
+			return new SignalRHealthMetrics
+			{
+				TotalConnections = ActiveConnections.Count,
+				ConnectedUsers = ActiveConnections.Values.Select(c => c.UserId).Distinct().Count(),
+				HubInstances = new[]
+				{
+					"ProjectNotificationHub",
+					"RequirementNotificationHub",
+					"BaselineNotificationHub",
+					"EstimationNotificationHub",
+					"TraceabilityNotificationHub"
+				},
+				LastCheckAt = DateTime.UtcNow,
+				IsHealthy = ActiveConnections.Count < 10000 // Warning threshold
+			};
+		}
+
+		/// <summary>
+		/// Get list of all connected clients
+		/// </summary>
+		public IEnumerable<ConnectionInfo> GetConnectedClients()
+		{
+			return ActiveConnections.Values
+				.OrderByDescending(c => c.ConnectedAt)
+				.ToList();
+		}
+
+		/// <summary>
+		/// Get connections for a specific user
+		/// </summary>
+		public IEnumerable<ConnectionInfo> GetConnectionsByUser(string userId)
+		{
+			return ActiveConnections.Values
+				.Where(c => c.UserId == userId)
+				.ToList();
+		}
+
+		/// <summary>
+		/// Get connection duration statistics
+		/// </summary>
+		public ConnectionDurationStats GetConnectionDurationStats()
+		{
+			var now = DateTime.UtcNow;
+			var durations = ActiveConnections.Values
+				.Select(c => (now - c.ConnectedAt).TotalSeconds)
+				.ToList();
+
+			return new ConnectionDurationStats
+			{
+				AverageConnectionDurationSeconds = durations.Any() ? durations.Average() : 0,
+				MinConnectionDurationSeconds = durations.Any() ? durations.Min() : 0,
+				MaxConnectionDurationSeconds = durations.Any() ? durations.Max() : 0,
+				TotalConnections = durations.Count
+			};
+		}
+	}
+
+	/// <summary>
+	/// SignalR Health Metrics
+	/// </summary>
+	public class SignalRHealthMetrics
+	{
+		public int TotalConnections { get; set; }
+		public int ConnectedUsers { get; set; }
+		public string[] HubInstances { get; set; } = Array.Empty<string>();
+		public DateTime LastCheckAt { get; set; }
+		public bool IsHealthy { get; set; }
+	}
+
+	/// <summary>
+	/// Individual Connection Information
+	/// </summary>
+	public class ConnectionInfo
+	{
+		public string ConnectionId { get; set; } = string.Empty;
+		public string UserId { get; set; } = string.Empty;
+		public DateTime ConnectedAt { get; set; }
+		public string IpAddress { get; set; } = string.Empty;
+
+		public double ConnectionDurationSeconds =>
+			(DateTime.UtcNow - ConnectedAt).TotalSeconds;
+	}
+
+	/// <summary>
+	/// Connection Duration Statistics
+	/// </summary>
+	public class ConnectionDurationStats
+	{
+		public double AverageConnectionDurationSeconds { get; set; }
+		public double MinConnectionDurationSeconds { get; set; }
+		public double MaxConnectionDurationSeconds { get; set; }
+		public int TotalConnections { get; set; }
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/TraceabilityNotificationHub.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/NotificationHub/TraceabilityNotificationHub.cs
@@ -1,0 +1,87 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenRose.WebUI.Services.NotificationHub
+{
+	/// <summary>
+	/// SignalR Hub for broadcasting traceability-related notifications to connected clients.
+	/// This uses the EXISTING SignalR circuit between Blazor Server and browsers.
+	/// 
+	/// When a user deletes/updates/creates a traceability via the WebUI,
+	/// this hub broadcasts the notification to all other connected users
+	/// viewing that same traceability.
+	/// </summary>
+	public class TraceabilityNotificationHub : Hub
+	{
+		private readonly ILogger<TraceabilityNotificationHub> _logger;
+
+		public TraceabilityNotificationHub(ILogger<TraceabilityNotificationHub> logger)
+		{
+			_logger = logger;
+		}
+
+		/// <summary>
+		/// Called by browser clients to join a group for a specific traceability.
+		/// This way, when a traceability is deleted/updated, we only notify users viewing that traceability.
+		/// 
+		/// Example: User views traceability 123abc, calls SubscribeToTraceabilityAsync(123abc)
+		/// Now this connection is added to group "traceability-123abc"
+		/// When traceability 123abc is deleted, notification is sent to "traceability-123abc" group
+		/// </summary>
+		/// <param name="traceabilityId">The GUID of the traceability to subscribe to notifications for</param>
+		public async Task SubscribeToTraceabilityAsync(Guid traceabilityId)
+		{
+			var groupName = $"traceability-{traceabilityId}";
+			await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) subscribed to traceability {TraceabilityId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				traceabilityId);
+		}
+
+		/// <summary>
+		/// Called when user leaves the traceability view or navigates away.
+		/// Removes the connection from the traceability's notification group.
+		/// </summary>
+		/// <param name="traceabilityId">The GUID of the traceability to unsubscribe from</param>
+		public async Task UnsubscribeFromTraceabilityAsync(Guid traceabilityId)
+		{
+			var groupName = $"traceability-{traceabilityId}";
+			await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+
+			_logger.LogInformation(
+				"User {UserId} (Connection: {ConnectionId}) unsubscribed from traceability {TraceabilityId}",
+				Context.User?.Identity?.Name ?? "Anonymous",
+				Context.ConnectionId,
+				traceabilityId);
+		}
+
+		public override async Task OnConnectedAsync()
+		{
+			_logger.LogInformation(
+				"Client connected: {ConnectionId}, User: {UserId}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous");
+
+			await base.OnConnectedAsync();
+		}
+
+		public override async Task OnDisconnectedAsync(Exception? exception)
+		{
+			_logger.LogInformation(
+				"Client disconnected: {ConnectionId}, User: {UserId}, Reason: {Reason}",
+				Context.ConnectionId,
+				Context.User?.Identity?.Name ?? "Anonymous",
+				exception?.Message ?? "Normal disconnection");
+
+			await base.OnDisconnectedAsync(exception);
+		}
+	}
+}


### PR DESCRIPTION
Users of OpenRose requirements management tool may end-up having direct links or open data views for actual requirements data that is deleted by another user or via a different session. In such case informing user about unavailability of the data from the server side in a graceful manner is important. OpenRose now handles unavailable data request in a better way rather then just throwing FATAL exception on the WebUI side. 

OpenRose system now gracefully handles following record types

Project
Requirement Item Types
Requirement Items
Baseline
Baseline Requirement Item Types
Baseline Requirement Items

We also included immediate notification to the user for one record type which is 'Project'. Now when two users are connected to the same project data via same or different views (i.e. detail or tree views) then any user deleting that project will trigger SignalR based immediate notification to the listening clients. This way users are immediately informed and given choice to go back to the project list / home page so that they do not work with any data that has been removed from the server in the background.


