### PR TITLE
Ability to have button in tree view to toggle between full screen modes

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
@@ -1,0 +1,24 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+namespace OpenRose.WebUI.Components.EventServices
+{
+	public class SplitBarManagementService
+	{
+		/// <summary>
+		/// Fired when any component requests the split bar to toggle
+		/// between default and collapsed positions.
+		/// </summary>
+		public event Action OnToggleSplitBarRequested;
+
+		/// <summary>
+		/// Components call this to toggle the split bar.
+		/// </summary>
+		public void ToggleSplitBar()
+		{
+			OnToggleSplitBarRequested?.Invoke();
+		}
+	}
+}
+

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
@@ -39,6 +39,20 @@
 }
 
 <MudPaper Class="pa-4 mb-5 align-start d-flex" Style="width: auto" Outlined="false">
+
+	@if (CalledFrom == nameof(BaselineTreeView))
+	{
+		<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+			<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+						   Color="Color.Success"
+						   Size="Size.Medium"
+						   IconSize="Size.Large"
+						   Variant="Variant.Filled"
+						   Class="mud-rounded-circle me-2"
+						   @onclick="toggleSplitBar" />
+
+		</MudTooltip>
+	}
 	<MudText Typo="Typo.h6" Align="Align.Left">Baseline Details</MudText>
 </MudPaper>
 
@@ -338,6 +352,8 @@
 	[Inject]
 	public FormStateService FormStateService { get; set; }
 
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
 
 	public Guid ParentId { get; set; }
 	private bool updateBaselineButtonClicked = false;
@@ -800,6 +816,11 @@
 	{
 		var url = $"/export-mermaid/{id}";
 		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
 	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -38,6 +38,16 @@
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent Style="padding:6px">
 					<div class="d-flex align-start justify-space-between" style="gap:8px;">
+						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+										   Color="Color.Success"
+										   Size="Size.Medium"
+										   IconSize="Size.Large"
+										   Variant="Variant.Filled"
+										   Class="mud-rounded-circle me-2"
+										   @onclick="toggleSplitBar" />
+
+						</MudTooltip>
 						<!-- Left side: Title -->
 						<MudText Typo="Typo.inherit"
 								 Class="flex-grow-1 text-responsive-title"
@@ -127,6 +137,9 @@
 
 	[Inject]
 	public IBaselinesService BaselinesService { get; set; }
+
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
 
 	public GetBaselineDTO singleBaseline { get; set; } = new();
 	public bool initializingPage { get; set; } = true;
@@ -290,4 +303,8 @@
 		BaselineItemzSelectionService.ScrollToTreeViewNode(BaselineId);
 	}
 
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
+	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -33,13 +33,27 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                           Color="Color.Success"
+                                           Size="Size.Medium"
+                                           IconSize="Size.Large"
+                                           Variant="Variant.Filled"
+                                           Class="mud-rounded-circle me-2"
+                                           @onclick="toggleSplitBar" />
+
+                        </MudTooltip>
+
+                        <!-- Left side: Title -->
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"
                                  Align="Align.Left"
                                  Style="white-space:normal; overflow-wrap:break-word;">
                             <strong>@_baseline.Name</strong>
                         </MudText>
+                    
                     <div class="d-flex align-top flex-shrink-0">
+                        <!-- Right side: Up + Down buttons -->
                         <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
                                         Color="Color.Success"
                                         Size="Size.Medium"
