### PR TITLE
Applied String Length limit on Title for affected DTOs

### DIFF
--- a/OpenRose.API/Models/GetBaselineDTO.cs
+++ b/OpenRose.API/Models/GetBaselineDTO.cs
@@ -3,39 +3,41 @@
 // See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace ItemzApp.API.Models
 {
-    /// <summary>
-    /// BaselineDTO is a POCO used for serving requests like GetBaselines or GetBaseline by BaselineID.
-    /// It will carry specified set of data that are exposed when baseline details are requested throgh "ItemzApp.API"
-    /// </summary>
-    public class GetBaselineDTO
-    {
-        /// <summary>
-        /// Id of the Baseline representated by a GUID.
-        /// </summary>
-        public Guid Id { get; set; }
-        /// <summary>
-        /// Baseline Name 
-        /// </summary>
-        public string? Name { get; set; }
-        /// <summary>
-        /// Description of the Baseline
-        /// </summary>
-        public string? Description { get; set; }
-        /// <summary>
-        /// User who created the Baseline
-        /// </summary>
-        public string? CreatedBy { get; set; }
-        /// <summary>
-        /// Date and Time when Baseline was created
-        /// </summary>
-        public DateTimeOffset CreatedDate { get; set; }
+	/// <summary>
+	/// BaselineDTO is a POCO used for serving requests like GetBaselines or GetBaseline by BaselineID.
+	/// It will carry specified set of data that are exposed when baseline details are requested throgh "ItemzApp.API"
+	/// </summary>
+	public class GetBaselineDTO
+	{
+		/// <summary>
+		/// Id of the Baseline representated by a GUID.
+		/// </summary>
+		public Guid Id { get; set; }
+		/// <summary>
+		/// Baseline Name 
+		/// </summary>
+		[StringLength(128, ErrorMessage = "Name length can't be more than 128 characters.")]
+		public string? Name { get; set; }
+		/// <summary>
+		/// Description of the Baseline
+		/// </summary>
+		public string? Description { get; set; }
+		/// <summary>
+		/// User who created the Baseline
+		/// </summary>
+		public string? CreatedBy { get; set; }
+		/// <summary>
+		/// Date and Time when Baseline was created
+		/// </summary>
+		public DateTimeOffset CreatedDate { get; set; }
 
-        /// <summary>
-        /// Baseline is contained within provided ProjectId
-        /// </summary>
+		/// <summary>
+		/// Baseline is contained within provided ProjectId
+		/// </summary>
 		public Guid ProjectId { get; set; }
 	}
 }

--- a/OpenRose.API/Models/GetItemzDTO.cs
+++ b/OpenRose.API/Models/GetItemzDTO.cs
@@ -3,48 +3,50 @@
 // See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace ItemzApp.API.Models
 {
-    /// <summary>
-    /// Itemz class containing several properties that represents it.
-    /// This Itemz class is returned by the "ItemzApp.API" in most of the cases when
-    /// user sends request to read an Itemz record.
-    /// </summary>
-    public class GetItemzDTO
-    {
-        /// <summary>
-        /// Id of the Itemz representated by a GUID.
-        /// </summary>
-        public Guid Id { get; set; }
-        /// <summary>
-        /// Name or Title of the Itemz
-        /// </summary>
-        public string? Name { get; set; }
-        /// <summary>
-        /// Status of the itemz
-        /// </summary>
-        public string? Status { get; set; }
-        /// <summary>
-        /// Priority of the Itemz
-        /// </summary>
-        public string? Priority { get; set; }
-        /// <summary>
-        /// Description of the Itemz
-        /// </summary>
-        public string? Description { get; set; }
-        /// <summary>
-        /// User who created the Itemz
-        /// </summary>
-        public string? CreatedBy { get; set; }
-        /// <summary>
-        /// Date and Time when Itemz was created
-        /// </summary>
-        public DateTimeOffset CreatedDate { get; set; }
-        /// <summary>
-        /// Severity of the Itemz
-        /// </summary>
-        public string? Severity { get; set; }
+	/// <summary>
+	/// Itemz class containing several properties that represents it.
+	/// This Itemz class is returned by the "ItemzApp.API" in most of the cases when
+	/// user sends request to read an Itemz record.
+	/// </summary>
+	public class GetItemzDTO
+	{
+		/// <summary>
+		/// Id of the Itemz representated by a GUID.
+		/// </summary>
+		public Guid Id { get; set; }
+		/// <summary>
+		/// Name or Title of the Itemz
+		/// </summary>
+		[StringLength(128, ErrorMessage = "Name length can't be more than 128 characters.")]
+		public string? Name { get; set; }
+		/// <summary>
+		/// Status of the itemz
+		/// </summary>
+		public string? Status { get; set; }
+		/// <summary>
+		/// Priority of the Itemz
+		/// </summary>
+		public string? Priority { get; set; }
+		/// <summary>
+		/// Description of the Itemz
+		/// </summary>
+		public string? Description { get; set; }
+		/// <summary>
+		/// User who created the Itemz
+		/// </summary>
+		public string? CreatedBy { get; set; }
+		/// <summary>
+		/// Date and Time when Itemz was created
+		/// </summary>
+		public DateTimeOffset CreatedDate { get; set; }
+		/// <summary>
+		/// Severity of the Itemz
+		/// </summary>
+		public string? Severity { get; set; }
 
 		/// <summary>
 		/// Tags associated with this Itemz.

--- a/OpenRose.API/Models/GetItemzTypeDTO.cs
+++ b/OpenRose.API/Models/GetItemzTypeDTO.cs
@@ -3,42 +3,44 @@
 // See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace ItemzApp.API.Models
 {
-    /// <summary>
-    /// ItemzTypeDTO is a POCO used for serving requests like GetItemzTypes or GetItemzType by ItemzTypeID.
-    /// It will carry specified set of data that are exposed when ItemzType details are requested throgh "ItemzApp.API"
-    /// </summary>
-    public class GetItemzTypeDTO
-    {
-        /// <summary>
-        /// Id of the ItemzType representated by a GUID.
-        /// </summary>
-        public Guid Id { get; set; }
-        /// <summary>
-        /// ItemzType Name 
-        /// </summary>
-        public string? Name { get; set; }
-        /// <summary>
-        /// Status of the ItemzType
-        /// </summary>
-        public string? Status { get; set; }
-        /// <summary>
-        /// Description of the ItemzType
-        /// </summary>
-        public string? Description { get; set; }
-        /// <summary>
-        /// User who created the ItemzType
-        /// </summary>
-        public string? CreatedBy { get; set; }
-        /// <summary>
-        /// Date and Time when ItemzType was created
-        /// </summary>
-        public DateTimeOffset CreatedDate { get; set; }
-        /// <summary>
-        /// Returns true if it's system ItemzType otherwise false
-        /// </summary>
-        public bool IsSystem { get; set; }
-    }
+	/// <summary>
+	/// ItemzTypeDTO is a POCO used for serving requests like GetItemzTypes or GetItemzType by ItemzTypeID.
+	/// It will carry specified set of data that are exposed when ItemzType details are requested throgh "ItemzApp.API"
+	/// </summary>
+	public class GetItemzTypeDTO
+	{
+		/// <summary>
+		/// Id of the ItemzType representated by a GUID.
+		/// </summary>
+		public Guid Id { get; set; }
+		/// <summary>
+		/// ItemzType Name 
+		/// </summary>
+		[StringLength(128, ErrorMessage = "Name length can't be more than 128 characters.")]
+		public string? Name { get; set; }
+		/// <summary>
+		/// Status of the ItemzType
+		/// </summary>
+		public string? Status { get; set; }
+		/// <summary>
+		/// Description of the ItemzType
+		/// </summary>
+		public string? Description { get; set; }
+		/// <summary>
+		/// User who created the ItemzType
+		/// </summary>
+		public string? CreatedBy { get; set; }
+		/// <summary>
+		/// Date and Time when ItemzType was created
+		/// </summary>
+		public DateTimeOffset CreatedDate { get; set; }
+		/// <summary>
+		/// Returns true if it's system ItemzType otherwise false
+		/// </summary>
+		public bool IsSystem { get; set; }
+	}
 }

--- a/OpenRose.API/Models/GetProjectDTO.cs
+++ b/OpenRose.API/Models/GetProjectDTO.cs
@@ -3,38 +3,40 @@
 // See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace ItemzApp.API.Models
 {
-    /// <summary>
-    /// ProjectDTO is a POCO used for serving requests like GetProjects or GetProject by ProjectID.
-    /// It will carry specified set of data that are exposed when project details are requested throgh "ItemzApp.API"
-    /// </summary>
-    public class GetProjectDTO
-    {
-        /// <summary>
-        /// Id of the Project representated by a GUID.
-        /// </summary>
-        public Guid Id { get; set; }
-        /// <summary>
-        /// Project Name 
-        /// </summary>
-        public string? Name { get; set; }
-        /// <summary>
-        /// Status of the Project
-        /// </summary>
-        public string? Status { get; set; }
-        /// <summary>
-        /// Description of the Project
-        /// </summary>
-        public string? Description { get; set; }
-        /// <summary>
-        /// User who created the Project
-        /// </summary>
-        public string? CreatedBy { get; set; }
-        /// <summary>
-        /// Date and Time when Project was created
-        /// </summary>
-        public DateTimeOffset CreatedDate { get; set; }
-    }
+	/// <summary>
+	/// ProjectDTO is a POCO used for serving requests like GetProjects or GetProject by ProjectID.
+	/// It will carry specified set of data that are exposed when project details are requested throgh "ItemzApp.API"
+	/// </summary>
+	public class GetProjectDTO
+	{
+		/// <summary>
+		/// Id of the Project representated by a GUID.
+		/// </summary>
+		public Guid Id { get; set; }
+		/// <summary>
+		/// Project Name 
+		/// </summary>
+		[StringLength(128, ErrorMessage = "Name length can't be more than 128 characters.")]
+		public string? Name { get; set; }
+		/// <summary>
+		/// Status of the Project
+		/// </summary>
+		public string? Status { get; set; }
+		/// <summary>
+		/// Description of the Project
+		/// </summary>
+		public string? Description { get; set; }
+		/// <summary>
+		/// User who created the Project
+		/// </summary>
+		public string? CreatedBy { get; set; }
+		/// <summary>
+		/// Date and Time when Project was created
+		/// </summary>
+		public DateTimeOffset CreatedDate { get; set; }
+	}
 }


### PR DESCRIPTION
To keep Server Side and Client Side DTOs in sync for compatibility purposes and possible future sharing of the DTOs OpenRose Requirements Management Team decided to apply necessary string length constrain as required in the API Server Side DTOs.

