### PR TITLE
Implemented Traceability properties toggle support for ReadOnly Views

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineTraceability/BaselineTraceabilityReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineTraceability/BaselineTraceabilityReadOnlyComponent.razor
@@ -34,14 +34,17 @@
 				 FixedHeader="true"
 				 HeaderClass="background-color: red;">
 		<Columns>
-			<PropertyColumn Property="x => x.Id" Title="Id" Filterable="false">
-				<CellTemplate>
-					<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
-					<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-					<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
-					</div>
-				</CellTemplate>
-			</PropertyColumn>
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Id" Title="Id" Filterable="false">
+					<CellTemplate>
+						<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
+						<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+						<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
+						</div>
+					</CellTemplate>
+				</PropertyColumn>
+			}
 			<PropertyColumn Property="x => x.Name" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
 			<PropertyColumn Property="x => x.TraceLabel" Title="Trace Label" Filterable="false">
 				<CellTemplate>
@@ -57,8 +60,11 @@
 					}
 				</CellTemplate>
 			</PropertyColumn>
-			<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
-			<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+				<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+			}
 			<TemplateColumn Title="Action">
 				<CellTemplate>
 					<div style="display: flex; justify-content: left; align-items: center; gap: 10px;">
@@ -133,14 +139,17 @@
 				 FixedHeader="true"
 				 HeaderClass="background-color: red;">
 		<Columns>
-			<PropertyColumn Property="x => x.Id" Title="Id">
-				<CellTemplate>
-					<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
-					<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-					<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
-					</div>
-				</CellTemplate>
-			</PropertyColumn>
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Id" Title="Id">
+					<CellTemplate>
+						<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
+						<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+						<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
+						</div>
+					</CellTemplate>
+				</PropertyColumn>
+			}
 			<PropertyColumn Property="x => x.Name" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
 			<PropertyColumn Property="x => x.TraceLabel" Title="Trace Label">
 				<CellTemplate>
@@ -156,9 +165,11 @@
 					}
 				</CellTemplate>
 			</PropertyColumn>
-
-			<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
-			<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+				<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+			}
 			<TemplateColumn CellClass="d-flex justify-left">
 				<CellTemplate>
 					<MudButton Size="@Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineTraceability/BaselineTraceabilityReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineTraceability/BaselineTraceabilityReadOnlyComponentForJson.razor
@@ -28,12 +28,15 @@
                  Striped="true"
                  FixedHeader="true">
         <Columns>
-            <PropertyColumn Property="x => x.Id" Title="Id">
-                <CellTemplate>
-                    <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-                </CellTemplate>
-            </PropertyColumn>
 
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Id" Title="Id">
+                    <CellTemplate>
+                        <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+                    </CellTemplate>
+                </PropertyColumn>
+            }
             <PropertyColumn Property="x => x.Name" CellStyle="max-width: 100px; white-space: normal;" />
 
             <PropertyColumn Property="x => x.TraceLabel" Title="Trace Label">
@@ -48,10 +51,11 @@
                     }
                 </CellTemplate>
             </PropertyColumn>
-
-            <PropertyColumn Property="x => x.Status" />
-            <PropertyColumn Property="x => x.Priority" />
-
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Status" />
+                <PropertyColumn Property="x => x.Priority" />
+            }
             <TemplateColumn Title="Action">
                 <CellTemplate>
                     <MudButton Size="@Size.Small"
@@ -114,12 +118,14 @@
                  Striped="true"
                  FixedHeader="true">
         <Columns>
-            <PropertyColumn Property="x => x.Id" Title="Id">
-                <CellTemplate>
-                    <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-                </CellTemplate>
-            </PropertyColumn>
-
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Id" Title="Id">
+                    <CellTemplate>
+                        <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+                    </CellTemplate>
+                </PropertyColumn>
+            }
             <PropertyColumn Property="x => x.Name" CellStyle="max-width: 100px; white-space: normal;" />
 
             <PropertyColumn Property="x => x.TraceLabel" Title="Trace Label">
@@ -134,10 +140,11 @@
                     }
                 </CellTemplate>
             </PropertyColumn>
-
-            <PropertyColumn Property="x => x.Status" />
-            <PropertyColumn Property="x => x.Priority" />
-
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Status" />
+                <PropertyColumn Property="x => x.Priority" />
+            }
             <TemplateColumn Title="Action">
                 <CellTemplate>
                     <MudButton Size="@Size.Small"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponent.razor
@@ -34,16 +34,19 @@
 				 FixedHeader="true"
 				 HeaderClass="background-color: red;">
 		<Columns>
-			<PropertyColumn Property="x => x.Id"
-							Title="Id"
-							Filterable="false">
-				<CellTemplate>
-					<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
-						<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-						<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
-					</div>
-				</CellTemplate>
-			</PropertyColumn>
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Id"
+								Title="Id"
+								Filterable="false">
+					<CellTemplate>
+						<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
+							<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+							<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
+						</div>
+					</CellTemplate>
+				</PropertyColumn>
+			}
 			<PropertyColumn Property="x => x.Name" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
 			<PropertyColumn Property="x => x.TraceLabel" Title="Trace Label" Filterable="false">
 				<CellTemplate>