@@ -96,8 +110,13 @@
 </MudGrid>
 
 @code {
-    [Parameter] public Guid BaselineId { get; set; }
-    [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
+    [Parameter] 
+    public Guid BaselineId { get; set; }
+    [Parameter] 
+    public EventCallback<Guid> OnNavigateNext { get; set; }
+
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
 
     private bool initializingPage = true;
     private GetBaselineExportDTO _baseline = new();
@@ -149,6 +168,11 @@
     private async Task findAndShowInTreeViewAsync()
     {
        await BaselineItemzSelectionServiceForJson.ScrollToTreeViewNodeAsync(BaselineId);
+    }
+
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
     }
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
@@ -30,6 +30,7 @@
 @inject ILogger<BaselineTreeView> _logger
 @inject ViewSettingsService ViewSettings
 @inject ProtectedSessionStorage SessionStorage
+@inject SplitBarManagementService SplitBarManagementService
 
 
 
@@ -214,7 +215,7 @@
     {
         if (_percentage == 27)
         {
-            _percentage = 1;
+            _percentage = 0;
         }
         else
         {
@@ -524,6 +525,7 @@
         BaselineItemzSelectionService.OnExcludeAllChildrenBaselineItemzTreeNodes += HandleExcludeAllChildrenBaselineItemzTreeNodes;
         BaselineItemzSelectionService.OnRequestNodeWithParent += HandleRequestNodeWithParent;
         BaselineItemzSelectionService.OnScrollToTreeViewNode += HandleScrollToTreeViewNode;
+        SplitBarManagementService.OnToggleSplitBarRequested += HandleToggleSplitBarRequested;
 
     }
 
@@ -1165,6 +1167,20 @@
         return endText;
     }
 
+    private void HandleToggleSplitBarRequested()
+    {
+        if (_percentage == 27)
+        {
+            _percentage = 0;   // collapse left panel
+        }
+        else
+        {
+            _percentage = 27;  // restore default
+        }
+
+        StateHasChanged();
+    }
+
 
     public void Dispose()
     {
@@ -1176,5 +1192,6 @@
         BaselineItemzSelectionService.OnExcludeAllChildrenBaselineItemzTreeNodes -= HandleExcludeAllChildrenBaselineItemzTreeNodes;
         BaselineItemzSelectionService.OnRequestNodeWithParent -= HandleRequestNodeWithParent;
         BaselineItemzSelectionService.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
+        SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -21,6 +21,7 @@
 @inject BaselineTreeNodeItemzSelectionServiceForJson BaselineItemzSelectionServiceForJson
 @inject IJSRuntime JS
 @inject ProtectedSessionStorage SessionStorage
+@inject SplitBarManagementService SplitBarManagementService
 @implements IDisposable
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
@@ -209,7 +210,7 @@
     {
         if (_percentage == 27)
         {
-            _percentage = 1;
+            _percentage = 0;
         }
         else
         {
@@ -338,6 +339,9 @@
         // Subscribe to JSON + DataSource changes
         JsonFileDataSource.OnJsonChanged += HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged += HandleStateChangedAsync;
+
+        SplitBarManagementService.OnToggleSplitBarRequested += HandleToggleSplitBarRequested;
+
 
         // await ReloadTreeAsync();
     }
@@ -752,11 +756,26 @@
         StateHasChanged();
     }
 
+    private void HandleToggleSplitBarRequested()
+    {
+        if (_percentage == 27)
+        {
+            _percentage = 0;   // collapse left panel
+        }
+        else
+        {
+            _percentage = 27;  // restore default
+        }
+
+        StateHasChanged();
+    }
+
     public void Dispose()
     {
         BaselineItemzSelectionServiceForJson.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
         JsonFileDataSource.OnJsonChanged -= HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged -= HandleStateChangedAsync;
+        SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
     }
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -40,6 +40,16 @@
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+										   Color="Color.Success"
+										   Size="Size.Medium"
+										   IconSize="Size.Large"
+										   Variant="Variant.Filled"
+										   Class="mud-rounded-circle me-2"
+										   @onclick="toggleSplitBar" />
+
+						</MudTooltip>
 
 						<!-- Left side: Title -->
 						<MudText Typo="Typo.inherit"
@@ -155,15 +165,18 @@
 @code {
 	[Parameter]
 	public Guid BaselineItemzId { get; set; }
-
-	[Parameter] public EventCallback<Guid> OnNavigatePrevious { get; set; }
-	[Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
-
+	[Parameter] 
+	public EventCallback<Guid> OnNavigatePrevious { get; set; }
+	[Parameter] 
+	public EventCallback<Guid> OnNavigateNext { get; set; }
 	[Parameter]
 	public bool IsIncluded { get; set; } = true;
 
 	[Inject]
 	public IBaselineItemzService BaselineItemzService { get; set; }
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
+
 
 	public GetBaselineItemzDTO singleBaselineItemz { get; set; } = new();
 	public bool initializingPage { get; set; } = true;
@@ -309,4 +322,10 @@
 
 		BaselineItemzSelectionService.ScrollToTreeViewNode(BaselineItemzId);
 	}
+
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
+	}
+
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -34,6 +34,16 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                           Color="Color.Success"
+                                           Size="Size.Medium"
+                                           IconSize="Size.Large"
+                                           Variant="Variant.Filled"
+                                           Class="mud-rounded-circle me-2"
+                                           @onclick="toggleSplitBar" />
+
+                        </MudTooltip>
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"
                                  Align="Align.Left"
@@ -140,6 +150,8 @@
     [Parameter]
     public bool IsIncluded { get; set; } = true;
 
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
 
     private bool initializingPage = true;
     private GetBaselineItemzExportDTO _baselineItemz = new();
@@ -210,4 +222,8 @@
         await BaselineItemzSelectionServiceForJson.ScrollToTreeViewNodeAsync(BaselineItemzId);
     }
 
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
+    }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
@@ -26,6 +26,16 @@
 
 
 <MudPaper Class="pa-4 mb-3 align-start d-flex" Style="width: auto" Outlined="false">
