### PR TITLE
Introducing Action tab in all Record Types

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
@@ -228,10 +228,12 @@
 			</MudTabPanel>
 
 
-		@if (CalledFrom == nameof(BaselineDetails))
-		{
-			<MudTabPanel Icon="@Icons.Material.Filled.Cancel" Text="Delete Baseline">
-			<MudItem xs="12" sm="12" md="12" lg="12">
+			<!-- ===================== -->
+            <!-- ACTIONS TAB FOR PROJECT -->
+            <!-- ===================== -->
+
+            <MudTabPanel @ref="deleteTab" Icon="@Icons.Material.Filled.BuildCircle" Text="Actions">
+ 			<MudItem xs="12" sm="12" md="12" lg="12">
 				<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
 					<MudCard style="margin: 16px;" Class="w-100">
 						<MudCardContent>
@@ -243,7 +245,37 @@
 						</MudCardContent>
 					</MudCard>
 				</MudStack>
-				<br />
+
+                <!-- ACTION: Export Baseline as JSON -->
+                <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Large" />
+                        <MudButton Variant="Variant.Filled"
+                                    Color="Color.Primary"
+                                    Size="Size.Medium"
+                                    OnClick="(() => OpenExportJsonPage(singleBaseline.Id))">
+                            Export Baseline (JSON)
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+
+
+                <!-- ACTION: Export Mermaid FlowChart -->
+                <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
+                        <MudButton Variant="Variant.Filled"
+                                    Color="Color.Primary"
+                                    Size="Size.Medium"
+                                           OnClick="(() => OpenMermaidExportPage(singleBaseline.Id))">
+                            Export Mermaid FlowChart
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+
+
+				@if (CalledFrom == nameof(BaselineDetails))
+				{
 				<MudExpansionPanels Elevation="10" style="margin-left : 15px">
 					<MudExpansionPanel style="background-color : #FABBBB; color : red;"
 										Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
@@ -264,9 +296,9 @@
 					</ChildContent>
 					</MudExpansionPanel>
 				</MudExpansionPanels>
+                }
 			</MudItem>
-			</MudTabPanel>
-		}
+			</MudTabPanel> 
 		</MudTabs>
 		</MudItem>
 
@@ -316,6 +348,8 @@
 
 	public bool initializingPage { get; set; } = false;
 	private bool deletingBaseline { get; set; } = false;
+
+	MudTabPanel deleteTab;
 
 	// private string _Content = string.Empty;
 	private string MyContent
@@ -749,6 +783,23 @@
 			isRecalculatingRollUpEstimations = false;
 			StateHasChanged();
 		}
+	}
+
+
+	// ===============================
+	// ACTION TAB METHODS FOR BASELINE
+	// ===============================
+
+	private async Task OpenExportJsonPage(Guid id)
+	{
+		var url = $"/export/Baseline/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private async Task OpenMermaidExportPage(Guid id)
+	{
+		var url = $"/export-mermaid/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzDetails.razor
@@ -162,6 +162,58 @@
 		<MudTabPanel Icon="@Icons.Material.Filled.Hub" Text="Treaceability">
 			<BaselineTraceabilityComponent BaselineItemzId="@BaselineItemzId" />
 		</MudTabPanel>
+
+		<!-- ===================== -->
+		<!-- ACTIONS TAB FOR BASELINE ITEMZ -->
+		<!-- ===================== -->
+
+		<MudTabPanel @ref="deleteTab" Icon="@Icons.Material.Filled.BuildCircle" Text="Actions">
+			<MudItem xs="12" sm="12" md="12" lg="12">
+				<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
+					<MudCard style="margin: 16px;" Class="w-100">
+						<MudCardContent>
+							<MudStack Row="true" Spacing="2">
+								<MudText><strong>ID          : </strong></MudText>
+								<CopyableText TextToCopy="@singleBaselineItemz.Id.ToString()" />
+							</MudStack>
+							<MudText><strong>Name        : </strong> @singleBaselineItemz.Name </MudText>
+							<MudText><strong>Status      : </strong> @singleBaselineItemz.Status </MudText>
+							<MudText><strong>Priority    : </strong> @singleBaselineItemz.Priority </MudText>
+							<MudText><strong>Severity    : </strong> @singleBaselineItemz.Severity </MudText>
+						</MudCardContent>
+					</MudCard>
+				</MudStack>
+
+				<!-- ACTION: Export BaselineItemz as JSON -->
+				<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+					<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+						<MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Large" />
+						<MudButton Variant="Variant.Filled"
+									Color="Color.Primary"
+									Size="Size.Medium"
+									OnClick="(() => OpenExportJsonPage(singleBaselineItemz.Id))">
+							Export Baseline Itemz (JSON)
+						</MudButton>
+					</MudStack>
+				</MudPaper>
+
+
+				<!-- ACTION: Export Mermaid FlowChart -->
+				<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+					<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+						<MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
+						<MudButton Variant="Variant.Filled"
+									Color="Color.Primary"
+									Size="Size.Medium"
+									OnClick="(() => OpenMermaidExportPage(singleBaselineItemz.Id))">
+							Export Mermaid FlowChart
+						</MudButton>
+					</MudStack>
+				</MudPaper>
+
+			</MudItem>
+		</MudTabPanel>
+
 		</MudTabs>
 		
 		</MudPaper>
@@ -190,6 +242,7 @@
 	bool success = true;
 	string[] errors = { };
 	MudForm form;
+	MudTabPanel deleteTab;
 
 	bool hideValidationError = true;
 
@@ -406,6 +459,22 @@
 			// await Task.Delay(1000);
 			// await JS.InvokeVoidAsync("applyMarkdownEditorFullscreenStyles");
 		}
+	}
+
+	// =====================================
+	// ACTION TAB METHODS FOR BASELINE ITEMZ
+	// =====================================
+
+	private async Task OpenExportJsonPage(Guid id)
+	{
+		var url = $"/export/BaselineItemz/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private async Task OpenMermaidExportPage(Guid id)
+	{
+		var url = $"/export-mermaid/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
@@ -143,6 +143,59 @@
 			<MudTabPanel Icon="@Icons.Material.Filled.Hub" Text="Treaceability">
 				<BaselineTraceabilityTreeViewComponent BaselineItemzId="@BaselineItemzId" />
 			</MudTabPanel>
+
+				<!-- ===================== -->
+				<!-- ACTIONS TAB FOR BASELINE ITEMZ -->
+				<!-- ===================== -->
+
+				<MudTabPanel @ref="deleteTab" Icon="@Icons.Material.Filled.BuildCircle" Text="Actions">
+					<MudItem xs="12" sm="12" md="12" lg="12">
+						<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
+							<MudCard style="margin: 16px;" Class="w-100">
+								<MudCardContent>
+									<MudStack Row="true" Spacing="2">
+										<MudText><strong>ID          : </strong></MudText>
+										<CopyableText TextToCopy="@singleBaselineItemz.Id.ToString()" />
+									</MudStack>
+									<MudText><strong>Name        : </strong> @singleBaselineItemz.Name </MudText>
+									<MudText><strong>Status      : </strong> @singleBaselineItemz.Status </MudText>
+									<MudText><strong>Priority    : </strong> @singleBaselineItemz.Priority </MudText>
+									<MudText><strong>Severity    : </strong> @singleBaselineItemz.Severity </MudText>
+								</MudCardContent>
+							</MudCard>
+						</MudStack>
+
+						<!-- ACTION: Export BaselineItemz as JSON -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenExportJsonPage(singleBaselineItemz.Id))">
+									Export Baseline Itemz (JSON)
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
+
+						<!-- ACTION: Export Mermaid FlowChart -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenMermaidExportPage(singleBaselineItemz.Id))">
+									Export Mermaid FlowChart
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
+					</MudItem>
+				</MudTabPanel>
+
+
 		</MudTabs>
 		</MudItem>
 	}
@@ -164,6 +217,7 @@
 	public bool anyChildBaselineItemzExcluded { get; set; } = false;
 
 	private MarkupString convertedMarkdown;
