### PR TITLE
Improve UI Dialog for notifying project deletion action

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
@@ -5,20 +5,19 @@
 *@
 
 @using MudBlazor
-@* Make Improvement to dialog appearance and make it similar to how other dialog box is displaying information  *@
-@* Utilize similar look and feel as the other dialog boxes in the application for consistency. *@
 <MudDialog>
     <TitleContent>
-        <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Class="mr-3" Color="Color.Warning" />
-        Project Deleted
+        PROJECT DELETED
     </TitleContent>
     <DialogContent>
-        <MudAlert Severity="Severity.Warning" Class="mb-4">
-            The project <strong>@ProjectName</strong> has been deleted by another user.
-        </MudAlert>
-        <MudText Class="mt-4">
-            This project is no longer available. You will be redirected to the projects list.
-        </MudText>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+            <MudIcon Icon="@Icons.Material.Filled.Warning" Size="Size.Large"
+                     Color="Color.Warning"
+                     Title="Project Deleted" />
+            <p style="font-size: 18px; margin-bottom: 0px;">
+                Project "<strong>@ProjectName</strong>" has been deleted by another user.
+            </p>
+        </MudStack>
     </DialogContent>
     <DialogActions>
         <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="NavigateToProjectsList">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
@@ -6,6 +6,7 @@
 
 @using MudBlazor
 @* Make Improvement to dialog appearance and make it similar to how other dialog box is displaying information  *@
+@* Utilize similar look and feel as the other dialog boxes in the application for consistency. *@
 <MudDialog>
     <TitleContent>
         <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Class="mr-3" Color="Color.Warning" />

--- a/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Dialogs/DeletedProjectDialog.razor
@@ -5,7 +5,7 @@
 *@
 
 @using MudBlazor
-
+@* Make Improvement to dialog appearance and make it similar to how other dialog box is displaying information  *@
 <MudDialog>
     <TitleContent>
         <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Class="mr-3" Color="Color.Warning" />


### PR DESCRIPTION
When a project is deleted by a user then all the other users who are connected to the project is sent a notification alert. This alert or warning dialog box was not looking same as other common dialog boxes that we have in the system. With this change we are now making UI look and feel same for project deleted alert dialog box as other common dialogs.