+	<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+		<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+					   Color="Color.Success"
+					   Size="Size.Medium"
+					   IconSize="Size.Large"
+					   Variant="Variant.Filled"
+					   Class="mud-rounded-circle me-2"
+					   @onclick="toggleSplitBar" />
+
+	</MudTooltip>
 	<MudText Typo="Typo.h6" Align="Align.Left">Baseline Itemz</MudText>
 </MudPaper>
 
@@ -209,6 +219,10 @@
 
 	[Inject]
 	public IBaselineHierarchyService baselineHierarchyService { get; set; }
+
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
+
 
 	public GetBaselineItemzDTO singleBaselineItemz { get; set; } = new();
 	private List<BaselineHierarchyIdRecordDetailsDTO> AllChildBaselineItemz { get; set; } = new List<BaselineHierarchyIdRecordDetailsDTO>();
@@ -533,5 +547,12 @@
 		var url = $"/export-mermaid/{id}";
 		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
+
+
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
+	}
+
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
@@ -548,11 +548,9 @@
 		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
 
-
 	private void toggleSplitBar()
 	{
 		SplitBarManagementService.ToggleSplitBar();
 	}
-
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -37,7 +37,16 @@
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+										   Color="Color.Success"
+										   Size="Size.Medium"
+										   IconSize="Size.Large"
+										   Variant="Variant.Filled"
+										   Class="mud-rounded-circle me-2"
+										   @onclick="toggleSplitBar" />
 
+						</MudTooltip>
 						<!-- Left side: Title -->
 						<MudText Typo="Typo.inherit"
 								 Class="flex-grow-1 text-responsive-title"
@@ -137,6 +146,9 @@
 
 	[Inject]
 	public IBaselineItemzTypesService BaselineItemzTypeServices { get; set; }
+
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
 
 
 	public GetBaselineItemzTypeDTO singleBaselineItemzType { get; set; } = new();
@@ -270,5 +282,10 @@
 	{
 
 		BaselineItemzSelectionService.ScrollToTreeViewNode(BaselineItemzTypeId);
+	}
+
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -33,6 +33,17 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                           Color="Color.Success"
+                                           Size="Size.Medium"
+                                           IconSize="Size.Large"
+                                           Variant="Variant.Filled"
+                                           Class="mud-rounded-circle me-2"
+                                           @onclick="toggleSplitBar" />
+
+                        </MudTooltip>
+                        <!-- Left side: Title -->
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"
                                  Align="Align.Left"
@@ -40,6 +51,7 @@
                             <strong>@_baselineItemzType.Name</strong>
                         </MudText>
                         <div class="d-flex align-top flex-shrink-0">
+                            <!-- Right side: Up + Down buttons -->
                             <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
                                            Color="Color.Success"
                                            Size="Size.Medium"
@@ -108,6 +120,9 @@
     [Parameter] public EventCallback<Guid> OnNavigatePrevious { get; set; }
     [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
 
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
+
     private bool initializingPage = true;
     private GetBaselineItemzTypeExportDTO _baselineItemzType = new();
     private MarkupString _convertedMarkdown;
@@ -160,4 +175,8 @@
         await BaselineItemzSelectionServiceForJson.ScrollToTreeViewNodeAsync(BaselineItemzTypeId);
     }
 
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
+    }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
@@ -23,6 +23,16 @@
 @inject ILogger<BaselineItemzTypeTreeViewComponent> _logger
 
 <MudPaper Class="pa-4 mb-3 ml-1 align-start d-flex" Style="width: auto" Outlined="false">