+	MudTabPanel deleteTab;
 
 	private List<string>? tagsList = new List<string>();
 
@@ -463,4 +517,21 @@
 			// await JS.InvokeVoidAsync("applyMarkdownEditorFullscreenStyles");
 		}
 	}
+
+	// =====================================
+	// ACTION TAB METHODS FOR BASELINE ITEMZ
+	// =====================================
+
+	private async Task OpenExportJsonPage(Guid id)
+	{
+		var url = $"/export/BaselineItemz/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private async Task OpenMermaidExportPage(Guid id)
+	{
+		var url = $"/export-mermaid/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
@@ -111,6 +111,61 @@
 												RecordType="BaselineItemzType" />
 				</MudPaper>
 			</MudTabPanel>
+
+
+
+
+
+			<!-- ===================== -->
+            <!-- ACTIONS TAB FOR PROJECT -->
+            <!-- ===================== -->
+
+            <MudTabPanel @ref="deleteTab" Icon="@Icons.Material.Filled.BuildCircle" Text="Actions">
+ 			<MudItem xs="12" sm="12" md="12" lg="12">
+				<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
+					<MudCard style="margin: 16px;" Class="w-100">
+						<MudCardContent>
+							<MudStack Row="true" Spacing="2">
+								<MudText><strong>ID          : </strong></MudText>
+								<CopyableText TextToCopy="@singleBaselineItemzType.Id.ToString()" />
+							</MudStack>
+							<MudText><strong>Name        : </strong> @singleBaselineItemzType.Name </MudText>
+							<MudText><strong>Status      : </strong> @singleBaselineItemzType.Status </MudText>
+							<MudText><strong>Is System?  : </strong> @(singleBaselineItemzType.IsSystem ? "Yes" : "No")</MudText>
+						</MudCardContent>
+					</MudCard>
+				</MudStack>
+
+                <!-- ACTION: Export BaselineItemzType as JSON -->
+                <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Large" />
+                        <MudButton Variant="Variant.Filled"
+                                    Color="Color.Primary"
+                                    Size="Size.Medium"
+                                    OnClick="(() => OpenExportJsonPage(singleBaselineItemzType.Id))">
+                            Export Baseline ItemzType (JSON)
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+
+
+                <!-- ACTION: Export Mermaid FlowChart -->
+                <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
+                        <MudButton Variant="Variant.Filled"
+                                    Color="Color.Primary"
+                                    Size="Size.Medium"
+                                           OnClick="(() => OpenMermaidExportPage(singleBaselineItemzType.Id))">
+                            Export Mermaid FlowChart
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+
+			</MudItem>
+			</MudTabPanel> 
+
 		</MudTabs>
 		</MudItem>
 	}
@@ -127,6 +182,8 @@
     public bool initializingPage { get; set; } = true;
 
     private MarkupString convertedMarkdown;
+
+	MudTabPanel deleteTab;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -255,5 +312,23 @@
             // await JS.InvokeVoidAsync("applyMarkdownEditorFullscreenStyles");
         }
     }
+
+	// ===============================
+	// ACTION TAB METHODS FOR BASELINE
+	// ===============================
+
+	private async Task OpenExportJsonPage(Guid id)
+	{
+		var url = $"/export/BaselineItemzType/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private async Task OpenMermaidExportPage(Guid id)
+	{
+		var url = $"/export-mermaid/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+
 }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
@@ -112,10 +112,6 @@
 				</MudPaper>
 			</MudTabPanel>
 
-
-
-
-
 			<!-- ===================== -->
             <!-- ACTIONS TAB FOR PROJECT -->
             <!-- ===================== -->
@@ -313,9 +309,9 @@
         }
     }
 
-	// ===============================
-	// ACTION TAB METHODS FOR BASELINE
-	// ===============================
+	// =========================================
+	// ACTION TAB METHODS FOR BASELINE ITEMZTYPE
+	// =========================================
 
 	private async Task OpenExportJsonPage(Guid id)
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/CopyRecords/CopyRecords.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/CopyRecords/CopyRecords.razor
@@ -5,6 +5,7 @@
 *@
 
 @page "/copy"
+@page "/copy/{RecordType}/{RecordId:guid}"
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.Services.ItemzType
@@ -29,17 +30,19 @@
 		<MudStack Row="false" Spacing="2" AlignItems="AlignItems.Center" JustifyContent="Justify.Center">
 			<div>
 				<MudTooltip Text="Step 1 is to select Record Type for the data to be copied">
-					<MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success"> STEP 1 </MudChip>
+					<MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success">
+						STEP 1
+					</MudChip>
 				</MudTooltip>
-			</div>
-			<MudStack Row="false" AlignItems="AlignItems.Center" JustifyContent="Justify.Center">
-				<MudText Align="Align.Center">Select Record Type :</MudText> <!-- Center-aligned title -->
-				<MudRadioGroup T="string" Value="@radioRecordType" ValueChanged="OnRadioValueChanged">
-					<MudRadio Value="@("Project")" Color="Color.Primary" Dense="false">Project</MudRadio>
-					<MudRadio Value="@("ItemzType")" Color="Color.Primary" Dense="false">ItemzType</MudRadio>
-					<MudRadio Value="@("Itemz")" Color="Color.Primary" Dense="false">Itemz</MudRadio>
-				</MudRadioGroup>
-			</MudStack>
+				</div>
+				<MudStack Row="false" AlignItems="AlignItems.Center" JustifyContent="Justify.Center">
+					<MudText Align="Align.Center">Select Record Type :</MudText>
+					<MudRadioGroup T="string" Value="@radioRecordType" ValueChanged="OnRadioValueChanged">
+						<MudRadio Value="@("Project")" Color="Color.Primary" Dense="false">Project</MudRadio>
+						<MudRadio Value="@("ItemzType")" Color="Color.Primary" Dense="false">ItemzType</MudRadio>
+						<MudRadio Value="@("Itemz")" Color="Color.Primary" Dense="false">Itemz</MudRadio>
+					</MudRadioGroup>
+				</MudStack>
 		</MudStack>
 		</div>
 	</MudPaper>
@@ -55,9 +58,15 @@
 			<MudTooltip Text="Step 2 is to select Source Record that should be copied">
 				<MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success"> STEP 2 </MudChip>
 			</MudTooltip>
-			<MudButton @onclick="async _ => await SelectSourceRecord()" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Primary">
-				Select @radioRecordType to be copied by ID
-			</MudButton>
+			@if (RecordId == Guid.Empty)
+			{
+				<MudButton @onclick="async _ => await SelectSourceRecord()"
+							Variant="Variant.Filled"
+							Size="Size.Medium"
+							Color="Color.Primary">
+					Select @radioRecordType to be copied by ID
+				</MudButton>
+			}
 		</MudStack>
 		@if (radioRecordType == "Itemz" && copyItemz != null && copyItemz.Id != Guid.Empty)
 		{
@@ -163,6 +172,13 @@
 }
 @code {
 
+	[Parameter] 
+	public string? RecordType { get; set; }
+	[Parameter] 
+	public Guid? RecordId { get; set; }
+
+	[Inject] 
+	public NavigationManager NavManager { get; set; }
 	[Inject]
 	public IItemzService ItemzService { get; set; }
 	[Inject]
@@ -177,6 +193,35 @@
 	public bool copyingOverlay { get; set; } = false;
 
 	public string radioRecordType { get; set; }
+
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (!firstRender)
+			return;
+
+		// Parse query parameters ?recordType=...&recordId=...
+		var uri = NavManager.ToAbsoluteUri(NavManager.Uri);
+		var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+		if (RecordType == null && query.TryGetValue("recordType", out var rt))
+			RecordType = rt.ToString();
+
+		if (RecordId == Guid.Empty && query.TryGetValue("recordId", out var rid))
+			if (Guid.TryParse(rid, out var parsed))
+				RecordId = parsed;
+
+		// If both parameters exist → auto-load
+		if (IsValidRecordType(RecordType) &&
+			RecordId != null &&
+			RecordId != Guid.Empty)
+		{
+			radioRecordType = RecordType!.Trim();   // ensure radio button is pre-selected
+			await AutoLoadSourceRecordAsync(radioRecordType, RecordId.Value);
+			StateHasChanged();
+		}
+	}
+
 
 	public async Task SelectSourceRecord()
 	{
@@ -379,6 +424,7 @@
 		copyProject = new();
 		copyItemzType = new();
 		copyingOverlay = false;
+        RecordId = Guid.Empty;
 	}
 
 	private async Task ShowErrorMessage(string message)