@@ -59,8 +62,12 @@
 					}
 				</CellTemplate>
 			</PropertyColumn>
-			<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
-			<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+				<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+			}
 			<TemplateColumn Title="Action">
 				<CellTemplate>
 					<div style="display: flex; justify-content: left; align-items: center; gap: 10px;">
@@ -87,7 +94,7 @@
 				<CellTemplate>
 					<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
 						<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
-                        @context.Item.Name	
+						@context.Item.Name	
 					</div>
 				</CellTemplate>
 			</PropertyColumn>
@@ -135,16 +142,19 @@
 				 FixedHeader="true"
 				 HeaderClass="background-color: red;">
 		<Columns>
-			<PropertyColumn Property="x => x.Id"
-							Title="Id"
-							Filterable="false">
-				<CellTemplate>
-					<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
-						<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-						<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
-					</div>
-				</CellTemplate>
-			</PropertyColumn>
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Id"
+								Title="Id"
+								Filterable="false">
+					<CellTemplate>
+						<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
+							<CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+							<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
+						</div>
+					</CellTemplate>
+				</PropertyColumn>
+			}
 			<PropertyColumn Property="x => x.Name" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
 			<PropertyColumn Property="x => x.TraceLabel" Title="Trace Label" Filterable="false">
 				<CellTemplate>
@@ -160,9 +170,11 @@
 					}
 				</CellTemplate>
 			</PropertyColumn>
-
-			<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
-			<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+			@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+			{
+				<PropertyColumn Property="x => x.Status" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+				<PropertyColumn Property="x => x.Priority" Filterable="false" CellStyle="max-width: 100px; overflow-x: visible; white-space: normal; " />
+			}
 			<TemplateColumn CellClass="d-flex justify-left">
 				<CellTemplate>
 					<MudButton Size="@Size.Large"
@@ -187,7 +199,7 @@
 				<CellTemplate>
 					<div style="display: flex; align-items: center; gap: 6px; white-space: nowrap;">
 						<ShowHierarchyTreeButton RecordId="@context.Item.Id" />
-                        @context.Item.Name	
+						@context.Item.Name	
 					</div>
 				</CellTemplate>
 			</PropertyColumn>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/Traceability/TraceabilityReadOnlyComponentForJson.razor
@@ -28,11 +28,14 @@
                  Striped="true"
                  FixedHeader="true">
         <Columns>
-            <PropertyColumn Property="x => x.Id" Title="Id" Filterable="false">
-                <CellTemplate>
-                    <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-                </CellTemplate>
-            </PropertyColumn>
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Id" Title="Id" Filterable="false">
+                    <CellTemplate>
+                        <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+                    </CellTemplate>
+                </PropertyColumn>
+            }
             <PropertyColumn Property="x => x.Name" Filterable="false" CellStyle="max-width: 100px; white-space: normal;" />
             <PropertyColumn Property="x => x.TraceLabel" Title="Trace Label" Filterable="false">
                 <CellTemplate>
@@ -46,8 +49,11 @@
                     }
                 </CellTemplate>
             </PropertyColumn>
-            <PropertyColumn Property="x => x.Status" Filterable="false" />
-            <PropertyColumn Property="x => x.Priority" Filterable="false" />
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Status" Filterable="false" />
+                <PropertyColumn Property="x => x.Priority" Filterable="false" />
+            }
             <TemplateColumn Title="Action">
                 <CellTemplate>
                     <MudButton Size="@Size.Small"
@@ -112,11 +118,14 @@
                  Striped="true"
                  FixedHeader="true">
         <Columns>
-            <PropertyColumn Property="x => x.Id" Title="Id">
-                <CellTemplate>
-                    <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
-                </CellTemplate>
-            </PropertyColumn>
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Id" Title="Id">
+                    <CellTemplate>
+                        <CopyableText TextToCopy="@context.Item.Id.ToString()" DisplayLength="8" />
+                    </CellTemplate>
+                </PropertyColumn>
+            }
             <PropertyColumn Property="x => x.Name" Filterable="false" CellStyle="max-width: 100px; white-space: normal;" />
             <PropertyColumn Property="x => x.TraceLabel" Title="Trace Label" Filterable="false">
                 <CellTemplate>
@@ -130,8 +139,11 @@
                     }
                 </CellTemplate>
             </PropertyColumn>
-            <PropertyColumn Property="x => x.Status" Filterable="false" />
-            <PropertyColumn Property="x => x.Priority" Filterable="false" />
+            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+            {
+                <PropertyColumn Property="x => x.Status" Filterable="false" />
+                <PropertyColumn Property="x => x.Priority" Filterable="false" />
+            }
             <TemplateColumn Title="Action">
                 <CellTemplate>
                     <MudButton Size="@Size.Small"


### PR DESCRIPTION
Fixes #141 

Now, properties like ID, Status, Priority will not show up in LIVE as well as Baseline Traceability ReadOnly component. The implementation takes into account both the, online connected mode as well as Offline mode, to control displaying properties in the traceability component. 