+	<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+		<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+					   Color="Color.Success"
+					   Size="Size.Medium"
+					   IconSize="Size.Large"
+					   Variant="Variant.Filled"
+					   Class="mud-rounded-circle me-2"
+					   @onclick="toggleSplitBar" />
+
+	</MudTooltip>
 	<MudText Typo="Typo.h6" Align="Align.Left">Baseline ItemzType</MudText>
 </MudPaper>
 
@@ -173,6 +183,8 @@
     [Inject]
     public IBaselineItemzTypesService baselineItemzTypesService { get; set; }
 
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
 
     public GetBaselineItemzTypeDTO singleBaselineItemzType { get; set; } = new();
     public bool initializingPage { get; set; } = true;
@@ -325,6 +337,10 @@
 		await JS.InvokeVoidAsync("openInNewTab", url);
 	}
 
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
+	}
 
 }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -57,6 +57,20 @@
 
 <MudPaper Class="pa-1 mb-1 align-start d-flex" Style="width: auto" Outlined="false">
 	<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="w-100">
+		@if (CalledFrom == nameof(ProjectTreeView) )
+		{
+			<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+				<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+				Color="Color.Success"
+				Size="Size.Medium"
+				IconSize="Size.Large"
+				Variant="Variant.Filled"
+				Class="mud-rounded-circle me-2"
+				@onclick="toggleSplitBar" />
+
+			</MudTooltip>
+		}
+
 		<MudText Typo="Typo.h6" Align="Align.Left">Itemz Details</MudText>
 		<MudSpacer />
 		@if (CalledFrom == nameof(ProjectTreeView) && singleItemz != null)
@@ -228,7 +242,6 @@
 				</MudStack>
 				<br />
 
-				@* Add Verification and warning when Name is longer then supported length. *@
 				<MudTextField T="string" Label="Name" Required="true" RequiredError="Name is required!"
 					@bind-Value="singleItemz.Name"
 					For="@(() => singleItemz.Name)" FullWidth="true" 
@@ -496,6 +509,8 @@
 	public IHierarchyService hierarchyService { get; set; }
 	[Inject]
 	public FormStateService FormStateService { get; set; }
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
 
 
 	private Guid ParentId { get; set; }
@@ -1182,6 +1197,11 @@
 	{
 		var url = $"/export-mermaid/{id}";
 		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+	
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
 	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -43,6 +43,17 @@
 
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                           Color="Color.Success"
+                                           Size="Size.Medium"
+                                           IconSize="Size.Large"
+                                           Variant="Variant.Filled"
+                                           Class="mud-rounded-circle me-2"
+                                           @onclick="toggleSplitBar" />
+
+                        </MudTooltip>
+
                         <!-- Title -->
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"
@@ -83,8 +94,8 @@
 @*             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);"> *@
             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
                 <MudCardContent Style="padding : 6px">
-                    @if (tagsList is { Count: > 0 })
-                    {
+                        @if (tagsList is { Count: > 0 })
+                        {
                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                             @* <MudText Typo="Typo.subtitle2">Tags :</MudText> *@
                             <MudChipSet T="string"
@@ -97,7 +108,7 @@
                                              Variant="Variant.Outlined" />
                                 }
                             </MudChipSet>
-                        </MudStack>
+                    </MudStack>
                     }
                     @if (!ViewSettings.IsKioskMode)
                     {
@@ -180,6 +191,9 @@
 
 	[Inject]
 	public IItemzService ItemzService { get; set; }
+
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
 
 	public GetItemzDTO singleItemz { get; set; } = new();
 	public bool initializingPage { get; set; } = true;
@@ -314,6 +328,11 @@
     private void findAndShowInTreeView()
     {
         TreeNodeItemzSelectionService.ScrollToTreeViewNode(ItemzId);
+    }
+
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
     }
 
     // private async Task ScrollUp()

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -35,7 +35,16 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding : 6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                           Color="Color.Success"
+                                           Size="Size.Medium"
+                                           IconSize="Size.Large"
+                                           Variant="Variant.Filled"
+                                           Class="mud-rounded-circle me-2"
+                                           @onclick="toggleSplitBar" />
 
+                        </MudTooltip>
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"
                                  Align="Align.Left"
@@ -69,8 +78,8 @@
 @*             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);"> *@
             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
                 <MudCardContent Style="padding : 6px">