@@ -390,5 +436,66 @@
 	{
 		await DialogService.ShowMessageBox("SUCCESS", markupMessage: new MarkupString($"<p style=\"color: blue;\">{message}</p>"), yesText: "OK");
 	}
-  
+
+	private async Task AutoLoadSourceRecordAsync(string recordType, Guid id)
+	{
+		radioRecordType = recordType; // Set Step 1 automatically
+
+		try
+		{
+			switch (recordType.ToLowerInvariant())
+			{
+				case "itemz":
+					var itemz = await ItemzService.__Single_Itemz_By_GUID_ID__Async(id);
+					if (itemz != null)
+					{
+						copyItemz = itemz;
+						return;
+					}
+					break;
+
+				case "itemztype":
+					var itemzType = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(id);
+					if (itemzType != null)
+					{
+						copyItemzType = itemzType;
+						return;
+					}
+					break;
+
+				case "project":
+					var project = await ProjectService.__Single_Project_By_GUID_ID__Async(id);
+					if (project != null)
+					{
+						copyProject = project;
+						return;
+					}
+					break;
+			}
+
+			await DialogService.ShowMessageBox("ERROR",
+				new MarkupString($"<p style='color:red;'>Could not find {recordType} with ID {id}.</p>"),
+				yesText: "OK");
+            await performCleanUpActivity(); // Clear out any partially loaded data
+		}
+		catch (Exception ex)
+		{
+			await DialogService.ShowMessageBox("ERROR",
+				new MarkupString($"<p style='color:red;'>EXCEPTION :: {ex.Message}</p>"),
+				yesText: "OK");
+			await performCleanUpActivity(); // Clear out any partially loaded data
+		}
+	}
+
+	private bool IsValidRecordType(string? recordType)
+	{
+		if (string.IsNullOrWhiteSpace(recordType))
+			return false;
+
+		var rt = recordType.Trim().ToLowerInvariant();
+
+		return rt == "project" || rt == "itemztype" || rt == "itemz";
+	}
+
+
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportMermaidFlowChart.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportMermaidFlowChart.razor
@@ -5,6 +5,7 @@
 *@
 
 @page "/export-mermaid"
+@page "/export-mermaid/{RecordId:guid}"
 
 @using OpenRose.WebUI.Client.Services.Export
 @using OpenRose.WebUI.Components.Dialogs
@@ -50,7 +51,17 @@
                           Immediate="true"
                           OnKeyDown="@(async e => { if (e.Key == "Enter" && IsGuidInputValid()) { await HandleExportMermaidFlowChartAsync(); } })" />
 
-            <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center" Justify="Justify.FlexStart">
+
+            <MudStack Row="false" Spacing="3" AlignItems="AlignItems.Center" JustifyContent="Justify.Center" Class="w-100">
+                <div>
+                    <MudTooltip Text="Step 2: Select export options">
+                        <MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success">
+                            STEP 2
+                        </MudChip>
+                    </MudTooltip>
+                </div>
+
+                <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center" Justify="Justify.FlexStart">
 
                 <MudCheckBox @bind-Value="exportIncludedBaselineItemzOnly"
                              Label="Only export BaselineItemz marked for Inclusion" />
@@ -71,28 +82,37 @@
                              Value="includeTags"
                              ValueChanged="@((bool x) => OnIncludeTagsChanged(x))" />
 
+                </MudStack>
             </MudStack>
 
+            <MudStack Row="false" Spacing="3" AlignItems="AlignItems.Center" JustifyContent="Justify.Center" Class="w-100">
+                <div>
+                    <MudTooltip Text="Step 3: Generate Mermaid FlowChart">
+                        <MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success">
+                            STEP 3
+                        </MudChip>
+                    </MudTooltip>
+                </div>
+                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                    <MudButton Variant="Variant.Filled"
+                            Size="Size.Medium"
+                            Color="Color.Primary"
+                            Disabled="!IsGuidInputValid() || loading"
+                            OnClick="async () => await HandleExportMermaidFlowChartAsync()">
+                        @if (loading)
+                        {
+                            <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                        }
+                        else
+                        {
+                            <span>Export Mermaid FlowChart</span>
+                        }
+                    </MudButton>
 
-            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
-                <MudButton Variant="Variant.Filled"
-                           Size="Size.Medium"
-                           Color="Color.Primary"
-                           Disabled="!IsGuidInputValid() || loading"
-                           OnClick="async () => await HandleExportMermaidFlowChartAsync()">
-                    @if (loading)
-                    {
-                        <MudProgressCircular Indeterminate="true" Size="Size.Small" />
-                    }
-                    else
-                    {
-                        <span>Export Mermaid FlowChart</span>
-                    }
+                    <MudButton OnClick="Reset" Variant="Variant.Filled" Color="Color.Warning">
+                        Reset
                 </MudButton>
-
-                <MudButton OnClick="Reset" Variant="Variant.Filled" Color="Color.Warning">
-                    Reset
-                </MudButton>
+                </MudStack>
             </MudStack>
         </MudStack>
     </MudPaper>
@@ -160,6 +180,17 @@
 </style>
 
 @code {
+
+    [Parameter]
+    public Guid? RecordId { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (RecordId.HasValue && RecordId.Value != Guid.Empty)
+        {
+            targetGuidText = RecordId.Value.ToString();
+        }
+    }
 
     private string targetGuidText { get; set; } = string.Empty;
     private bool exportIncludedBaselineItemzOnly { get; set; } = false;
@@ -243,6 +274,7 @@
         mermaidText = string.Empty;
         exportIncludedBaselineItemzOnly = false;
         loading = false;
+        RecordId = Guid.Empty;
     }
 
     // This is the method Blazor will call when ValueChanged fires

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportRecords.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ExportRecords/ExportRecords.razor
@@ -5,6 +5,7 @@
 *@
 
 @page "/export"
+@page "/export/{RecordType}/{RecordId:guid}"
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.Services.Project
 @using OpenRose.WebUI.Client.Services.ItemzType
@@ -227,6 +228,15 @@
 }
 
 @code {
+    [Parameter]
+    public string? RecordType { get; set; }
+
+    [Parameter]
+    public Guid? RecordId { get; set; }
+
+    [Inject]
+    public NavigationManager NavManager { get; set; }
+
     public string recordType { get; set; }
     public Guid selectedRecordId { get; set; } = Guid.Empty;
     public bool exportingOverlay { get; set; } = false;
@@ -239,6 +249,35 @@
     public GetBaselineDTO selectedBaseline { get; set; } = new();
     public GetBaselineItemzTypeDTO selectedBaselineItemzType { get; set; } = new();
     public GetBaselineItemzDTO selectedBaselineItemz { get; set; } = new();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        // Parse query parameters ?recordType=...&recordId=...
+        var uri = NavManager.ToAbsoluteUri(NavManager.Uri);
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+        if (RecordType == null && query.TryGetValue("recordType", out var rt))
+            RecordType = rt.ToString();
+
+        if ((RecordId == null || RecordId == Guid.Empty) && query.TryGetValue("recordId", out var rid))
+            if (Guid.TryParse(rid, out var parsed))
+                RecordId = parsed;
+
+        // If both parameters exist → auto-load
+        if (IsValidRecordType(RecordType) &&
+            RecordId != null &&
+            RecordId != Guid.Empty)
+        {
+            recordType = RecordType!.Trim();   // Step 1 auto-select
+            selectedRecordId = RecordId.Value; // Step 2 auto-select
+            await AutoLoadSourceRecordAsync(recordType, RecordId.Value);
+            StateHasChanged();
+        }
+    }
+
 
     private async Task OnRecordTypeChanged(string newValue)
     {
@@ -312,6 +351,70 @@
             await ShowErrorMessage($"Could not find {type} with ID {id} in repository.");
             await ResetSelection();
         }
