### PR TITLE
Enable Environment Variable based overrides for Empty String configuration settings

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Services/StartUpConfiguration/OfflineContentPathResolver.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/StartUpConfiguration/OfflineContentPathResolver.cs
@@ -52,18 +52,20 @@ namespace OpenRose.WebUI.Services.StartUpConfiguration
 				_logger.LogInformation(
 					"OfflineContent: StorageFolder is not configured. Server-side JSON mode will be unavailable.");
 			}
-			else if (!IsStorageFolderAvailable)
-			{
-				_logger.LogWarning(
-					"OfflineContent: StorageFolder resolved to '{Path}', but the folder is unavailable (creation failed or inaccessible).",
-					ResolvedStorageFolderPath);
-			}
-			else
-			{
-				_logger.LogInformation(
-					"OfflineContent: StorageFolder resolved to '{Path}' and is available.",
-					ResolvedStorageFolderPath);
-			}
+			#region DELETE ME NEXT TIME
+			//else if (!IsStorageFolderAvailable)
+			//{
+			//	_logger.LogWarning(
+			//		"OfflineContent: StorageFolder resolved to '{Path}', but the folder is unavailable (creation failed or inaccessible).",
+			//		ResolvedStorageFolderPath);
+			//}
+			//else
+			//{
+			//	_logger.LogInformation(
+			//		"OfflineContent: StorageFolder resolved to '{Path}' and is available.",
+			//		ResolvedStorageFolderPath);
+			//}
+			#endregion
 		}
 
 

--- a/OpenRose.Web/OpenRose.WebUI/Services/StartupCapabilitiesService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/StartupCapabilitiesService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace OpenRose.WebUI.Services
 {
@@ -28,18 +29,96 @@ namespace OpenRose.WebUI.Services
 		public bool ApiAvailable { get; }
 		public bool ServerOfflineAvailable { get; }
 
-		public StartupCapabilitiesService(IConfiguration configuration)
+		public StartupCapabilitiesService(IConfiguration configuration,
+										  ILogger<StartupCapabilitiesService>? logger = null)
 		{
+			// If logger was not provided (because Program.cs manually constructs this service),
+			// create a temporary logger using the same logging infrastructure.
+			logger ??= LoggerFactory.Create(builder =>
+			{
+				builder.AddConsole();
+				builder.AddDebug();
+			}).CreateLogger<StartupCapabilitiesService>();
+
+
 			// API is considered available if the section exists AND BaseUrl is non-empty.
 			var apiSection = configuration.GetSection("APISettings");
-			ApiAvailable = apiSection.Exists() &&
-						   !string.IsNullOrWhiteSpace(apiSection["BaseUrl"]);
+			var rawBaseUrl = apiSection["BaseUrl"];
+
+			var normalizedBaseUrl = NormalizeConfigValue(rawBaseUrl);
+
+			// API is available only if normalized BaseUrl is non-empty
+			ApiAvailable = !string.IsNullOrWhiteSpace(normalizedBaseUrl);
+
+			// LOGGING: Provide a single, clear diagnostic entry for API configuration
+			var apiStatusMessage = BuildApiConfigurationStatusMessage(
+				rawBaseUrl ?? "(null)",
+				normalizedBaseUrl,
+				ApiAvailable);
+
+			logger.LogInformation(apiStatusMessage);
+
+
+			#region DELETE ME NEXT TIME
+			//// Offline is considered available if the section exists,
+			//// regardless of folder/file validity.
+			//var serverOfflineSection = configuration.GetSection("OfflineContent");
+			//ServerOfflineAvailable =
+			//	serverOfflineSection.Exists() &&
+			//	!string.IsNullOrWhiteSpace(serverOfflineSection["StorageFolder"]);
+			#endregion
 
 			// Offline is considered available if the section exists,
 			// regardless of folder/file validity.
 			var serverOfflineSection = configuration.GetSection("OfflineContent");
-			ServerOfflineAvailable = serverOfflineSection.Exists() &&
-				   !string.IsNullOrEmpty(serverOfflineSection["StorageFolder"]);
+			var rawStorageFolder = serverOfflineSection["StorageFolder"];
+
+			var normalizedStorageFolder = NormalizeConfigValue(rawStorageFolder);
+
+			// Offline is available only if normalized StorageFolder is non-empty
+			ServerOfflineAvailable = !string.IsNullOrWhiteSpace(normalizedStorageFolder);
+
+		}
+
+		private string BuildApiConfigurationStatusMessage(string rawBaseUrl,
+														  string normalizedBaseUrl,
+														  bool apiAvailable)
+		{
+			var message = new System.Text.StringBuilder();
+
+			message.AppendLine("=== API Configuration ===");
+			message.AppendLine($"  Raw BaseUrl: {rawBaseUrl ?? "(null)"}");
+			message.AppendLine($"  Normalized BaseUrl: {normalizedBaseUrl}");
+			message.AppendLine($"  ApiAvailable: {apiAvailable}");
+			message.Append("=== End API Configuration ===");
+
+			return message.ToString();
+		}
+
+		/// <summary>
+		/// EXPLANATION:
+		/// Normalizes configuration values that may come from environment variables,
+		/// appsettings.json, or other sources where empty values may be represented as:
+		///   - ""
+		///   - "''"
+		///   - "\"\""
+		///   - whitespace
+		///   - null
+		///
+		/// This ensures consistent behavior across all configuration inputs.
+		/// </summary>
+		private static string NormalizeConfigValue(string? value)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+				return string.Empty;
+
+			var trimmed = value.Trim();
+
+			// Treat quoted empty strings as empty
+			if (trimmed == "\"\"" || trimmed == "''")
+				return string.Empty;
+
+			return trimmed;
 		}
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
+++ b/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
@@ -8,19 +8,18 @@
   "AllowedHosts": "*",
   "Http_Ports": "7673",
   // "Https_Ports": "47673",