-                    @if (tagsList is { Count: > 0 })
-                    {
+                        @if (tagsList is { Count: > 0 })
+                        {
                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                             @* <MudText Typo="Typo.subtitle2">Tags :</MudText> *@
                             <MudChipSet T="string"
@@ -83,7 +92,7 @@
                                              Variant="Variant.Outlined" />
                                 }
                             </MudChipSet>
-                        </MudStack>
+                    </MudStack>
                     }
                     @if (!ViewSettings.IsKioskMode)
                     {
@@ -139,6 +148,9 @@
     [Parameter] public EventCallback<Guid> OnNavigatePrevious { get; set; }
     [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
     [Parameter] public EventCallback<Guid> OnOpenTraceTarget { get; set; }
+
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
 
     private bool initializingPage = true;
     private GetItemzExportDTO _itemz = new();
@@ -209,5 +221,10 @@
     private async Task findAndShowInTreeViewAsync()
     {
         await ItemzSelectionServiceForJson.ScrollToTreeViewNodeAsync(ItemzId);
+    }
+
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -42,6 +42,19 @@
 
 <MudPaper Class="pa-1 mb-1 align-start d-flex" Style="width: auto" Outlined="false">
 	<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="w-100">
+	@if (CalledFrom == nameof(ProjectTreeView))
+	{
+		<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+			<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+							Color="Color.Success"
+							Size="Size.Medium"
+							IconSize="Size.Large"
+							Variant="Variant.Filled"
+							Class="mud-rounded-circle me-2"
+							@onclick="toggleSplitBar" />
+
+		</MudTooltip>
+	}
 	<MudText Typo="Typo.h6" Align="Align.Left">ItemzType Details</MudText>
 		<MudSpacer />
 		@if (CalledFrom == nameof(ProjectTreeView) && singleItemzType != null)
@@ -368,6 +381,9 @@
 	public IItemzTypeItemzsService ItemzTypeItemzsService { get; set; }
 	[Inject]
 	public FormStateService FormStateService { get; set; }
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
+
 
 	public Guid ParentId { get; set; }
 	private bool updateItemzTypeButtonClicked = false;
@@ -841,6 +857,11 @@
 	{
 		var url = $"/export-mermaid/{id}";
 		await JS.InvokeVoidAsync("openInNewTab", url);
+	}
+
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
 	}
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -38,6 +38,16 @@
 			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
 				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+										   Color="Color.Success"
+										   Size="Size.Medium"
+										   IconSize="Size.Large"
+										   Variant="Variant.Filled"
+										   Class="mud-rounded-circle me-2"
+										   @onclick="toggleSplitBar" />
+
+						</MudTooltip>
 						<!-- Left side: Title -->
 						<MudText Typo="Typo.inherit"
 								 Class="flex-grow-1 text-responsive-title"
@@ -129,6 +139,9 @@
 
 	[Inject]
 	public IItemzTypeService ItemzTypeService { get; set; }
+	[Inject]
+	public SplitBarManagementService SplitBarManagementService { get; set; }
+
 
 	public GetItemzTypeDTO singleItemzType { get; set; } = new();
 	public bool initializingPage { get; set; } = true;
@@ -253,4 +266,9 @@
     {
         TreeNodeItemzSelectionService.ScrollToTreeViewNode(ItemzTypeId);
     }
+
+	private void toggleSplitBar()
+	{
+		SplitBarManagementService.ToggleSplitBar();
+	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -32,6 +32,16 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                    <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                        <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                        Color="Color.Success"
+                                        Size="Size.Medium"
+                                        IconSize="Size.Large"
+                                        Variant="Variant.Filled"
+                                        Class="mud-rounded-circle me-2"
+                                        @onclick="toggleSplitBar" />
+
+                    </MudTooltip>
                     <MudText Typo="Typo.inherit"
                                 Class="flex-grow-1 text-responsive-title"
                                 Align="Align.Left"
@@ -111,6 +121,9 @@
     [Parameter] public EventCallback<Guid> OnNavigatePrevious { get; set; }
     [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
 
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
+
     private bool initializingPage = true;
     private GetItemzTypeExportDTO _itemzType = new();
     private MarkupString _convertedMarkdown;
@@ -167,4 +180,10 @@
     {
         await ItemzSelectionServiceForJson.ScrollToTreeViewNodeAsync(ItemzTypeId);
     }
+
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
+    }
+
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -37,6 +37,19 @@
 
 <MudPaper Class="pa-4 mb-5 align-start d-flex" Style="width: auto" Outlined="false">
 	<MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="w-100">
+        @if (CalledFrom == nameof(ProjectTreeView))
+        {
+            <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                               Color="Color.Success"
+                               Size="Size.Medium"
+                               IconSize="Size.Large"
+                               Variant="Variant.Filled"
+                               Class="mud-rounded-circle me-2"
+                               @onclick="toggleSplitBar" />
+
+            </MudTooltip>
+        }
 		<MudText Typo="Typo.h6" Align="Align.Left">Project Details</MudText>
 		<MudSpacer />
 		@if (CalledFrom == nameof(ProjectTreeView))
@@ -352,32 +365,35 @@
 </MudGrid>
 @code 
 {
-        [Parameter]
-        public Guid ProjectId { get; set; }
-        [Parameter]
-        [SupplyParameterFromQuery(Name = "showBaselineTab")]
-        public bool ShowBaselineTab { get; set; } = false;
-        [Parameter]
-        [SupplyParameterFromQuery(Name = "calledFrom")]
-        public string CalledFrom { get; set; } = string.Empty;
+    [Parameter]
+    public Guid ProjectId { get; set; }
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "showBaselineTab")]
+    public bool ShowBaselineTab { get; set; } = false;
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "calledFrom")]
+    public string CalledFrom { get; set; } = string.Empty;
 