+    }
+
+    private async Task AutoLoadSourceRecordAsync(string recordType, Guid id)
+    {
+        this.recordType = recordType; // Step 1 auto-select
+
+        try
+        {
+            switch (recordType.Trim().ToLowerInvariant())
+            {
+                case "project":
+                    selectedProject = await ProjectService.__Single_Project_By_GUID_ID__Async(id) ?? new();
+                    if (selectedProject.Id != Guid.Empty) return;
+                    break;
+
+                case "itemztype":
+                    selectedItemzType = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(id) ?? new();
+                    if (selectedItemzType.Id != Guid.Empty) return;
+                    break;
+
+                case "itemz":
+                    selectedItemz = await ItemzService.__Single_Itemz_By_GUID_ID__Async(id) ?? new();
+                    if (selectedItemz.Id != Guid.Empty) return;
+                    break;
+
+                case "baseline":
+                    selectedBaseline = await BaselinesService.__Single_Baseline_By_GUID_ID__Async(id) ?? new();
+                    if (selectedBaseline.Id != Guid.Empty) return;
+                    break;
+
+                case "baselineitemztype":
+                    selectedBaselineItemzType = await BaselineItemzTypesService.__Single_BaselineItemzType_By_GUID_ID__Async(id) ?? new();
+                    if (selectedBaselineItemzType.Id != Guid.Empty) return;
+                    break;
+
+                case "baselineitemz":
+                    selectedBaselineItemz = await BaselineItemzService.__Single_BaselineItemz_By_GUID_ID__Async(id) ?? new();
+                    if (selectedBaselineItemz.Id != Guid.Empty) return;
+                    break;
+            }
+
+            await ShowErrorMessage($"Could not find {recordType} with ID {id}.");
+            await ResetSelection();
+        }
+        catch (Exception ex)
+        {
+            await ShowErrorMessage($"EXCEPTION :: {ex.Message}");
+            await ResetSelection();
+        }
+    }
+
+    private bool IsValidRecordType(string? recordType)
+    {
+        if (string.IsNullOrWhiteSpace(recordType))
+            return false;
+
+        var rt = recordType.Trim().ToLowerInvariant();
+
+        return rt == "project"
+            || rt == "itemztype"
+            || rt == "itemz"
+            || rt == "baseline"
+            || rt == "baselineitemztype"
+            || rt == "baselineitemz";
     }
 
     private bool HasSelectedRecord()

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -345,10 +345,8 @@
 							</MudCard>
 						</MudStack>
 
-						<br />
-
 						<!-- ACTIONS HEADER -->
-						<MudPaper Class="pa-3 mb-3" Outlined="false">
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;" Outlined="false">
 							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
 
 								<!-- Move Itemz Under -->
@@ -365,7 +363,7 @@
 						</MudPaper>
 
 						<!-- ACTIONS HEADER -->
-						<MudPaper Class="pa-3 mb-3" Outlined="false">
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;" Outlined="false">
 							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
 								<MudIcon Icon="@Icons.Material.Filled.Compress" Size="Size.Large" />
 
@@ -380,7 +378,7 @@
 						</MudPaper>
 						
 						<!-- ACTIONS HEADER -->
-						<MudPaper Class="pa-3 mb-3" Outlined="false">
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;" Outlined="false">
 							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
 								<MudIcon Icon="@Icons.Material.Filled.AutoAwesomeMotion" Size="Size.Large" />
 
@@ -394,9 +392,24 @@
 							</MudStack>
 						</MudPaper>
 
-						<br />
+						<!-- Export Mermaid FlowChart -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;" Outlined="false">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
 
-						<MudExpansionPanels Elevation="10" style="margin-left : 15px">
+								<MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
+
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   Style="gap: 10px;"
+										   OnClick="(() => OpenMermaidExportPage(singleItemz.Id))">
+									<MudText>Export Mermaid FlowChart</MudText>
+								</MudButton>
+
+							</MudStack>
+						</MudPaper>
+
+						<MudExpansionPanels Elevation="10" style="margin: 16px;">
 							<MudExpansionPanel style="background-color : #FABBBB; color : red;"
 											   Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
 								<TitleContent>
@@ -1141,6 +1154,12 @@
 	{
 		var url = $"/copy/Itemz/{id}";
 		await JS.InvokeVoidAsync("open", url, "_blank");
+	}
+
+	private async Task OpenMermaidExportPage(Guid id)
+	{
+		var url = $"/export-mermaid/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -392,6 +392,19 @@
 							</MudStack>
 						</MudPaper>
 
+						<!-- ACTION: Export Itemz as JSON -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenExportJsonPage(singleItemz.Id))">
+									Export ItemzType (JSON)
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
 						<!-- Export Mermaid FlowChart -->
 						<MudPaper Class="pa-3 mb-3" style="margin: 16px;" Outlined="false">
 							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
@@ -1154,6 +1167,12 @@
 	{
 		var url = $"/copy/Itemz/{id}";
 		await JS.InvokeVoidAsync("open", url, "_blank");
+	}
+
+	private async Task OpenExportJsonPage(Guid id)
+	{
+		var url = $"/export/Itemz/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
 
 	private async Task OpenMermaidExportPage(Guid id)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -378,6 +378,22 @@
 								</MudButton>
 							</MudStack>
 						</MudPaper>
+						
+						<!-- ACTIONS HEADER -->
+						<MudPaper Class="pa-3 mb-3" Outlined="false">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.AutoAwesomeMotion" Size="Size.Large" />
+
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   Style="gap: 10px;"
+										   OnClick="(() => OpenCopyPage(singleItemz.Id))">
+									<MudText>Copy Itemz</MudText>
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
 						<br />
 
 						<MudExpansionPanels Elevation="10" style="margin-left : 15px">
@@ -1121,5 +1137,10 @@
 		await JS.InvokeVoidAsync("open", url, "_blank");
 	}
 
