### PR TITLE
TreeView Splitter to be thicker and supports double clicking enhancement

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
@@ -34,10 +34,13 @@
 
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
+                            Height="@_height"
                             OnDoubleClicked="@OnDoubleClicked"
                             BarStyle="width:9px !important;"
-                            EnableSlide="@_sliderEnabled" EnableMargin="@_marginEnabled" Sensitivity="_sensitivity"
-                            Height="@_height" Bordered="_borderedEnabled">
+                            EnableSlide="true" 
+                            EnableMargin="true" 
+                            Sensitivity="_sensitivity"
+                            Bordered="false">
     <StartContent>
         <MudPaper Elevation="0" Class="full-width">
             @if (showLoadingMessage)
@@ -196,10 +199,7 @@
     string _height = "calc(100vh - 80px)";
     double _sensitivity = 0.3d;
     double _percentage = 27;
-    bool _sliderEnabled = true;
-    bool _marginEnabled = true;
-    bool _borderedEnabled = false;
-    bool _doubleClickEnabled = true;
+
 
     private List<Guid> _linearIds = new();
     private int _currentIndex = -1;
@@ -212,16 +212,13 @@
 
     private Task OnDoubleClicked()
     {
-        if (_doubleClickEnabled)
+        if (_percentage == 27)
         {
-            if (_percentage == 27)
-            {
-                _percentage = 1;
-            }
-            else
-            {
-                _percentage = 27;
-            }
+            _percentage = 1;
+        }
+        else
+        {
+            _percentage = 27;
         }
         return Task.CompletedTask;
     }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
@@ -35,7 +35,7 @@
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             OnDoubleClicked="@OnDoubleClicked"
-                            BarStyle="width:6px !important;"
+                            BarStyle="width:9px !important;"
                             EnableSlide="@_sliderEnabled" EnableMargin="@_marginEnabled" Sensitivity="_sensitivity"
                             Height="@_height" Bordered="_borderedEnabled">
     <StartContent>
@@ -214,7 +214,14 @@
     {
         if (_doubleClickEnabled)
         {
-            _percentage = 27;
+            if (_percentage == 27)
+            {
+                _percentage = 1;
+            }
+            else
+            {
+                _percentage = 27;
+            }
         }
         return Task.CompletedTask;
     }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -25,7 +25,7 @@
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"
-                            BarStyle="width:6px !important;"
+                            BarStyle="width:9px !important;"
                             EnableSlide="true"
                             EnableMargin="true"
                             Bordered="false">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -25,9 +25,11 @@
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"
+                            OnDoubleClicked="@OnDoubleClicked"
                             BarStyle="width:9px !important;"
                             EnableSlide="true"
                             EnableMargin="true"
+                            Sensitivity="_sensitivity"
                             Bordered="false">
 
     <!-- LEFT: TREE -->
@@ -189,8 +191,9 @@
 
     private List<TreeItemPresenter> _flatList;
 
-    // splitter layout
+    // Variables related to MudSlidder
     string _height = "calc(100vh - 80px)";
+    double _sensitivity = 0.3d;
     double _percentage = 27;
 
     // Kiosk mode variables
@@ -200,6 +203,20 @@
     private const int ClickTimeoutMs = 700;
 
     private bool showEstimation = true; // Toggle to show estimation in end text
+
+
+    private Task OnDoubleClicked()
+    {
+        if (_percentage == 27)
+        {
+            _percentage = 1;
+        }
+        else
+        {
+            _percentage = 27;
+        }
+        return Task.CompletedTask;
+    }
 
     public class TreeItemPresenter : MudBlazor.TreeItemData<Guid>
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -36,10 +36,13 @@
 @inject ProjectDeletionService DeletionService
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
+                            Height="@_height"
                             OnDoubleClicked="@OnDoubleClicked"
                             BarStyle="width:9px !important;"
-                            EnableSlide="@_sliderEnabled" EnableMargin="@_marginEnabled" Sensitivity="_sensitivity"
-                            Height="@_height" Bordered="_borderedEnabled">
+                            EnableSlide="true" 
+                            EnableMargin="true" 
+                            Sensitivity="_sensitivity"
+                            Bordered="false">
     <StartContent>
         <MudPaper Elevation="0" Class="full-width">
             @if (showLoadingMessage)