-  //"APISettings": {
-    //"BaseUrl": "http://localhost:6736"	
-//	"BaseUrl": ""
-//  },
+  "APISettings": {
+    "BaseUrl": "http://localhost:6736"
+  },
   "OfflineContent": {
     //"StorageFolder": "C:\\OpenRoseData\\OfflineFiles",
     "StorageFolder": "OpenRose/OfflineFiles",
-//    "DefaultJsonFile": "OpenRoseData.json"
+    "DefaultJsonFile": "OpenRoseData.json"
   },
   "OpenRose": {
     "UserFilesStorage": {
       "Enabled": true,
       "RootPath": "./user-files"
-	}
+    }
   }
 }

--- a/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
+++ b/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
@@ -8,13 +8,14 @@
   "AllowedHosts": "*",
   "Http_Ports": "7673",
   // "Https_Ports": "47673",
-  "APISettings": {
-    "BaseUrl": "http://localhost:6736"	
-  },
+  //"APISettings": {
+    //"BaseUrl": "http://localhost:6736"	
+//	"BaseUrl": ""
+//  },
   "OfflineContent": {
     //"StorageFolder": "C:\\OpenRoseData\\OfflineFiles",
     "StorageFolder": "OpenRose/OfflineFiles",
-    "DefaultJsonFile": "OpenRoseData.json"
+//    "DefaultJsonFile": "OpenRoseData.json"
   },
   "OpenRose": {
     "UserFilesStorage": {

--- a/OpenRose.Web/OpenRose.WebUI/appsettings.json
+++ b/OpenRose.Web/OpenRose.WebUI/appsettings.json
@@ -10,13 +10,12 @@
   // "Https_Ports": "47673",
   "APISettings": {
     "BaseUrl": "http://localhost:6736"
-  //  "BaseUrl": ""
   },
-//  "OfflineContent": {
+  "OfflineContent": {
     //  "StorageFolder": "C:\\OpenRoseData\\OfflineFiles",
-//    "StorageFolder": "OpenRose/OfflineFiles",
-//    "DefaultJsonFile": "OpenRoseData.json"
-//  },
+    "StorageFolder": "OpenRose/OfflineFiles",
+    "DefaultJsonFile": "OpenRoseData.json"
+  },
   "OpenRose": {
     "UserFilesStorage": {
       "Enabled": true,

--- a/OpenRose.Web/OpenRose.WebUI/appsettings.json
+++ b/OpenRose.Web/OpenRose.WebUI/appsettings.json
@@ -10,12 +10,13 @@
   // "Https_Ports": "47673",
   "APISettings": {
     "BaseUrl": "http://localhost:6736"
+  //  "BaseUrl": ""
   },
-  "OfflineContent": {
+//  "OfflineContent": {
     //  "StorageFolder": "C:\\OpenRoseData\\OfflineFiles",
-    "StorageFolder": "OpenRose/OfflineFiles",
-    "DefaultJsonFile": "OpenRoseData.json"
-  },
+//    "StorageFolder": "OpenRose/OfflineFiles",
+//    "DefaultJsonFile": "OpenRoseData.json"
+//  },
   "OpenRose": {
     "UserFilesStorage": {
       "Enabled": true,


### PR DESCRIPTION
In an OpenRose requirements management tool it's possible to configure settings using AppSettings.json file. Now when installing OpenRose  on a stand alone computer, users will have access to this file so that they can change it as necessary based on their own requirements.

But while installing in Network Environment, Cloud Deployments or even container based deployments, it will not be always possible that administrators will be allowed to change files on the target deployment environment. This is where using Environment Variable comes handy.

With this change, users can set environment variable to an empty value so that they can disable certain start-up features as part of start-up configuration modes supported by OpenRose. 

For example, if user does not want to enable API back-end but deploy OpenRose for Server JSON file content based deployment then they can use following Environment Variable settings to disable API back-end support 

```
setx APISettings__BaseUrl ""
````

Here we are setting value for 'BaseURL' to an empty string using double quotes.

Same way if administrator would like to disable support for Offline Sever JSON data file access then they can set environment variable value as per below...

```
setx OfflineContent__StorageFolder ""

```