+	private async Task OpenCopyPage(Guid id)
+	{
+		var url = $"/copy/Itemz/{id}";
+		await JS.InvokeVoidAsync("open", url, "_blank");
+	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -324,47 +324,79 @@
 					</MudPaper>
 				</MudItem>
 			</MudTabPanel>
-			<MudTabPanel Icon="@Icons.Material.Filled.Cancel" Text="Delete Itemz">
- 			<MudItem xs="12" sm="12" md="12" lg="12">
-				<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-					<MudCard style="margin: 16px;" Class="w-100">
-						<MudCardContent Style="padding : 6px">
-							<MudStack Row="true" Spacing="2">
-								<MudText><strong>ID          : </strong></MudText>
-								<CopyableText TextToCopy="@singleItemz.Id.ToString()" />
-								<ShowHierarchyTreeButton RecordId="@singleItemz.Id" />
+@* 			<MudTabPanel Icon="@Icons.Material.Filled.Cancel" Text="Delete Itemz"> *@
+				<MudTabPanel Icon="@Icons.Material.Filled.BuildCircle" Text="Actions">
+					<MudItem xs="12" sm="12" md="12" lg="12">
+
+						<!-- EXISTING DELETE UI (kept exactly as-is) -->
+						<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
+							<MudCard style="margin: 16px;" Class="w-100">
+								<MudCardContent Style="padding : 6px">
+									<MudStack Row="true" Spacing="2">
+										<MudText><strong>ID          : </strong></MudText>
+										<CopyableText TextToCopy="@singleItemz.Id.ToString()" />
+										<ShowHierarchyTreeButton RecordId="@singleItemz.Id" />
+									</MudStack>
+									<MudText><strong>Name        : </strong> @singleItemz.Name </MudText>
+									<MudText><strong>Status      : </strong> @singleItemz.Status</MudText>
+									<MudText><strong>Priority    : </strong> @singleItemz.Priority</MudText>
+									<MudText><strong>Severity    : </strong> @singleItemz.Severity</MudText>
+								</MudCardContent>
+							</MudCard>
+						</MudStack>
+
+						<br />
+
+						<!-- ACTIONS HEADER -->
+						<MudPaper Class="pa-3 mb-3" Outlined="false">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+
+								<!-- Move Itemz Under -->
+								<MudIcon Icon="@Icons.Material.Filled.ConnectingAirports" Size="Size.Large" />
+
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   Style="gap: 10px;"
+										   OnClick="(() => OpenMoveItemzPage(singleItemz.Id))">
+									<MudText>Move Itemz Under</MudText>
+								</MudButton>
 							</MudStack>
-							<MudText><strong>Name        : </strong> @singleItemz.Name </MudText>
-							<MudText><strong>Status      : </strong> @singleItemz.Status</MudText>
-							<MudText><strong>Priority    : </strong> @singleItemz.Priority</MudText>
-							<MudText><strong>Severity    : </strong> @singleItemz.Severity</MudText>
-						</MudCardContent>
-					</MudCard>
-				</MudStack>
-				<br />
-					<MudExpansionPanels Elevation="10" style="margin-left : 15px">
-						<MudExpansionPanel style="background-color : #FABBBB; color : red;"
-							Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
-						<TitleContent>
-							<div class="d-flex">
-								<MudIcon Icon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Medium" class="mr-3"></MudIcon>
-								<MudText Color="Color.Error"><strong>DANGER ZONE!</strong></MudText>
-							</div>
-						</TitleContent>
-						<ChildContent>
-							<MudText Typo="Typo.body1" Color="Color.Error">Deleting Itemz means losing all it's data including all Child Itemz Tree Nodes. </MudText>
-							<MudText Typo="Typo.body1" Color="Color.Error">This is <STRONG>IRREVERSIBLE</STRONG> operation.</MudText>
-							<MudButton @onclick="OpenDeleteConfirmationDialogAsync" Variant="Variant.Filled"
-								Disabled="@(disableUpdateItemzDetailsButton || FormStateService.IsDirty(ItemzId))"
-								Color="Color.Error" Size="Size.Large" style="align-items: center; margin-top : 10px">
-								Delete Itemz
-							</MudButton>
-						</ChildContent>
-					</MudExpansionPanel>
-				</MudExpansionPanels>
-			</MudItem>
-			</MudTabPanel>
-		</MudTabs>
+						</MudPaper>
+
+						<br />
+
+						<MudExpansionPanels Elevation="10" style="margin-left : 15px">
+							<MudExpansionPanel style="background-color : #FABBBB; color : red;"
+											   Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
+								<TitleContent>
+									<div class="d-flex">
+										<MudIcon Icon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Medium" class="mr-3"></MudIcon>
+										<MudText Color="Color.Error"><strong>DANGER ZONE!</strong></MudText>
+									</div>
+								</TitleContent>
+								<ChildContent>
+									<MudText Typo="Typo.body1" Color="Color.Error">
+										Deleting Itemz means losing all its data including all Child Itemz Tree Nodes.
+									</MudText>
+									<MudText Typo="Typo.body1" Color="Color.Error">
+										This is <strong>IRREVERSIBLE</strong> operation.
+									</MudText>
+									<MudButton @onclick="OpenDeleteConfirmationDialogAsync"
+											   Variant="Variant.Filled"
+											   Disabled="@(disableUpdateItemzDetailsButton || FormStateService.IsDirty(ItemzId))"
+											   Color="Color.Error"
+											   Size="Size.Large"
+											   style="align-items: center; margin-top : 10px">
+										Delete Itemz
+									</MudButton>
+								</ChildContent>
+							</MudExpansionPanel>
+						</MudExpansionPanels>
+
+					</MudItem>
+				</MudTabPanel>
+			</MudTabs>
 @* 		</MudContainer> *@
 @* 		</MudPaper> *@
 		</MudItem>
@@ -1062,4 +1094,11 @@
 	{
 		TreeNodeItemzSelectionService.ScrollToTreeViewNode(ItemzId);
 	}
+
+	private async Task OpenMoveItemzPage(Guid id)
+	{
+		var url = $"/moveitemz?recordId={id}";
+		await JS.InvokeVoidAsync("open", url, "_blank");
+	}
+
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -364,6 +364,20 @@
 							</MudStack>
 						</MudPaper>
 
+						<!-- ACTIONS HEADER -->
+						<MudPaper Class="pa-3 mb-3" Outlined="false">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.Compress" Size="Size.Large" />
+
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   Style="gap: 10px;"
+										   OnClick="(() => OpenMoveItemzBetweenPage(singleItemz.Id))">
+									<MudText>Move Itemz Between</MudText>
+								</MudButton>
+							</MudStack>
+						</MudPaper>
 						<br />
 
 						<MudExpansionPanels Elevation="10" style="margin-left : 15px">
@@ -1100,5 +1114,12 @@
 		var url = $"/moveitemz?recordId={id}";
 		await JS.InvokeVoidAsync("open", url, "_blank");
 	}
+
+	private async Task OpenMoveItemzBetweenPage(Guid id)
+	{
+		var url = $"/moveitemzbetween?recordId={id}";
+		await JS.InvokeVoidAsync("open", url, "_blank");
+	}
+
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -253,7 +253,7 @@
 						<!-- ACTION: Move ItemzType Between -->
 						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
 							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
-								<MudIcon Icon="@Icons.Material.Filled.Compress" Size="Size.Large" />
+								<MudIcon Icon="@Icons.Material.Filled.FormatIndentIncrease" Size="Size.Large" />
 								<MudButton Variant="Variant.Filled"
 										   Color="Color.Primary"
 										   Size="Size.Medium"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -276,6 +276,19 @@
 							</MudStack>
 						</MudPaper>
 
+						<!-- ACTION: Export ItemzType as JSON -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenExportJsonPage(singleItemzType.Id))">
+									Export ItemzType (JSON)
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
 						<!-- ACTION: Export Mermaid FlowChart -->
 						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
 							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
@@ -818,11 +831,16 @@
 		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
 