@@ -194,15 +197,10 @@
     private List<HierarchyIdRecordDetailsDTO> AllItemzTypesForProject { get; set; } = new List<HierarchyIdRecordDetailsDTO>();
     public bool initializingPage { get; set; } = false;
 
-
     // Variables related to MudSlidder
     string _height = "calc(100vh - 75px)";
     double _sensitivity = 0.3d;
     double _percentage = 27;
-    bool _sliderEnabled = true;
-    bool _marginEnabled = true;
-    bool _borderedEnabled = false;
-    bool _doubleClickEnabled = true;
 
     // Varibale related to selecting node in treeview
     private bool _suppressSelectionChanged;
@@ -220,16 +218,13 @@
 
     private Task OnDoubleClicked()
     {
-        if (_doubleClickEnabled)
+        if (_percentage == 27)
         {
-            if (_percentage == 27)
-            {
-                _percentage = 1;
-            }
-            else
-            {
-                _percentage = 27;
-            }
+            _percentage = 1;
+        }
+        else
+        {
+            _percentage = 27;
         }
         return Task.CompletedTask;
     }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -37,7 +37,7 @@
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             OnDoubleClicked="@OnDoubleClicked"
-                            BarStyle="width:6px !important;"
+                            BarStyle="width:9px !important;"
                             EnableSlide="@_sliderEnabled" EnableMargin="@_marginEnabled" Sensitivity="_sensitivity"
                             Height="@_height" Bordered="_borderedEnabled">
     <StartContent>
@@ -222,7 +222,14 @@
     {
         if (_doubleClickEnabled)
         {
-            _percentage = 27;
+            if (_percentage == 27)
+            {
+                _percentage = 1;
+            }
+            else
+            {
+                _percentage = 27;
+            }
         }
         return Task.CompletedTask;
     }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -26,7 +26,7 @@
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"
-                            BarStyle="width:6px !important;"
+                            BarStyle="width:9px !important;"
                             EnableSlide="true"
                             EnableMargin="true"
                             Bordered="false">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -26,9 +26,11 @@
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"
+                            OnDoubleClicked="@OnDoubleClicked"
                             BarStyle="width:9px !important;"
                             EnableSlide="true"
                             EnableMargin="true"
+                            Sensitivity="_sensitivity"
                             Bordered="false">
 
     <!-- LEFT SIDE: TREE -->
@@ -146,7 +148,9 @@
     private Guid _selectedValue;
     private TreeItemPresenter? selectedItem;
 
+    // Variables related to MudSlidder
     string _height = "calc(100vh - 80px)";
+    double _sensitivity = 0.3d;
     double _percentage = 27;
 
     private Dictionary<Guid, TreeItemPresenter> _nodeLookup
@@ -161,6 +165,19 @@
     private const int ClickTimeoutMs = 700;
 
     private bool showEstimation = true; // Toggle to show estimation in end text
+
+    private Task OnDoubleClicked()
+    {
+        if (_percentage == 27)
+        {
+            _percentage = 1;
+        }
+        else
+        {
+            _percentage = 27;
+        }
+        return Task.CompletedTask;
+    }
 
     public class TreeItemPresenter : MudBlazor.TreeItemData<Guid>
     {


### PR DESCRIPTION
Fixes #143 

This implementation in OpenRose Requirements Management Tool allows users to work with TreeView more effectively as the vertical splitter bar is more thicker and supports double clicking. With thicker vertical splitter bar, mobile users of the requirements management tool will have better UI UX experience to scroll left and right based on their preference to see TreeView data. 

This enhancement is now implemented in following components...

- Project TreeView 
- Project ReadOnly TreeView 
- Baseline TreeView 
- Baseline ReadOnly TreeView 

Users hosting just JSON data in OpenRose WebUI application will also be able to take benefit of this supported enhancement as JSON data file views are nothing but ReadOnly TreeViews.