-        [Parameter]
-        public EventCallback<string> ContentChanged { get; set; }
+    [Parameter]
+    public EventCallback<string> ContentChanged { get; set; }
 
-        [Inject]
-        public IProjectService ProjectService { get; set; }
+    [Inject]
+    public IProjectService ProjectService { get; set; }
 
-        [Inject]
-        public IBaselinesService BaselineService { get; set; }
+    [Inject]
+    public IBaselinesService BaselineService { get; set; }
 
-        [Inject]
-        public IItemzTypeService ItemzTypeService { get; set; }
+    [Inject]
+    public IItemzTypeService ItemzTypeService { get; set; }
 
-        [Inject]
-        public IHierarchyService HierarchyService { get; set; }
+    [Inject]
+    public IHierarchyService HierarchyService { get; set; }
 
-        [Inject]
-        public FormStateService FormStateService { get; set; }
+    [Inject]
+    public FormStateService FormStateService { get; set; }
+
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
 
 
     // public Guid displayOnlyProjectID = Guid.Empty ;
@@ -1199,6 +1215,10 @@
         await JS.InvokeVoidAsync("openInNewTab", url);
     }
 
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
+    }
 
     // private async Task OpenCopyProjectPage()
     // {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -37,7 +37,16 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                            Color="Color.Success"
+                                            Size="Size.Medium"
+                                            IconSize="Size.Large"
+                                            Variant="Variant.Filled"
+                                            Class="mud-rounded-circle me-2"
+                                            @onclick="toggleSplitBar" />
 
+                        </MudTooltip>
                         <!-- Left side: Title -->
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"
@@ -130,14 +139,17 @@
         </MudOverlay>
     </MudPaper>
 }