+	private async Task OpenExportJsonPage(Guid id)
+	{
+		var url = $"/export/ItemzType/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
 	private async Task OpenMermaidExportPage(Guid id)
 	{
 		var url = $"/export-mermaid/{id}";
 		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
-
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -218,46 +218,100 @@
 				</MudPaper>
 			</MudTabPanel>
 
-			@if (CalledFrom == nameof(ItemzTypeDetails) && (singleItemzType.IsSystem == false))
-			{
-				<MudTabPanel Icon="@Icons.Material.Filled.Cancel" Text="Delete ItemzType">
- 				<MudItem xs="12" sm="12" md="12" lg="12">
-					<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
-						<MudCard style="margin: 16px;" Class="w-100">
-							<MudCardContent>
-								<MudStack Row="true" Spacing="2">
-									<MudText><strong>ID          : </strong></MudText>
-									<CopyableText TextToCopy="@singleItemzType.Id.ToString()" />
-									<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
-								</MudStack>
-								<MudText><strong>Name        : </strong> @singleItemzType.Name </MudText>
-										<MudText><strong>Status      : </strong> @singleItemzType.Status</MudText>
-							</MudCardContent>
-						</MudCard>
-					</MudStack>
-					<br />
-					<MudExpansionPanels Elevation="10" style="margin-left : 15px">
-						<MudExpansionPanel style="background-color : #FABBBB; color : red;"
-											Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
-						<TitleContent>
-							<div class="d-flex">
-								<MudIcon Icon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Medium" class="mr-3"></MudIcon>
-								<MudText Color="Color.Error"><strong>DANGER ZONE!</strong></MudText>
-							</div>
-						</TitleContent>
-						<ChildContent>
-							<MudText Typo="Typo.body1" Color="Color.Error">Deleting itemzType means loosing all it's data. This is <STRONG>IRREVERSIBLE</STRONG> operation.</MudText>
-							<MudButton @onclick="OpenDeleteConfirmationDialogAsync" Variant="Variant.Filled"
-								Disabled="@(disableUpdateItemzTypeDetailsButton || FormStateService.IsDirty(ItemzTypeId))"
-								Color="Color.Error" Size="Size.Large" style="align-items: center; margin-top : 10px">
-							Delete ItemzType
-							</MudButton>
-						</ChildContent>
-						</MudExpansionPanel>
-					</MudExpansionPanels>
-				</MudItem>
+				<MudTabPanel Icon="@Icons.Material.Filled.BuildCircle" Text="Actions">
+					<MudItem xs="12" sm="12" md="12" lg="12">
+
+						<!-- DETAILS CARD -->
+						<MudStack Row="true" Spacing="2" Class="w-100">
+							<MudCard style="margin: 16px;" Class="w-100">
+								<MudCardContent Style="padding : 6px">
+									<MudStack Row="true" Spacing="2">
+										<MudText><strong>ID          : </strong></MudText>
+										<CopyableText TextToCopy="@singleItemzType.Id.ToString()" />
+										<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
+									</MudStack>
+									<MudText><strong>Name        : </strong> @singleItemzType.Name </MudText>
+									<MudText><strong>Status      : </strong> @singleItemzType.Status</MudText>
+									<MudText><strong>IsSystem    : </strong> @singleItemzType.IsSystem</MudText>
+								</MudCardContent>
+							</MudCard>
+						</MudStack>
+
+						<!-- ACTION: Move ItemzType Under Project -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.AirlineStops" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenMoveItemzTypePage(singleItemzType.Id))">
+									Move ItemzType Under Project
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
+						<!-- ACTION: Move ItemzType Between -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.Compress" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenMoveItemzTypeBetweenPage(singleItemzType.Id))">
+									Move ItemzType Between
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
+						<!-- ACTION: Copy ItemzType -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.AutoAwesomeMotion" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenCopyItemzTypePage(singleItemzType.Id))">
+									Copy ItemzType
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+
+						<!-- ACTION: Export Mermaid FlowChart -->
+						<MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+							<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+								<MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
+								<MudButton Variant="Variant.Filled"
+										   Color="Color.Primary"
+										   Size="Size.Medium"
+										   OnClick="(() => OpenMermaidExportPage(singleItemzType.Id))">
+									Export Mermaid FlowChart
+								</MudButton>
+							</MudStack>
+						</MudPaper>
+ 						@if (CalledFrom == nameof(ItemzTypeDetails) && (singleItemzType.IsSystem == false))
+						{
+							<MudExpansionPanels Elevation="10" style="margin : 16px">
+								<MudExpansionPanel style="background-color : #FABBBB; color : red;"
+								Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
+									<TitleContent>
+										<div class="d-flex">
+											<MudIcon Icon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Medium" class="mr-3"></MudIcon>
+											<MudText Color="Color.Error"><strong>DANGER ZONE!</strong></MudText>
+										</div>
+									</TitleContent>
+									<ChildContent>
+										<MudText Typo="Typo.body1" Color="Color.Error">Deleting itemzType means loosing all it's data. This is <STRONG>IRREVERSIBLE</STRONG> operation.</MudText>
+										<MudButton @onclick="OpenDeleteConfirmationDialogAsync" Variant="Variant.Filled"
+										Disabled="@(disableUpdateItemzTypeDetailsButton || FormStateService.IsDirty(ItemzTypeId))"
+										Color="Color.Error" Size="Size.Large" style="align-items: center; margin-top : 10px">
+											Delete ItemzType
+										</MudButton>
+									</ChildContent>
+								</MudExpansionPanel>
+							</MudExpansionPanels>
+						}
+					</MudItem>
 				</MudTabPanel>
-			}
 		</MudTabs>
 	</MudItem>
 
@@ -745,5 +799,30 @@
 	{
 		TreeNodeItemzSelectionService.ScrollToTreeViewNode(ItemzTypeId);
     }
+
+	private async Task OpenMoveItemzTypePage(Guid id)
+	{
+		var url = $"/moveitemztype/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private async Task OpenMoveItemzTypeBetweenPage(Guid id)
+	{
+		var url = $"/moveitemztypebetween/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private async Task OpenCopyItemzTypePage(Guid id)
+	{
+		var url = $"/copy/ItemzType/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private async Task OpenMermaidExportPage(Guid id)
+	{
+		var url = $"/export-mermaid/{id}";
+		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemz/MoveItemz.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemz/MoveItemz.razor
@@ -5,6 +5,7 @@
 *@
 
 @page "/moveitemz"
+@page "/moveitemz/{RecordId:guid}"
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.Services.ItemzType
@@ -29,7 +30,15 @@
 				<MudTooltip Text="Step 1 is to select Source Itemz that should be moved">
 					<MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success"> STEP 1 </MudChip>
 				</MudTooltip>
-				<MudButton @onclick="async _ => await selectSourceItemz()" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Primary"> Select Source Itemz </MudButton>
+				@if (sourceItemz == null || sourceItemz.Id == Guid.Empty)
+				{
+					<MudButton @onclick="async _ => await selectSourceItemz()"
+							   Variant="Variant.Filled"
+							   Size="Size.Medium"
+							   Color="Color.Primary">
+						Select Source Itemz
+					</MudButton>
+				}
 			</MudStack>
 			@if (sourceItemz != null && sourceItemz.Id != Guid.Empty)
 			{
@@ -153,10 +162,15 @@
 }
 @code {
 
+	[Parameter] 
+	public Guid? RecordId { get; set; }
+
 	[Inject]
 	public IItemzService ItemzService { get; set; }
 	[Inject]
 	public IItemzTypeService ItemzTypeService { get; set; }
+	[Inject] 
+	public NavigationManager NavManager { get; set; }
 
 	public GetItemzDTO sourceItemz { get; set; } = new();
 	public GetItemzDTO targetItemz { get; set; } = new();
@@ -164,6 +178,30 @@
 	public bool radioAtBottomOfChildList { get; set; } = true;
 	public bool movingItemzOverlay { get; set; } = false;
 
+
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (!firstRender)
+			return;
+
+		// Parse query parameter ?recordId=...
+		var uri = NavManager.ToAbsoluteUri(NavManager.Uri);
+		var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+		if (RecordId == null && query.TryGetValue("recordId", out var idStr))
+		{
+			if (Guid.TryParse(idStr, out var parsed))
+				RecordId = parsed;
+		}
+
+		// If we have a valid RecordId, auto-load the source Itemz
+		if (RecordId != null && RecordId != Guid.Empty)
+		{
+			await LoadSourceItemzAsync(RecordId.Value);
+			StateHasChanged();
+		}
+	}
 
 	public async Task selectSourceItemz()
 	{
@@ -351,6 +389,32 @@
 		radioAtBottomOfChildList = true;
 		movingItemzOverlay = false;
 	}
+
+	private async Task LoadSourceItemzAsync(Guid id)
+	{
+		try
+		{
+			var found = await ItemzService.__Single_Itemz_By_GUID_ID__Async(id);
+
+			if (found != null)
+			{
+				sourceItemz = found;
+			}
+			else
+			{
+				await DialogService.ShowMessageBox("ERROR",
+					new MarkupString($"<p style=\"color:red;\">Could not find Source Itemz with ID {id}.</p>"),
+					yesText: "OK");
+			}
+		}
+		catch (Exception ex)
+		{
+			await DialogService.ShowMessageBox("ERROR",
+				new MarkupString($"<p style=\"color:red;\">EXCEPTION :: {ex.Message}</p>"),
+				yesText: "OK");
+		}
+	}
+
 
 	// private async Task<(bool isEligible, string checkEligibilityErrorMessage)> CheckTargetEligibility(GetItemzDTO checkTargetItemz)
 	// {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemz/MoveItemzBetween.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemz/MoveItemzBetween.razor
@@ -5,6 +5,7 @@
 *@
 
 @page "/moveitemzbetween"
+@page "/moveitemzbetween/{RecordId:guid}"
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.Services.Hierarchy
@@ -27,9 +28,20 @@
 		<div class="d-flex flex-column align-items-center justify-center w-100 h-100">
 			<MudStack Row="true" Spacing="2">
 				<MudTooltip Text="Step 1 is to select Source Itemz that should be moved">
-					<MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success"> STEP 1 </MudChip>
+					<MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success">
+						STEP 1
+					</MudChip>
 				</MudTooltip>
-				<MudButton @onclick="async _ => await selectSourceItemz()" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Primary"> Select Source Itemz </MudButton>
+
+				@if (sourceItemz == null || sourceItemz.Id == Guid.Empty)
+				{
+					<MudButton @onclick="async _ => await selectSourceItemz()"
+							   Variant="Variant.Filled"
+							   Size="Size.Medium"
+							   Color="Color.Primary">
+						Select Source Itemz
+					</MudButton>
+				}
 			</MudStack>
 			@if (sourceItemz != null && sourceItemz.Id != Guid.Empty)
 			{
@@ -132,15 +144,44 @@
 }
 @code {
 
+	[Parameter] 
+	public Guid? RecordId { get; set; }
+
 	[Inject]
 	public IItemzService ItemzService { get; set; }
 	[Inject]
 	public IHierarchyService HierarchyService { get; set; }
+	[Inject]
+	public NavigationManager NavManager { get; set; }
 
 	public GetItemzDTO sourceItemz { get; set; } = new();
 	public GetItemzDTO targetFirstItemz { get; set; } = new();
 	public GetItemzDTO targetSecondItemz { get; set; } = new();
 	public bool movingItemzOverlay { get; set; } = false;
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (!firstRender)
+			return;
+
+		// Parse query parameter ?recordId=...
+		var uri = NavManager.ToAbsoluteUri(NavManager.Uri);
+		var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+		if (RecordId == null && query.TryGetValue("recordId", out var idStr))
+		{
+			if (Guid.TryParse(idStr, out var parsed))
+				RecordId = parsed;
+		}
+
+		// Auto-load source Itemz
+		if (RecordId != null && RecordId != Guid.Empty)
+		{
+			await LoadSourceItemzAsync(RecordId.Value);
+			StateHasChanged();
+		}
+	}
+
 
 	public async Task selectSourceItemz()
 	{
@@ -302,5 +343,30 @@
 
 	// 	return (true, checkEligibilityErrorMessage);
 	// }
-  
+
+	private async Task LoadSourceItemzAsync(Guid id)
+	{
+		try
+		{
+			var found = await ItemzService.__Single_Itemz_By_GUID_ID__Async(id);
+
+			if (found != null)
+			{
+				sourceItemz = found;
+			}
+			else
+			{
+				await DialogService.ShowMessageBox("ERROR",
+					new MarkupString($"<p style='color:red;'>Could not find Source Itemz with ID {id}.</p>"),
+					yesText: "OK");
+			}
+		}
+		catch (Exception ex)
+		{
+			await DialogService.ShowMessageBox("ERROR",
+				new MarkupString($"<p style='color:red;'>EXCEPTION :: {ex.Message}</p>"),
+				yesText: "OK");
+		}
+	}
+
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemzType/MoveItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemzType/MoveItemzType.razor
@@ -5,7 +5,7 @@
 *@
 
 @page "/moveitemztype"
-@page "/moveitemztype/{SourceItemzTypeId:guid}"
+@page "/moveitemztype/{ParamSourceItemzTypeId:guid}"
 
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.Services.Itemz
@@ -135,7 +135,7 @@
 @code {
 
 	[Parameter]
-	public Guid? SourceItemzTypeId { get; set; }
+	public Guid? ParamSourceItemzTypeId { get; set; }
 
 	[Inject]
 	public IItemzService ItemzService { get; set; }
@@ -155,9 +155,9 @@
 
 	protected override async Task OnParametersSetAsync()
 	{
-		if (SourceItemzTypeId.HasValue && SourceItemzTypeId.Value != Guid.Empty)
+		if (ParamSourceItemzTypeId.HasValue && ParamSourceItemzTypeId.Value != Guid.Empty)
 		{
-			await LoadSourceItemzTypeAsync(SourceItemzTypeId.Value);
+			await LoadSourceItemzTypeAsync(ParamSourceItemzTypeId.Value);
 			_yesDisableSelectTargetProject = false;   // allow Step 2
 		}
 	}
@@ -330,7 +330,7 @@
 		_yesDisableSelectTargetProject = false;
 		radioAtBottomOfChildList = true;
 		movingItemzTypeOverlay = false;
-        SourceItemzTypeId = Guid.Empty;
+        ParamSourceItemzTypeId = Guid.Empty;
 	}
 
 	private async Task LoadSourceItemzTypeAsync(Guid id)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemzType/MoveItemzType.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemzType/MoveItemzType.razor
@@ -5,6 +5,8 @@
 *@
 
 @page "/moveitemztype"
+@page "/moveitemztype/{SourceItemzTypeId:guid}"
+
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.Services.Itemz
 @using OpenRose.WebUI.Client.Services.ItemzType
@@ -132,6 +134,9 @@
 }
 @code {
 
+	[Parameter]
+	public Guid? SourceItemzTypeId { get; set; }
+
 	[Inject]
 	public IItemzService ItemzService { get; set; }
 	[Inject]
@@ -146,6 +151,16 @@
 	public bool radioAtBottomOfChildList { get; set; } = true;
 	public bool movingItemzTypeOverlay { get; set; } = false;
 	public bool _yesDisableSelectTargetProject { get; set; } = false;
+
+
+	protected override async Task OnParametersSetAsync()
+	{
+		if (SourceItemzTypeId.HasValue && SourceItemzTypeId.Value != Guid.Empty)
+		{
+			await LoadSourceItemzTypeAsync(SourceItemzTypeId.Value);
+			_yesDisableSelectTargetProject = false;   // allow Step 2
+		}
+	}
 
 
 	public async Task selectSourceItemzType()
@@ -315,6 +330,36 @@
 		_yesDisableSelectTargetProject = false;
 		radioAtBottomOfChildList = true;
 		movingItemzTypeOverlay = false;
+        SourceItemzTypeId = Guid.Empty;
+	}
+
+	private async Task LoadSourceItemzTypeAsync(Guid id)
+	{
+		try
+		{
+			var found = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(id);
+
+			if (found != null)
+			{
+				sourceItemzType = found;
+			}
+			else
+			{
+				await DialogService.ShowMessageBox("ERROR",
+					markupMessage: new MarkupString($"<p style='color:red;'>Could not find ItemzType with ID {id}.</p>"),
+					yesText: "OK");
+
+				await performCleanUpActivity();
+			}
+		}
+		catch
+		{
+			await DialogService.ShowMessageBox("ERROR",
+				markupMessage: new MarkupString($"<p style='color:red;'>EXCEPTION: Could not load ItemzType with ID {id}.</p>"),
+				yesText: "OK");
+
+			await performCleanUpActivity();
+		}
 	}
 
 	// private async Task<(bool isEligible, string checkEligibilityErrorMessage)> CheckTargetEligibility(GetItemzDTO checkTargetItemz)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemzType/MoveItemzTypeBetween.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/MoveItemzType/MoveItemzTypeBetween.razor
@@ -5,6 +5,8 @@
 *@
 
 @page "/moveitemztypebetween"
+@page "/moveitemztypebetween/{ParamSourceItemzTypeId:guid}"
+
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Client.Services.ItemzType
 @using OpenRose.WebUI.Client.Services.Hierarchy
@@ -29,7 +31,12 @@
 				<MudTooltip Text="Step 1 : Select Source ItemzType that should be moved">
 					<MudChip T="string" Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Color="Color.Success"> STEP 1 </MudChip>
 				</MudTooltip>
-				<MudButton @onclick="async _ => await selectSourceItemzType()" Variant="Variant.Filled" Size="Size.Medium" Color="Color.Primary"> Select Source ItemzType </MudButton>
+				<MudButton @onclick="async _ => await selectSourceItemzType()"
+						   Variant="Variant.Filled"
+						   Size="Size.Medium"
+						   Color="Color.Primary">
+					Select Source ItemzType
+				</MudButton>
 			</MudStack>
 			@if (sourceItemzType != null && sourceItemzType.Id != Guid.Empty)
 			{
@@ -128,6 +135,8 @@
 	</MudPaper>
 }
 @code {
+	[Parameter]
+	public Guid? ParamSourceItemzTypeId { get; set; }
 
 	[Inject]
 	public IItemzTypeService ItemzTypeService { get; set; }
@@ -138,6 +147,17 @@
 	public GetItemzTypeDTO targetFirstItemzType { get; set; } = new();
 	public GetItemzTypeDTO targetSecondItemzType { get; set; } = new();
 	public bool movingItemzTypeOverlay { get; set; } = false;
+
+	protected override async Task OnParametersSetAsync()
+	{
+		if (ParamSourceItemzTypeId.HasValue && ParamSourceItemzTypeId.Value != Guid.Empty)
+		{
+			await LoadSourceItemzTypeAsync(ParamSourceItemzTypeId.Value);
+
+			StateHasChanged();
+		}
+	}
+
 
 	public async Task selectSourceItemzType()
 	{
@@ -286,6 +306,40 @@
 		targetFirstItemzType = new();
 		targetSecondItemzType = new();
 		movingItemzTypeOverlay = false;
+        ParamSourceItemzTypeId = Guid.Empty;
+	}
+
+	private async Task LoadSourceItemzTypeAsync(Guid id)
+	{
+		try
+		{
+			var found = await ItemzTypeService.__Single_ItemzType_By_GUID_ID__Async(id);
+
+			if (found != null)
+			{
+				sourceItemzType = found;
+
+				// Clear target siblings
+				targetFirstItemzType = new();
+				targetSecondItemzType = new();
+			}
+			else
+			{
+				await DialogService.ShowMessageBox("ERROR",
+					markupMessage: new MarkupString($"<p style='color:red;'>Could not find ItemzType with ID {id}.</p>"),
+					yesText: "OK");
+
+				sourceItemzType = new();
+			}
+		}
+		catch
+		{
+			await DialogService.ShowMessageBox("ERROR",
+				markupMessage: new MarkupString($"<p style='color:red;'>EXCEPTION: Could not load ItemzType with ID {id}.</p>"),
+				yesText: "OK");
+
+			sourceItemzType = new();
+		}
 	}
 
 	// private async Task<(bool isEligible, string checkEligibilityErrorMessage)> CheckTargetEligibility(GetItemzDTO checkTargetItemz)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -282,6 +282,20 @@
                     </MudStack>
                 </MudPaper>
 
+                <!-- ACTION: Export Project as JSON -->
+                <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.FileDownload" Size="Size.Large" />
+                        <MudButton Variant="Variant.Filled"
+                                    Color="Color.Primary"
+                                    Size="Size.Medium"
+                                    OnClick="(() => OpenExportJsonPage(singleProject.Id))">
+                            Export Project (JSON)
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+
+
                 <!-- ACTION: Export Mermaid FlowChart -->
                 <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
                     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
@@ -318,8 +332,6 @@
                 }
 			</MudItem>
 			</MudTabPanel> 
-
-
 		</MudTabs>
 	</MudContainer>
 	<MudItem xs="12" sm="12">
@@ -1172,6 +1184,12 @@
     private async Task OpenCopyProjectPage(Guid id)
     {
         var url = $"/copy/Project/{id}";
+        await JS.InvokeVoidAsync("openInNewTab", url);
+    }
+
+    private async Task OpenExportJsonPage(Guid id)
+    {
+        var url = $"/export/Project/{id}";
         await JS.InvokeVoidAsync("openInNewTab", url);
     }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -249,9 +249,12 @@
 					<ProjectBaselineComponent ProjectId="@ProjectId" />
 				</MudPaper>
 			</MudTabPanel>
-			@if (CalledFrom == nameof(ProjectDetails))
-			{
-			<MudTabPanel @ref="deleteTab" Icon="@Icons.Material.Filled.Cancel" Text="Delete Project">
+
+            <!-- ===================== -->
+            <!-- ACTIONS TAB FOR PROJECT -->
+            <!-- ===================== -->
+
+            <MudTabPanel @ref="deleteTab" Icon="@Icons.Material.Filled.BuildCircle" Text="Actions">
  			<MudItem xs="12" sm="12" md="12" lg="12">
 				<MudStack Row="true" Spacing="2" StretchItems="StretchItems.None" AlignItems="AlignItems.Start" Class="w-100">
 					<MudCard style="margin: 16px;" Class="w-100">
@@ -265,10 +268,39 @@
 						</MudCardContent>
 					</MudCard>
 				</MudStack>
-				<br />
-				<MudExpansionPanels Elevation="10" style="margin-left : 15px">
-					<MudExpansionPanel style="background-color : #FABBBB; color : red;"
-										Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
+
+                <!-- ACTION: Copy Project -->
+                <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.AutoAwesomeMotion" Size="Size.Large" />
+                        <MudButton Variant="Variant.Filled"
+                                    Color="Color.Primary"
+                                    Size="Size.Medium"
+                                           OnClick="(() => OpenCopyProjectPage(singleProject.Id))">
+                            Copy Project
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+
+                <!-- ACTION: Export Mermaid FlowChart -->
+                <MudPaper Class="pa-3 mb-3" style="margin: 16px;">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.GraphicEq" Size="Size.Large" />
+                        <MudButton Variant="Variant.Filled"
+                                    Color="Color.Primary"
+                                    Size="Size.Medium"
+                                           OnClick="(() => OpenMermaidExportPage(singleProject.Id))">
+                            Export Mermaid FlowChart
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+
+
+                @if (CalledFrom == nameof(ProjectDetails))
+                {
+                <MudExpansionPanels Elevation="10" style="margin : 16px">
+                    <MudExpansionPanel style="background-color : #FABBBB; color : red;"
+							Text="DANGER ZONE!" MaxHeight="150" Expanded="false">
 					<TitleContent>
 						<div class="d-flex">
 							<MudIcon Icon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Medium" class="mr-3"></MudIcon>
@@ -283,9 +315,11 @@
 					</ChildContent>
 					</MudExpansionPanel>
 				</MudExpansionPanels>
+                }
 			</MudItem>
-			</MudTabPanel>
-			}
+			</MudTabPanel> 
+
+
 		</MudTabs>
 	</MudContainer>
 	<MudItem xs="12" sm="12">
@@ -1130,4 +1164,34 @@
     }
 
     #endregion
+
+    // ===============================
+    // ACTION TAB METHODS FOR PROJECT
+    // ===============================
+
+    private async Task OpenCopyProjectPage(Guid id)
+    {
+        var url = $"/copy/Project/{id}";
+        await JS.InvokeVoidAsync("openInNewTab", url);
+    }
+
+    private async Task OpenMermaidExportPage(Guid id)
+    {
+        var url = $"/export-mermaid/{id}";
+        await JS.InvokeVoidAsync("openInNewTab", url);
+    }
+
+
+    // private async Task OpenCopyProjectPage()
+    // {
+    //     var url = $"/copyrecords?recordType=Project&recordId={ProjectId}";
+    //     await JS.InvokeVoidAsync("openInNewTab", url);
+    // }
+
+    // private async Task OpenExportMermaidPage()
+    // {
+    //     var url = $"/exportmermaidflowchart/{ProjectId}";
+    //     await JS.InvokeVoidAsync("openInNewTab", url);
+    // }
+
 }


### PR DESCRIPTION
Adding ability to allow users to perform actions like

- Move 
- Copy
- Export
- Export Mermaid Diagrams
- Delete 

from within the given record type's details component UI pages. Instead of copying ID of the record in focus and then opening separate page for the given action and performing paste of the ID to take action, we now allow users to just click on the desired action from the newly introduced Action Tab which will open target action page with source record details filled in. 

This new feature will improve users experience of working with OpenRose by performing desired action with ease of clicking on a button rather then multiple locations. 