-@code {
-        [Parameter]
-        public Guid ProjectId { get; set; }
+@code 
+{
+    [Parameter]
+    public Guid ProjectId { get; set; }
 
-        [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
+    [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
 
-        [Inject]
-        public IProjectService ProjectService { get; set; }
+    [Inject]
+    public IProjectService ProjectService { get; set; }
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
 
     public GetProjectDTO singleProject { get; set; } = new();
     public bool initializingPage { get; set; } = true;
@@ -187,5 +199,10 @@
     private void findAndShowInTreeView()
     {
         TreeNodeItemzSelectionService.ScrollToTreeViewNode(ProjectId);
+    }
+
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -33,6 +33,16 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                           Color="Color.Success"
+                                           Size="Size.Medium"
+                                           IconSize="Size.Large"
+                                           Variant="Variant.Filled"
+                                           Class="mud-rounded-circle me-2"
+                                           @onclick="toggleSplitBar" />
+
+                        </MudTooltip>
                         <MudText Typo="Typo.inherit"
                                  Class="flex-grow-1 text-responsive-title"
                                  Align="Align.Left"
@@ -108,6 +118,9 @@
 @code {
     [Parameter] public Guid ProjectId { get; set; }
     [Parameter] public EventCallback<Guid> OnNavigateNext { get; set; }
+
+    [Inject]
+    public SplitBarManagementService SplitBarManagementService { get; set; }
 
     private bool initializingPage = true;
     private GetProjectExportDTO _project = new();
@@ -189,5 +202,10 @@
     private async Task findAndShowInTreeViewAsync()
     {
         await ItemzSelectionServiceForJson.ScrollToTreeViewNodeAsync(ProjectId);
+    }
+
+    private void toggleSplitBar()
+    {
+        SplitBarManagementService.ToggleSplitBar();
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -34,6 +34,7 @@
 @inject ViewSettingsService ViewSettings
 @inject ProtectedSessionStorage SessionStorage
 @inject ProjectDeletionService DeletionService
+@inject SplitBarManagementService SplitBarManagementService
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"
@@ -220,7 +221,7 @@
     {
         if (_percentage == 27)
         {
-            _percentage = 1;
+            _percentage = 0;
         }
         else
         {
@@ -541,6 +542,9 @@
         {
             await HandleCreatedNewItemzTypeAsync(recordId, itemzType);
         };
+
+        SplitBarManagementService.OnToggleSplitBarRequested += HandleToggleSplitBarRequested;
+
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -1311,6 +1315,21 @@
         // StateHasChanged();
     }
 
+    private void HandleToggleSplitBarRequested()
+    {
+        if (_percentage == 27)
+        {
+            _percentage = 0;   // collapse left panel
+        }
+        else
+        {
+            _percentage = 27;  // restore default
+        }
+
+        StateHasChanged();
+    }
+
+
     public async ValueTask DisposeAsync()
     {
         // Always unsubscribe to avoid memory leaks
@@ -1320,6 +1339,7 @@
         ItemzSelectionService.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
         ItemzSelectionService.OnTreeNodeItemzDeleted -= HandleItemzDeleted;
         ItemzSelectionService.OnCreatedNewItemzType -= HandleCreatedNewItemzTypeAsync;
+        SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
 
         // Cleanup SignalR connection
         if (hubConnection is not null)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -21,6 +21,7 @@
 @inject TreeNodeItemzSelectionServiceForJson ItemzSelectionServiceForJson
 @inject IJSRuntime JS
 @inject ProtectedSessionStorage SessionStorage
+@inject SplitBarManagementService SplitBarManagementService
 @implements IDisposable
 
 
@@ -170,7 +171,7 @@
     {
         if (_percentage == 27)
         {
-            _percentage = 1;
+            _percentage = 0;
         }
         else
         {
@@ -234,6 +235,8 @@
         // Subscribe to state changes
         JsonFileDataSource.OnJsonChanged += HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged += HandleStateChangedAsync;
+
+        SplitBarManagementService.OnToggleSplitBarRequested += HandleToggleSplitBarRequested;
 
         //  await ReloadTreeAsync();
 
@@ -647,10 +650,26 @@
 
 
 
+
+    private void HandleToggleSplitBarRequested()
+    {
+        if (_percentage == 27)
+        {
+            _percentage = 0;   // collapse left panel
+        }
+        else
+        {
+            _percentage = 27;  // restore default
+        }
+
+        StateHasChanged();
+    }
+
     public void Dispose()
     {
         ItemzSelectionServiceForJson.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
         JsonFileDataSource.OnJsonChanged -= HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged -= HandleStateChangedAsync;
+        SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Program.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Program.cs
@@ -302,6 +302,9 @@ builder.Services.AddScoped<JsonFileSchemaValidationService>(); // This service v
 builder.Services.AddScoped<JsonFileDataSourceService>(); // This service provides hierarchy/project data queries from loaded JSON files
 builder.Services.AddScoped<BaselineTreeNodeItemzSelectionServiceForJson>(); // Register the service
 builder.Services.AddScoped<TreeNodeItemzSelectionServiceForJson>(); // Register the service
+builder.Services.AddScoped<SplitBarManagementService>(); // Register the service
+
+
 
 
 builder.Services.AddScoped<AssemblyInfoService>(); // Register the service


### PR DESCRIPTION
resolves #146 

With this change we are now implementing support for Toggle Split Bar in both, Project and Baseline, TreeViews. OpenRose Requirements Management Team has implemented Toggle Split Bar capabilities in following views.

- Project 
- Requirement Type
- Requirement Item
- Baseline
- Baseline Requirement Type
- Baseline Requirement Item

For all these record types, we also implemented the desired change for 'Read Only' and 'JSON' (data files) views.

Open Rose team has also performed necessary testing activities to verify that implementation of this large change has been successful. All test were conducted in Windows environment and manual testing efforts took place to verify the desired outcome. 




