### PR TITLE
Add swipe gesture navigation (left/right) for different record types within read only TreeView 

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/App.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/App.razor
@@ -50,6 +50,7 @@
     <script src="@Assets["js/fullscreen.js"]"></script>
     <script src="@Assets["js/blockNavigation.js"]"></script>
     <script src="@Assets["js/clipboard.js"]"></script>
+    <script src="@Assets["js/swipe.js"]"></script>
     <script src="@Assets["/_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js"]"></script>
     <script src="@Assets["/_content/PSC.Blazor.Components.MarkdownEditor/js/markdownEditor.js"]"></script>
     <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -20,7 +20,10 @@
 @inject NavigationBlockerService NavigationBlocker
 @inject ViewSettingsService ViewSettings
 @inject ILogger<BaselineReadOnlyComponent> _logger
+@implements IAsyncDisposable
 
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 <MudGrid>
 	@if (initializingPage)
 	{
@@ -117,6 +120,8 @@
 		<br />
 	}
 </MudGrid>
+</div>
+
 @if (_showOverlay)
 {
 	<MudPaper Height="calc(100vh - 100px);" Width="100%">
@@ -149,10 +154,40 @@
 
 	private Breakpoint bp;
 
+	// Swipe support (ElementReference-based)
+	private string _elementId => $"openrose-swipe-baseline-{BaselineId}";
+	private ElementReference _swipeElementRef;
+	private DotNetObjectReference<BaselineReadOnlyComponent>? _dotNetRef;
+	private bool _swipeRegistered = false;
+
+
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		if (firstRender)
 		{
+
+			// register swipe handlers
+			_dotNetRef = DotNetObjectReference.Create(this);
+			try
+			{
+				_swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+				if (!_swipeRegistered)
+				{
+					_logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+				}
+			}
+			catch (JSException jsex)
+			{
+				_logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+			catch (Exception ex)
+			{
+				_logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+
+
 			initializingPage = true;
 			StateHasChanged();
 			await Task.Delay(300);
@@ -306,5 +341,54 @@
 	private void toggleSplitBar()
 	{
 		SplitBarManagementService.ToggleSplitBar();
+	}
+
+
+	[JSInvokable("OnSwipe")]
+	public async Task OnSwipe(string direction)
+	{
+		// Book-style mapping: swipe left => Next, swipe right => Previous
+		if (direction == "left")
+		{
+			if (OnNavigateNext.HasDelegate)
+				await OnNavigateNext.InvokeAsync(BaselineId);
+		}
+		// else if (direction == "right")
+		// {
+		// 	if (OnNavigatePrevious.HasDelegate)
+		// 		await OnNavigatePrevious.InvokeAsync(BaselineId);
+		// }
+	}
+
+	// IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+	public async ValueTask DisposeAsync()
+	{
+		try
+		{
+			if (_swipeRegistered)
+			{
+				await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+			}
+		}
+		catch (Microsoft.JSInterop.JSDisconnectedException)
+		{
+			// circuit disconnected while disposing - ignore
+		}
+		catch (JSException jsex)
+		{
+			_logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+		}
+		catch (Exception ex)
+		{
+			_logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+		}
+		finally
+		{
+			if (_dotNetRef != null)
+			{
+				_dotNetRef.Dispose();
+				_dotNetRef = null;
+			}
+		}
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -15,7 +15,11 @@
 @inject BaselineTreeNodeItemzSelectionServiceForJson BaselineItemzSelectionServiceForJson
 @inject IJSRuntime JS
 @inject JsonFileDataSourceService JsonService
+@inject ILogger<BaselineReadOnlyComponentForJson> _logger
+@implements IAsyncDisposable
 
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 <MudGrid>
     @if (initializingPage)
     {
@@ -108,7 +112,7 @@
         </MudItem>
     }
 </MudGrid>
-
+</div>
 @code {
     [Parameter] 
     public Guid BaselineId { get; set; }
@@ -124,6 +128,12 @@
     private bool _needsRender = false;
 
     private Breakpoint bp;
+
+    // Swipe support (ElementReference-based)
+    private string _elementId => $"openrose-swipe-baselinejson-{BaselineId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<BaselineReadOnlyComponentForJson>? _dotNetRef;
+    private bool _swipeRegistered = false;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -147,6 +157,33 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+
+        if (firstRender)
+        {
+
+            // register swipe handlers
+            _dotNetRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+
+        }
+
         if (_needsRender)
         {
             _needsRender = false;
@@ -173,6 +210,55 @@
     private void toggleSplitBar()
     {
         SplitBarManagementService.ToggleSplitBar();
+    }
+
+
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        // Book-style mapping: swipe left => Next, swipe right => Previous
+        if (direction == "left")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(BaselineId);
+        }
+        // else if (direction == "right")
+        // {
+        // 	if (OnNavigatePrevious.HasDelegate)
+        // 		await OnNavigatePrevious.InvokeAsync(BaselineId);
+        // }
+    }
+
+    // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // circuit disconnected while disposing - ignore
+        }
+        catch (JSException jsex)
+        {
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
     }
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -22,6 +22,9 @@
 @inject IDialogService DialogService
 @inject IJSRuntime JS
 @inject ILogger<BaselineItemzReadOnlyComponent> _logger
+@implements IAsyncDisposable
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 
 <MudGrid>
 	@if (initializingPage)
@@ -150,6 +153,7 @@
 		<br />
 	}
 </MudGrid>
+</div>
 @if (_showOverlay)
 {
 	<MudPaper Height="calc(100vh - 100px);" Width="100%">
@@ -188,10 +192,38 @@
 
 	private Breakpoint bp;
 
+	// Swipe support (ElementReference-based)
+	private string _elementId => $"openrose-swipe-baselineitemz-{BaselineItemzId}";
+	private ElementReference _swipeElementRef;
+	private DotNetObjectReference<BaselineItemzReadOnlyComponent>? _dotNetRef;
+	private bool _swipeRegistered = false;
+
+
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		if (firstRender)
 		{
+			// register swipe handlers
+			_dotNetRef = DotNetObjectReference.Create(this);
+			try
+			{
+				_swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+				if (!_swipeRegistered)
+				{
+					_logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+				}
+			}
+			catch (JSException jsex)
+			{
+				_logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+			catch (Exception ex)
+			{
+				_logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+
 			initializingPage = true;
 			StateHasChanged();
 			await Task.Delay(300);
@@ -328,4 +360,52 @@
 		SplitBarManagementService.ToggleSplitBar();
 	}
 
+
+	[JSInvokable("OnSwipe")]
+	public async Task OnSwipe(string direction)
+	{
+		// Book-style mapping: swipe left => Next, swipe right => Previous
+		if (direction == "left")
+		{
+			if (OnNavigateNext.HasDelegate)
+				await OnNavigateNext.InvokeAsync(BaselineItemzId);
+		}
+		else if (direction == "right")
+		{
+			if (OnNavigatePrevious.HasDelegate)
+				await OnNavigatePrevious.InvokeAsync(BaselineItemzId);
+		}
+	}
+
+	// IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+	public async ValueTask DisposeAsync()
+	{
+		try
+		{
+			if (_swipeRegistered)
+			{
+				await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+			}
+		}
+		catch (Microsoft.JSInterop.JSDisconnectedException)
+		{
+			// circuit disconnected while disposing - ignore
+		}
+		catch (JSException jsex)
+		{
+			_logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+		}
+		catch (Exception ex)
+		{
+			_logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+		}
+		finally
+		{
+			if (_dotNetRef != null)
+			{
+				_dotNetRef.Dispose();
+				_dotNetRef = null;
+			}
+		}
+	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -16,6 +16,10 @@
 @inject BaselineTreeNodeItemzSelectionServiceForJson BaselineItemzSelectionServiceForJson
 @inject IJSRuntime JS
 @inject JsonFileDataSourceService JsonService
+@inject ILogger<BaselineItemzReadOnlyComponentForJson> _logger
+@implements IAsyncDisposable
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 
 <MudGrid>
     @if (initializingPage)
@@ -140,7 +144,7 @@
         </MudItem>
     }
 </MudGrid>
-
+</div>
 @code {
     [Parameter] public Guid BaselineItemzId { get; set; }
     [Parameter] public EventCallback<Guid> OnNavigatePrevious { get; set; }
@@ -159,8 +163,14 @@
     private bool _needsRender = false;
 
     private List<string>? tagsList = new List<string>();
-    
+
     private Breakpoint bp;
+
+    // Swipe support (ElementReference-based)
+    private string _elementId => $"openrose-swipe-baselineitemzjson-{BaselineItemzId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<BaselineItemzReadOnlyComponentForJson>? _dotNetRef;
+    private bool _swipeRegistered = false;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -198,6 +208,31 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+
+        if (firstRender)
+        {
+            // register swipe handlers
+            _dotNetRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+        }
+
         if (_needsRender)
         {
             _needsRender = false;
@@ -225,5 +260,53 @@
     private void toggleSplitBar()
     {
         SplitBarManagementService.ToggleSplitBar();
+    }
+
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        // Book-style mapping: swipe left => Next, swipe right => Previous
+        if (direction == "left")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(BaselineItemzId);
+        }
+        else if (direction == "right")
+        {
+            if (OnNavigatePrevious.HasDelegate)
+                await OnNavigatePrevious.InvokeAsync(BaselineItemzId);
+        }
+    }
+
+    // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // circuit disconnected while disposing - ignore
+        }
+        catch (JSException jsex)
+        {
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -19,6 +19,9 @@
 @inject IDialogService DialogService
 @inject IJSRuntime JS
 @inject ILogger<BaselineItemzTypeReadOnlyComponent> _logger
+@implements IAsyncDisposable
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 
 <MudGrid>
 	@if (initializingPage)
@@ -124,6 +127,7 @@
 		<br />
 	}
 </MudGrid>
+</div>
 @if (_showOverlay)
 {
 	<MudPaper Height="calc(100vh - 100px);" Width="100%">
@@ -159,10 +163,38 @@
 
 	private Breakpoint bp;
 
+	// Swipe support (ElementReference-based)
+	private string _elementId => $"openrose-swipe-baselineitemztype-{BaselineItemzTypeId}";
+	private ElementReference _swipeElementRef;
+	private DotNetObjectReference<BaselineItemzTypeReadOnlyComponent>? _dotNetRef;
+	private bool _swipeRegistered = false;
+
+
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		if (firstRender)
 		{
+			// register swipe handlers
+			_dotNetRef = DotNetObjectReference.Create(this);
+			try
+			{
+				_swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+				if (!_swipeRegistered)
+				{
+					_logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+				}
+			}
+			catch (JSException jsex)
+			{
+				_logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+			catch (Exception ex)
+			{
+				_logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+
 			initializingPage = true;
 			StateHasChanged();
 			await Task.Delay(300);
@@ -287,5 +319,54 @@
 	private void toggleSplitBar()
 	{
 		SplitBarManagementService.ToggleSplitBar();
+	}
+
+
+	[JSInvokable("OnSwipe")]
+	public async Task OnSwipe(string direction)
+	{
+		// Book-style mapping: swipe left => Next, swipe right => Previous
+		if (direction == "left")
+		{
+			if (OnNavigateNext.HasDelegate)
+				await OnNavigateNext.InvokeAsync(BaselineItemzTypeId);
+		}
+		else if (direction == "right")
+		{
+			if (OnNavigatePrevious.HasDelegate)
+				await OnNavigatePrevious.InvokeAsync(BaselineItemzTypeId);
+		}
+	}
+
+	// IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+	public async ValueTask DisposeAsync()
+	{
+		try
+		{
+			if (_swipeRegistered)
+			{
+				await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+			}
+		}
+		catch (Microsoft.JSInterop.JSDisconnectedException)
+		{
+			// circuit disconnected while disposing - ignore
+		}
+		catch (JSException jsex)
+		{
+			_logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+		}
+		catch (Exception ex)
+		{
+			_logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+		}
+		finally
+		{
+			if (_dotNetRef != null)
+			{
+				_dotNetRef.Dispose();
+				_dotNetRef = null;
+			}
+		}
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -15,6 +15,10 @@
 @inject BaselineTreeNodeItemzSelectionServiceForJson BaselineItemzSelectionServiceForJson
 @inject IJSRuntime JS
 @inject JsonFileDataSourceService JsonService
+@inject ILogger<BaselineItemzTypeReadOnlyComponentForJson> _logger
+@implements IAsyncDisposable
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 
 <MudGrid>
     @if (initializingPage)
@@ -114,7 +118,7 @@
         </MudItem>
     }
 </MudGrid>
-
+</div>
 @code {
     [Parameter] public Guid BaselineItemzTypeId { get; set; }
     [Parameter] public EventCallback<Guid> OnNavigatePrevious { get; set; }
@@ -129,6 +133,12 @@
     private bool _needsRender = false;
 
     private Breakpoint bp;
+
+    // Swipe support (ElementReference-based)
+    private string _elementId => $"openrose-swipe-baselineitemztypejson-{BaselineItemzTypeId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<BaselineItemzTypeReadOnlyComponentForJson>? _dotNetRef;
+    private bool _swipeRegistered = false;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -152,6 +162,31 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+
+        if (firstRender)
+        {
+            // register swipe handlers
+            _dotNetRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+        }
+
         if (_needsRender)
         {
             _needsRender = false;
@@ -178,5 +213,53 @@
     private void toggleSplitBar()
     {
         SplitBarManagementService.ToggleSplitBar();
+    }
+
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        // Book-style mapping: swipe left => Next, swipe right => Previous
+        if (direction == "left")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(BaselineItemzTypeId);
+        }
+        else if (direction == "right")
+        {
+            if (OnNavigatePrevious.HasDelegate)
+                await OnNavigatePrevious.InvokeAsync(BaselineItemzTypeId);
+        }
+    }
+
+    // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // circuit disconnected while disposing - ignore
+        }
+        catch (JSException jsex)
+        {
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -22,7 +22,10 @@
 @inject IDialogService DialogService
 @inject IJSRuntime JS
 @inject ILogger<ItemzReadOnlyComponent> _logger
+@implements IAsyncDisposable
 
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 <MudGrid>
     @if (initializingPage)
     {
@@ -164,7 +167,7 @@
         <br />
     }
 </MudGrid>
-
+</div>
 @if (_showOverlay)
 {
 	<MudPaper Height="calc(100vh - 100px);" Width="100%">
@@ -205,10 +208,46 @@
 
     private Breakpoint bp;
 
+    // Swipe support
+    private string _elementId => $"openrose-swipe-itemz-{ItemzId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<ItemzReadOnlyComponent>? _dotNetRef;
+    private bool _swipeRegistered = false;
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+
+            // Create dotnet ref for callback
+            _dotNetRef = DotNetObjectReference.Create(this);
+
+            try
+            {
+                // register: returns true/false
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                // If JS interop function missing or error, log at warning level
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+
+
+
+
+
+
             initializingPage = true;
             StateHasChanged();
             await Task.Delay(300);
@@ -324,7 +363,6 @@
 		}
 	}
 
-
     private void findAndShowInTreeView()
     {
         TreeNodeItemzSelectionService.ScrollToTreeViewNode(ItemzId);
@@ -335,6 +373,55 @@
         SplitBarManagementService.ToggleSplitBar();
     }
 
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        if (direction == "left")
+        {
+            if (OnNavigatePrevious.HasDelegate)
+                await OnNavigatePrevious.InvokeAsync(ItemzId);
+        }
+        else if (direction == "right")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(ItemzId);
+        }
+    }
+
+    // IAsyncDisposable implementation — swallow JSDisconnectedException
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                // Try to unregister; if JS is disconnected this will throw JSDisconnectedException
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // Circuit disconnected while disposing — this is expected sometimes in Blazor Server.
+            // Silently ignore.
+        }
+        catch (JSException jsex)
+        {
+            // Other JS interop issues — log as Warning but continue disposing
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
+    }
     // private async Task ScrollUp()
     // {
     //     await JS.InvokeVoidAsync("window.scrollBy", 0, -200); // scroll up by 200px

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -376,15 +376,16 @@
     [JSInvokable("OnSwipe")]
     public async Task OnSwipe(string direction)
     {
+        // Page-like behavior: swipe left => Next, swipe right => Previous
         if (direction == "left")
-        {
-            if (OnNavigatePrevious.HasDelegate)
-                await OnNavigatePrevious.InvokeAsync(ItemzId);
-        }
-        else if (direction == "right")
         {
             if (OnNavigateNext.HasDelegate)
                 await OnNavigateNext.InvokeAsync(ItemzId);
+        }
+        else if (direction == "right")
+        {
+            if (OnNavigatePrevious.HasDelegate)
+                await OnNavigatePrevious.InvokeAsync(ItemzId);
         }
     }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -17,131 +17,135 @@
 @inject ViewSettingsService ViewSettings
 @inject IJSRuntime JS
 @inject JsonFileDataSourceService JsonService
+@inject ILogger<ItemzReadOnlyComponentForJson> _logger
+@implements IAsyncDisposable
 
-<MudGrid>
-    @if (initializingPage)
-    {
-        <MudPaper Width="100%">
-            <MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
-                <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
-                <br />
-                <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
-            </MudOverlay>
-        </MudPaper>
-    }
-    else
-    {
-        <MudItem xs="12" sm="12">
-            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-                <MudCardContent Style="padding : 6px">
-                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
-                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle me-2"
-                                           @onclick="toggleSplitBar" />
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
+    <MudGrid>
+        @if (initializingPage)
+        {
+            <MudPaper Width="100%">
+                <MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
+                    <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
+                    <br />
+                    <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+                </MudOverlay>
+            </MudPaper>
+        }
+        else
+        {
+            <MudItem xs="12" sm="12">
+                <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
+                    <MudCardContent Style="padding : 6px">
+                        <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                            <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                               Color="Color.Success"
+                                               Size="Size.Medium"
+                                               IconSize="Size.Large"
+                                               Variant="Variant.Filled"
+                                               Class="mud-rounded-circle me-2"
+                                               @onclick="toggleSplitBar" />
 
-                        </MudTooltip>
-                        <MudText Typo="Typo.inherit"
-                                 Class="flex-grow-1 text-responsive-title"
-                                 Align="Align.Left"
-                                 Style="white-space:normal; overflow-wrap:break-word;">
-                            <strong>@_itemz.Name</strong>
-                        </MudText>
+                            </MudTooltip>
+                            <MudText Typo="Typo.inherit"
+                                     Class="flex-grow-1 text-responsive-title"
+                                     Align="Align.Left"
+                                     Style="white-space:normal; overflow-wrap:break-word;">
+                                <strong>@_itemz.Name</strong>
+                            </MudText>
 
 
-                        <div class="d-flex align-top flex-shrink-0">
+                            <div class="d-flex align-top flex-shrink-0">
 
-                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle me-2"
-                                           OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzId); })" />
+                                <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
+                                               Color="Color.Success"
+                                               Size="Size.Medium"
+                                               IconSize="Size.Large"
+                                               Variant="Variant.Filled"
+                                               Class="mud-rounded-circle me-2"
+                                               OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzId); })" />
 
-                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle"
-                                           OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzId); })" />
+                                <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+                                               Color="Color.Success"
+                                               Size="Size.Medium"
+                                               IconSize="Size.Large"
+                                               Variant="Variant.Filled"
+                                               Class="mud-rounded-circle"
+                                               OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzId); })" />
+                            </div>
                         </div>
-                    </div>
-                </MudCardContent>
-            </MudCard>
+                    </MudCardContent>
+                </MudCard>
 
-@*             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);"> *@
-            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
-                <MudCardContent Style="padding : 6px">
+                @*             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent; overflow-y:auto; max-height:calc(100vh - 20px);"> *@
+                <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
+                    <MudCardContent Style="padding : 6px">
                         @if (tagsList is { Count: > 0 })
                         {
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                            @* <MudText Typo="Typo.subtitle2">Tags :</MudText> *@
-                            <MudChipSet T="string"
-                                        AllClosable="false">
-                                @foreach (var tag in tagsList)
-                                {
-                                    <MudChip Text="@tag"
-                                             Value="@tag"
-                                             Color="Color.Success"
-                                             Variant="Variant.Outlined" />
-                                }
-                            </MudChipSet>
-                    </MudStack>
-                    }
-                    @if (!ViewSettings.IsKioskMode)
-                    {
-                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
-                        <div style=" display:flex;
-                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
-                                align-items:flex-start;
-                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
-                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
-                            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
-                            {
-                                <div style="display:flex; align-items:center; gap:6px;">
-                                <strong>ID : </strong>
-                                <CopyableText TextToCopy="@_itemz.Id.ToString()" DisplayLength="8" />
-                                <MudTooltip Text="Show in Tree View">
-                                    <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
-                                </MudTooltip>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                @* <MudText Typo="Typo.subtitle2">Tags :</MudText> *@
+                                <MudChipSet T="string"
+                                            AllClosable="false">
+                                    @foreach (var tag in tagsList)
+                                    {
+                                        <MudChip Text="@tag"
+                                                 Value="@tag"
+                                                 Color="Color.Success"
+                                                 Variant="Variant.Outlined" />
+                                    }
+                                </MudChipSet>
+                            </MudStack>
+                        }
+                        @if (!ViewSettings.IsKioskMode)
+                        {
+                            <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                                <div style=" display:flex;
+                                        gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                        align-items:flex-start;
+                                        flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                        flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                                    @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                                    {
+                                        <div style="display:flex; align-items:center; gap:6px;">
+                                            <strong>ID : </strong>
+                                            <CopyableText TextToCopy="@_itemz.Id.ToString()" DisplayLength="8" />
+                                            <MudTooltip Text="Show in Tree View">
+                                                <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
+                                            </MudTooltip>
+                                        </div>
+                                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_itemz.Status</div>
+                                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Priority    : </strong> @_itemz.Priority</div>
+                                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Severity    : </strong> @_itemz.Severity</div>
+                                        @if (!string.IsNullOrEmpty(_itemz.EstimationUnit))
+                                        {
+                                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemz.EstimationUnit] : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
+                                        }
+                                        else
+                                        {
+                                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
+                                        }
+                                    }
                                 </div>
-                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_itemz.Status</div>
-                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Priority    : </strong> @_itemz.Priority</div>
-                                <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Severity    : </strong> @_itemz.Severity</div>
-                                @if (!string.IsNullOrEmpty(_itemz.EstimationUnit))
-                                {
-                                    <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemz.EstimationUnit] : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
-                                }
-                                else
-                                {
-                                    <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemz.OwnEstimation <strong>|| Roll-Up</strong> :@_itemz.RolledUpEstimation </div>
-                                }
+                            </MudBreakpointProvider>
+                            <br />
+                        }
+                        <div class="custom-markdown-editor">
+                            @if (!string.IsNullOrEmpty(_itemz.Description))
+                            {
+                                <div class="markdown-body">@((MarkupString)_convertedMarkdown)</div>
                             }
                         </div>
-                    </MudBreakpointProvider>
-                    <br />
-                     }
-                    <div class="custom-markdown-editor">
-                        @if (!string.IsNullOrEmpty(_itemz.Description))
-                        {
-                            <div class="markdown-body">@((MarkupString)_convertedMarkdown)</div>
-                        }
-                    </div>
 
-                    <TraceabilityReadOnlyComponentForJson ItemzId="@ItemzId"
-                                                          OnOpenTraceTarget="OnOpenTraceTarget" />
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-        <br />
-    }
-</MudGrid>
+                        <TraceabilityReadOnlyComponentForJson ItemzId="@ItemzId"
+                                                              OnOpenTraceTarget="OnOpenTraceTarget" />
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <br />
+        }
+    </MudGrid>
+</div>
 
 @code {
     [Parameter] public Guid ItemzId { get; set; }
@@ -162,6 +166,12 @@
 
     private Breakpoint bp;
 
+    // Swipe support (ElementReference-based)
+    private string _elementId => $"openrose-swipe-itemzjson-{ItemzId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<ItemzReadOnlyComponentForJson>? _dotNetRef;
+    private bool _swipeRegistered = false;
+
     protected override async Task OnParametersSetAsync()
     {
         initializingPage = true;
@@ -173,8 +183,6 @@
             if (!string.IsNullOrEmpty(_itemz.Description))
             {
                 _needsRender = true;
-                // var html = await JS.InvokeAsync<string>("markdownToHtml", _itemz.Description);
-                // _convertedMarkdown = (MarkupString)html;
             }
             else
             {
@@ -200,6 +208,30 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // register swipe handlers
+            _dotNetRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+        }
+
         if (_needsRender)
         {
             _needsRender = false;
@@ -226,5 +258,53 @@
     private void toggleSplitBar()
     {
         SplitBarManagementService.ToggleSplitBar();
+    }
+
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        // Book-style mapping: swipe left => Next, swipe right => Previous
+        if (direction == "left")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(ItemzId);
+        }
+        else if (direction == "right")
+        {
+            if (OnNavigatePrevious.HasDelegate)
+                await OnNavigatePrevious.InvokeAsync(ItemzId);
+        }
+    }
+
+    // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // circuit disconnected while disposing - ignore
+        }
+        catch (JSException jsex)
+        {
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -20,106 +20,110 @@
 @inject IDialogService DialogService
 @inject IJSRuntime JS
 @inject ILogger<ItemzType> _logger
+@implements IAsyncDisposable
 
-<MudGrid>
-	@if (initializingPage)
-	{
-		<MudPaper Height="calc(100vh - 100px);" Width="100%">
-			<MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
-				<MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
-				<br />
-				<MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
-			</MudOverlay>
-		</MudPaper>
-	}
-	else if (singleItemzType != null)
-	{
- 		<MudItem xs="12" sm="12">
-			<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-				<MudCardContent Style="padding:6px">
-                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
-						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
-										   Color="Color.Success"
-										   Size="Size.Medium"
-										   IconSize="Size.Large"
-										   Variant="Variant.Filled"
-										   Class="mud-rounded-circle me-2"
-										   @onclick="toggleSplitBar" />
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
+	<MudGrid>
+		@if (initializingPage)
+		{
+			<MudPaper Height="calc(100vh - 100px);" Width="100%">
+				<MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
+					<MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
+					<br />
+					<MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+				</MudOverlay>
+			</MudPaper>
+		}
+		else if (singleItemzType != null)
+		{
+			<MudItem xs="12" sm="12">
+				<MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
+					<MudCardContent Style="padding:6px">
+						<div class="d-flex align-start justify-space-between" style="gap:8px;">
+							<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+								<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+											   Color="Color.Success"
+											   Size="Size.Medium"
+											   IconSize="Size.Large"
+											   Variant="Variant.Filled"
+											   Class="mud-rounded-circle me-2"
+											   @onclick="toggleSplitBar" />
 
-						</MudTooltip>
-						<!-- Left side: Title -->
-						<MudText Typo="Typo.inherit"
-								 Class="flex-grow-1 text-responsive-title"
-								 Align="Align.Left"
-								 Style="white-space:normal; overflow-wrap:break-word;">
-							<strong>@singleItemzType.Name</strong>
-						</MudText>
-
-						<!-- Right side: Circular Icon Buttons -->
-                        <div class="d-flex align-top flex-shrink-0">
-
-							<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
-										   Color="Color.Success"
-										   Size="Size.Medium"
-										   IconSize="Size.Large"
-										   Variant="Variant.Filled"
-										   Class="mud-rounded-circle me-2"
-										   OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzTypeId); })" />
-
-							<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-										   Color="Color.Success"
-										   Size="Size.Medium"
-										   IconSize="Size.Large"
-										   Variant="Variant.Filled"
-										   Class="mud-rounded-circle"
-										   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzTypeId); })" />
-						</div>
-					</div>
-				</MudCardContent>
-			</MudCard>
-
-			<MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
-				<MudCardContent Style="padding : 6px">
-					@if (!ViewSettings.IsKioskMode)
-					{
-                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
-                        <div style="
-                                    display:flex;
-                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
-                                    align-items:flex-start;
-                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
-                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
-                                    ">
-							<div style="display:flex; align-items:center; gap:6px;">
-							<strong>ID : </strong>
-							<CopyableText TextToCopy="@singleItemzType.Id.ToString()" DisplayLength="8" />
-							<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
-								<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
 							</MudTooltip>
-							<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
+							<!-- Left side: Title -->
+							<MudText Typo="Typo.inherit"
+									 Class="flex-grow-1 text-responsive-title"
+									 Align="Align.Left"
+									 Style="white-space:normal; overflow-wrap:break-word;">
+								<strong>@singleItemzType.Name</strong>
+							</MudText>
+
+							<!-- Right side: Circular Icon Buttons -->
+							<div class="d-flex align-top flex-shrink-0">
+
+								<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
+											   Color="Color.Success"
+											   Size="Size.Medium"
+											   IconSize="Size.Large"
+											   Variant="Variant.Filled"
+											   Class="mud-rounded-circle me-2"
+											   OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzTypeId); })" />
+
+								<MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+											   Color="Color.Success"
+											   Size="Size.Medium"
+											   IconSize="Size.Large"
+											   Variant="Variant.Filled"
+											   Class="mud-rounded-circle"
+											   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzTypeId); })" />
 							</div>
-							@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+						</div>
+					</MudCardContent>
+				</MudCard>
+
+				<MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
+					<MudCardContent Style="padding : 6px">
+						@if (!ViewSettings.IsKioskMode)
+						{
+							<MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+								<div style="
+		                                    display:flex;
+		                                    gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+		                                    align-items:flex-start;
+		                                    flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+		                                    flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+		                                    ">
+									<div style="display:flex; align-items:center; gap:6px;">
+										<strong>ID : </strong>
+										<CopyableText TextToCopy="@singleItemzType.Id.ToString()" DisplayLength="8" />
+										<MudTooltip Text="Show in Tree View" Placement="Placement.Top">
+											<MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
+										</MudTooltip>
+										<ShowHierarchyTreeButton RecordId="@singleItemzType.Id" />
+									</div>
+									@if (ViewSettings.ShowPropertiesInReadOnlyViews)
+									{
+										<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Status : </strong> @singleItemzType.Status</div>
+										<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzTypeId" /> </div>
+									}
+								</div>
+							</MudBreakpointProvider>
+						}
+						<br />
+						<div class="custom-markdown-editor">
+							@if (!string.IsNullOrEmpty(singleItemzType.Description))
 							{
-								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")Status : </strong> @singleItemzType.Status</div>
-								<div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong> <EstimationReadOnlyComponent RecordId="@ItemzTypeId" /> </div>
+								<div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
 							}
 						</div>
-					</MudBreakpointProvider>
-					}
-					<br />
-					<div class="custom-markdown-editor">
-						@if (!string.IsNullOrEmpty(singleItemzType.Description))
-						{
-							<div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
-						}
-					</div>
-				</MudCardContent>
-			</MudCard>
-		</MudItem>
-		<br />
-	}
-</MudGrid>
+					</MudCardContent>
+				</MudCard>
+			</MudItem>
+			<br />
+		}
+	</MudGrid>
+</div>
+
 @if (_showOverlay)
 {
 	<MudPaper Height="calc(100vh - 100px);" Width="100%">
@@ -151,10 +155,37 @@
 
 	private Breakpoint bp;
 
+	// Swipe support (ElementReference-based)
+	private string _elementId => $"openrose-swipe-itemztype-{ItemzTypeId}";
+	private ElementReference _swipeElementRef;
+	private DotNetObjectReference<ItemzTypeReadOnlyComponent>? _dotNetRef;
+	private bool _swipeRegistered = false;
+
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		if (firstRender)
 		{
+			// register swipe handlers
+			_dotNetRef = DotNetObjectReference.Create(this);
+			try
+			{
+				_swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+				if (!_swipeRegistered)
+				{
+					_logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+				}
+			}
+			catch (JSException jsex)
+			{
+				_logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+			catch (Exception ex)
+			{
+				_logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+				_swipeRegistered = false;
+			}
+
 			initializingPage = true;
 			StateHasChanged();
 			await Task.Delay(300);
@@ -221,7 +252,7 @@
 					}
 					else
 					{
-						// 🔑 USER CLICKED "GO TO Home Screen"
+						// 🔑 USER CLICKED "GO TO Home SCREEN"
 						_logger.LogInformation("User chose to go to home screen");
 						NavManager.NavigateTo("/");
 						loadingSuccessful = true;
@@ -262,13 +293,60 @@
 		}
 	}
 
-    private void findAndShowInTreeView()
-    {
-        TreeNodeItemzSelectionService.ScrollToTreeViewNode(ItemzTypeId);
-    }
+	private void findAndShowInTreeView()
+	{
+		TreeNodeItemzSelectionService.ScrollToTreeViewNode(ItemzTypeId);
+	}
 
 	private void toggleSplitBar()
 	{
 		SplitBarManagementService.ToggleSplitBar();
+	}
+
+	[JSInvokable("OnSwipe")]
+	public async Task OnSwipe(string direction)
+	{
+		if (direction == "left")
+		{
+			if (OnNavigatePrevious.HasDelegate)
+				await OnNavigatePrevious.InvokeAsync(ItemzTypeId);
+		}
+		else if (direction == "right")
+		{
+			if (OnNavigateNext.HasDelegate)
+				await OnNavigateNext.InvokeAsync(ItemzTypeId);
+		}
+	}
+
+	// IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+	public async ValueTask DisposeAsync()
+	{
+		try
+		{
+			if (_swipeRegistered)
+			{
+				await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+			}
+		}
+		catch (Microsoft.JSInterop.JSDisconnectedException)
+		{
+			// circuit disconnected while disposing - ignore (expected in some scenarios)
+		}
+		catch (JSException jsex)
+		{
+			_logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+		}
+		catch (Exception ex)
+		{
+			_logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+		}
+		finally
+		{
+			if (_dotNetRef != null)
+			{
+				_dotNetRef.Dispose();
+				_dotNetRef = null;
+			}
+		}
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -306,15 +306,16 @@
 	[JSInvokable("OnSwipe")]
 	public async Task OnSwipe(string direction)
 	{
+		// Page-like behavior: swipe left => Next, swipe right => Previous
 		if (direction == "left")
-		{
-			if (OnNavigatePrevious.HasDelegate)
-				await OnNavigatePrevious.InvokeAsync(ItemzTypeId);
-		}
-		else if (direction == "right")
 		{
 			if (OnNavigateNext.HasDelegate)
 				await OnNavigateNext.InvokeAsync(ItemzTypeId);
+		}
+		else if (direction == "right")
+		{
+			if (OnNavigatePrevious.HasDelegate)
+				await OnNavigatePrevious.InvokeAsync(ItemzTypeId);
 		}
 	}
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -14,7 +14,11 @@
 @inject ViewSettingsService ViewSettings
 @inject IJSRuntime JS
 @inject JsonFileDataSourceService JsonService
+@inject ILogger<ItemzTypeReadOnlyComponentForJson> _logger
+@implements IAsyncDisposable
 
+
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
 <MudGrid>
     @if (initializingPage)
     {
@@ -32,89 +36,90 @@
             <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
-                    <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                        <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
-                                        Color="Color.Success"
-                                        Size="Size.Medium"
-                                        IconSize="Size.Large"
-                                        Variant="Variant.Filled"
-                                        Class="mud-rounded-circle me-2"
-                                        @onclick="toggleSplitBar" />
+                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                            Color="Color.Success"
+                                            Size="Size.Medium"
+                                            IconSize="Size.Large"
+                                            Variant="Variant.Filled"
+                                            Class="mud-rounded-circle me-2"
+                                            @onclick="toggleSplitBar" />
 
-                    </MudTooltip>
-                    <MudText Typo="Typo.inherit"
-                                Class="flex-grow-1 text-responsive-title"
-                                Align="Align.Left"
-                                Style="white-space:normal; overflow-wrap:break-word;">
-                        <strong>@_itemzType.Name</strong>
-                    </MudText>
-                    <div class="d-flex align-top flex-shrink-0">
-                        <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
-                                        Color="Color.Success"
-                                        Size="Size.Medium"
-                                        IconSize="Size.Large"
-                                        Variant="Variant.Filled"
-                                        Class="mud-rounded-circle me-2"
-                                        OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzTypeId); })" />
+                        </MudTooltip>
+                        <MudText Typo="Typo.inherit"
+                                    Class="flex-grow-1 text-responsive-title"
+                                    Align="Align.Left"
+                                    Style="white-space:normal; overflow-wrap:break-word;">
+                            <strong>@_itemzType.Name</strong>
+                        </MudText>
+                        <div class="d-flex align-top flex-shrink-0">
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleUp"
+                                            Color="Color.Success"
+                                            Size="Size.Medium"
+                                            IconSize="Size.Large"
+                                            Variant="Variant.Filled"
+                                            Class="mud-rounded-circle me-2"
+                                            OnClick="@(() => { if (OnNavigatePrevious.HasDelegate) OnNavigatePrevious.InvokeAsync(ItemzTypeId); })" />
 
-                        <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-                                        Color="Color.Success"
-                                        Size="Size.Medium"
-                                        IconSize="Size.Large"
-                                        Variant="Variant.Filled"
-                                        Class="mud-rounded-circle"
-                                        OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzTypeId); })" />
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+                                            Color="Color.Success"
+                                            Size="Size.Medium"
+                                            IconSize="Size.Large"
+                                            Variant="Variant.Filled"
+                                            Class="mud-rounded-circle"
+                                            OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ItemzTypeId); })" />
                         </div>
-                    </div>                
-                 </MudCardContent>
+                    </div>
+                </MudCardContent>
             </MudCard>
 
             <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
                 <MudCardContent>
-                @if (!ViewSettings.IsKioskMode)
-                {
-                <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
-                    <div style=" display:flex;
-                            gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
-                            align-items:flex-start;
-                            flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
-                            flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
-                    @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                    @if (!ViewSettings.IsKioskMode)
                     {
-                        <div style="display:flex; align-items:center; gap:6px;">
-                        <strong>ID : </strong>
-                        <CopyableText TextToCopy="@_itemzType.Id.ToString()" DisplayLength="8" />
-                        <MudTooltip Text="Show in Tree View">
-                            <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
-                        </MudTooltip>
-                        </div>
+                        <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                            <div style=" display:flex;
+                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                align-items:flex-start;
+                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                                @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                                {
+                                    <div style="display:flex; align-items:center; gap:6px;">
+                                        <strong>ID : </strong>
+                                        <CopyableText TextToCopy="@_itemzType.Id.ToString()" DisplayLength="8" />
+                                        <MudTooltip Text="Show in Tree View">
+                                            <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
+                                        </MudTooltip>
+                                    </div>
 
-                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status : </strong> @_itemzType.Status</div>
-                        @if (!string.IsNullOrEmpty(_itemzType.EstimationUnit))
-                        {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemzType.EstimationUnit] : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
-                        }
-                        else
-                        {
-                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
-                        }
-                    }
-                    </div>
-                </MudBreakpointProvider>
-                <br />
+                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status : </strong> @_itemzType.Status</div>
+                                    @if (!string.IsNullOrEmpty(_itemzType.EstimationUnit))
+                                    {
+                                        <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_itemzType.EstimationUnit] : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
+                                    }
+                                    else
+                                    {
+                                        <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong> @_itemzType.OwnEstimation <b>|| Roll-Up</b> :@_itemzType.RolledUpEstimation </div>
+                                    }
+                                }
+                            </div>
+                        </MudBreakpointProvider>
+                        <br />
                     }
                     <div class="custom-markdown-editor">
-                    @if (!string.IsNullOrEmpty(_itemzType.Description))
-                    {
-                        <div class="markdown-body">@((MarkupString)_convertedMarkdown)</div>
-                    }
-                </div>
+                        @if (!string.IsNullOrEmpty(_itemzType.Description))
+                        {
+                            <div class="markdown-body">@((MarkupString)_convertedMarkdown)</div>
+                        }
+                    </div>
                 </MudCardContent>
             </MudCard>
         </MudItem>
         <br />
     }
 </MudGrid>
+</div>
 
 @code {
     [Parameter] public Guid ItemzTypeId { get; set; }
@@ -131,6 +136,12 @@
 
     private Breakpoint bp;
 
+    // Swipe support (ElementReference-based)
+    private string _elementId => $"openrose-swipe-itemztypejson-{ItemzTypeId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<ItemzTypeReadOnlyComponentForJson>? _dotNetRef;
+    private bool _swipeRegistered = false;
+
     protected override async Task OnParametersSetAsync()
     {
         initializingPage = true;
@@ -142,8 +153,6 @@
             if (!string.IsNullOrEmpty(_itemzType.Description))
             {
                 _needsRender = true;
-                // var html = await JS.InvokeAsync<string>("markdownToHtml", _itemzType.Description);
-                // _convertedMarkdown = (MarkupString)html;
             }
             else
             {
@@ -158,6 +167,30 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // register swipe handlers
+            _dotNetRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+        }
+
         if (_needsRender)
         {
             _needsRender = false;
@@ -186,4 +219,51 @@
         SplitBarManagementService.ToggleSplitBar();
     }
 
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        // Book-style mapping: swipe left => Next, swipe right => Previous
+        if (direction == "left")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(ItemzTypeId);
+        }
+        else if (direction == "right")
+        {
+            if (OnNavigatePrevious.HasDelegate)
+                await OnNavigatePrevious.InvokeAsync(ItemzTypeId);
+        }
+    }
+
+    // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // circuit disconnected while disposing - ignore
+        }
+        catch (JSException jsex)
+        {
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
+    }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -226,12 +226,14 @@
     [JSInvokable("OnSwipe")]
     public async Task OnSwipe(string direction)
     {
-        // Project only supports "next"
-        if (direction == "right")
+        // For Project (root): swipe left => Next (move forward).
+        // Swipe right would normally be Previous, but Project has no previous in this view so we ignore it.
+        if (direction == "left")
         {
             if (OnNavigateNext.HasDelegate)
                 await OnNavigateNext.InvokeAsync(ProjectId);
         }
+        // else: right swipe -> no-op for project root
     }
 
     // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -17,118 +17,108 @@
 @inject ViewSettingsService ViewSettings
 @inject TreeNodeItemzSelectionService TreeNodeItemzSelectionService
 @inject IJSRuntime JS
+@inject ILogger<Project> _logger
+@implements IAsyncDisposable
 
-<MudGrid>
-    @if (initializingPage)
-    {
-        <MudPaper Height="calc(100vh - 100px);" Width="100%">
-            <MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
-                <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
-                <br />
-                <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
-            </MudOverlay>
-        </MudPaper>
-    }
-    else
-    {
-        if (singleProject != null && singleProject.Id != Guid.Empty)
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
+    <MudGrid>
+        @if (initializingPage)
         {
-        <MudItem xs="12" sm="12">
-            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-                <MudCardContent Style="padding:6px">
-                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
-                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
-                                            Color="Color.Success"
-                                            Size="Size.Medium"
-                                            IconSize="Size.Large"
-                                            Variant="Variant.Filled"
-                                            Class="mud-rounded-circle me-2"
-                                            @onclick="toggleSplitBar" />
+            <MudPaper Height="calc(100vh - 100px);" Width="100%">
+                <MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
+                    <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
+                    <br />
+                    <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+                </MudOverlay>
+            </MudPaper>
+        }
+        else
+        {
+            if (singleProject != null && singleProject.Id != Guid.Empty)
+            {
+                <MudItem xs="12" sm="12">
+                    <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
+                        <MudCardContent Style="padding:6px">
+                            <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                                <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                                    <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                                   Color="Color.Success"
+                                                   Size="Size.Medium"
+                                                   IconSize="Size.Large"
+                                                   Variant="Variant.Filled"
+                                                   Class="mud-rounded-circle me-2"
+                                                   @onclick="toggleSplitBar" />
 
-                        </MudTooltip>
-                        <!-- Left side: Title -->
-                        <MudText Typo="Typo.inherit"
-                                 Class="flex-grow-1 text-responsive-title"
-                                 Align="Align.Left"
-                                 Style="white-space:normal; overflow-wrap:break-word;">
-                            <strong>@singleProject.Name</strong>
-                        </MudText>
+                                </MudTooltip>
+                                <!-- Left side: Title -->
+                                <MudText Typo="Typo.inherit"
+                                         Class="flex-grow-1 text-responsive-title"
+                                         Align="Align.Left"
+                                         Style="white-space:normal; overflow-wrap:break-word;">
+                                    <strong>@singleProject.Name</strong>
+                                </MudText>
 
-                        <div class="d-flex align-top flex-shrink-0">
+                                <div class="d-flex align-top flex-shrink-0">
 
-                            <!-- Right side: Only Down button -->
-                            <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
-                                <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-                                               Color="Color.Success"
-                                               Size="Size.Medium"
-                                               IconSize="Size.Large"
-                                               Variant="Variant.Filled"
-                                               Class="mud-rounded-circle"
-                                               OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
-                            </MudItem>
-                        </div>
-                    </div>
-                </MudCardContent>
-            </MudCard>
-
-            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
-                <MudCardContent>
-                    @if (!ViewSettings.IsKioskMode)
-                    {
-                        <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
-                            <div style="
-                                            display:flex;
-                                            gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
-                                            align-items:flex-start;
-                                            flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
-                                            flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
-                                            ">
-                                <div style="display:flex; align-items:center; gap:6px;">
-                                    <strong>ID : </strong>
-                                    <CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
-                                    <MudTooltip Text="Show in Tree View" Placement="Placement.Top">
-                                        <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
-                                    </MudTooltip>
+                                    <!-- Right side: Only Down button -->
+                                    <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                                        <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+                                                       Color="Color.Success"
+                                                       Size="Size.Medium"
+                                                       IconSize="Size.Large"
+                                                       Variant="Variant.Filled"
+                                                       Class="mud-rounded-circle"
+                                                       OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
+                                    </MudItem>
                                 </div>
-                                @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                            </div>
+                        </MudCardContent>
+                    </MudCard>
+
+                    <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
+                        <MudCardContent>
+                            @if (!ViewSettings.IsKioskMode)
+                            {
+                                <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                                    <div style="
+                                                        display:flex;
+                                                        gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                                        align-items:flex-start;
+                                                        flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                                        flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap");
+                                                        ">
+                                        <div style="display:flex; align-items:center; gap:6px;">
+                                            <strong>ID : </strong>
+                                            <CopyableText TextToCopy="@singleProject.Id.ToString()" DisplayLength="8" />
+                                            <MudTooltip Text="Show in Tree View" Placement="Placement.Top">
+                                                <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="findAndShowInTreeView" />
+                                            </MudTooltip>
+                                        </div>
+                                        @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                                        {
+                                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleProject.Status </div>
+                                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong>  <EstimationReadOnlyComponent RecordId="@ProjectId" /> </div>
+                                        }
+                                    </div>
+                                </MudBreakpointProvider>
+                            }
+
+                            <br />
+                            <div class="custom-markdown-editor">
+                                @if (singleProject != null && !(string.IsNullOrEmpty(singleProject.Description)))
                                 {
-                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "") Status      : </strong> @singleProject.Status </div>
-                                    <div><strong> @(bp >= Breakpoint.Md ? "||" : "")</strong>  <EstimationReadOnlyComponent RecordId="@ProjectId" /> </div>
+                                    <div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
                                 }
                             </div>
-                        </MudBreakpointProvider>
-                    }
-
-                    <br />
-                    <div class="custom-markdown-editor">
-                        @if (singleProject != null && !(string.IsNullOrEmpty(singleProject.Description)))
-                        {
-                            <div class="markdown-body">@((MarkupString)convertedMarkdown)</div>
-                        }
-                    </div>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-            <br />
-        }
-@*         else
-        {
-            if (initializingPage == false)
-            { 
-                <MudItem xs="12" sm="12">
-                    <br />
-                    <MudButton Variant="Variant.Filled"
-                               Color="Color.Secondary"
-                               OnClick="@(() => OnAfterRenderAsync(true))">
-                        CLICK TO LOAD PROJECT DATA MANUALLY
-                    </MudButton>
-                    <br />
+                        </MudCardContent>
+                    </MudCard>
                 </MudItem>
+                <br />
             }
-        } *@
-    }
-</MudGrid>
+        }
+    </MudGrid>
+</div>
+
 @if (_showOverlay)
 {
     <MudPaper Height="calc(100vh - 100px);" Width="100%">
@@ -139,7 +129,7 @@
         </MudOverlay>
     </MudPaper>
 }
-@code 
+@code
 {
     [Parameter]
     public Guid ProjectId { get; set; }
@@ -159,10 +149,37 @@
 
     private Breakpoint bp;
 
+    // Swipe support (ElementReference-based)
+    private string _elementId => $"openrose-swipe-project-{ProjectId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<ProjectReadOnlyComponent>? _dotNetRef;
+    private bool _swipeRegistered = false;
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            // Register swipe handlers first (non-blocking for data load)
+            _dotNetRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+
             initializingPage = true;
             StateHasChanged();
             await Task.Delay(300);
@@ -204,5 +221,48 @@
     private void toggleSplitBar()
     {
         SplitBarManagementService.ToggleSplitBar();
+    }
+
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        // Project only supports "next"
+        if (direction == "right")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(ProjectId);
+        }
+    }
+
+    // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // circuit disconnected while disposing - ignore
+        }
+        catch (JSException jsex)
+        {
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -4,7 +4,6 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 *@
 
-
 @using OpenRose.WebUI.Client.Services.JsonFile
 @using OpenRose.WebUI.Client.SharedModels
 @using OpenRose.WebUI.Components.EventServices
@@ -15,105 +14,109 @@
 @inject ViewSettingsService ViewSettings
 @inject IJSRuntime JS
 @inject JsonFileDataSourceService JsonService
+@inject ILogger<ProjectReadOnlyComponentForJson> _logger
+@implements IAsyncDisposable
 
-<MudGrid>
-    @if (initializingPage)
-    {
-        <MudPaper Width="100%">
-            <MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
-                <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
-                <br />
-                <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
-            </MudOverlay>
-        </MudPaper>
-    }
-    else
-    {
-        <MudItem xs="12" sm="12">
-            <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
-                <MudCardContent Style="padding:6px">
-                    <div class="d-flex align-start justify-space-between" style="gap:8px;">
-                        <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle me-2"
-                                           @onclick="toggleSplitBar" />
-
-                        </MudTooltip>
-                        <MudText Typo="Typo.inherit"
-                                 Class="flex-grow-1 text-responsive-title"
-                                 Align="Align.Left"
-                                 Style="white-space:normal; overflow-wrap:break-word;">
-                            <strong>@_project.Name</strong>
-                        </MudText>
-                        <div class="d-flex align-top flex-shrink-0">
-
-                        <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
-                            <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
-                                           Color="Color.Success"
-                                           Size="Size.Medium"
-                                           IconSize="Size.Large"
-                                           Variant="Variant.Filled"
-                                           Class="mud-rounded-circle"
-                                           OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
-                        </MudItem>
-                        </div>
-                    </div>
-
-                </MudCardContent>
-            </MudCard>
-            <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
-                <MudCardContent>
-                    @if (!ViewSettings.IsKioskMode)
-                    {
-                    
-                        
-                    <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
-                        <div style=" display:flex;
-                                gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
-                                align-items:flex-start;
-                                flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
-                                flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
-                            @if (ViewSettings.ShowPropertiesInReadOnlyViews)
-                            {
-                            <div style="display:flex; align-items:center; gap:6px;">
-                                <strong>ID : </strong>
-                                <CopyableText TextToCopy="@_project.Id.ToString()" DisplayLength="8" />
-                                <MudTooltip Text="Show in Tree View">
-                                    <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
-                                </MudTooltip>
-                            </div>
-                            <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_project.Status</div>
-                            @if (!string.IsNullOrEmpty(_project.EstimationUnit))
-                            {
-                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_project.EstimationUnit] : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
-                            }
-                            else
-                            {
-                                <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
-                            }
-                        }
-                        </div>
-                    </MudBreakpointProvider>
-
-
+<div style="height:100%;" id="@_elementId" @ref="_swipeElementRef">
+    <MudGrid>
+        @if (initializingPage)
+        {
+            <MudPaper Width="100%">
+                <MudOverlay Visible="@initializingPage" DarkBackground="true" Absolute="true">
+                    <MudText Typo="Typo.h4" Align="Align.Center" Color="Color.Inherit">Loading ...</MudText>
                     <br />
-                    }
-                    <div class="custom-markdown-editor">
-                        @if (!string.IsNullOrEmpty(_project.Description))
+                    <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+                </MudOverlay>
+            </MudPaper>
+        }
+        else
+        {
+            <MudItem xs="12" sm="12">
+                <MudCard style="background-color:#FABBBB; position:sticky; top:0; z-index:10;">
+                    <MudCardContent Style="padding:6px">
+                        <div class="d-flex align-start justify-space-between" style="gap:8px;">
+                            <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
+                                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                               Color="Color.Success"
+                                               Size="Size.Medium"
+                                               IconSize="Size.Large"
+                                               Variant="Variant.Filled"
+                                               Class="mud-rounded-circle me-2"
+                                               @onclick="toggleSplitBar" />
+
+                            </MudTooltip>
+                            <MudText Typo="Typo.inherit"
+                                     Class="flex-grow-1 text-responsive-title"
+                                     Align="Align.Left"
+                                     Style="white-space:normal; overflow-wrap:break-word;">
+                                <strong>@_project.Name</strong>
+                            </MudText>
+                            <div class="d-flex align-top flex-shrink-0">
+
+                                <MudItem xs="12" sm="12" md="5" lg="5" Class="d-flex justify-end align-center">
+                                    <MudIconButton Icon="@Icons.Material.Filled.ArrowCircleDown"
+                                                   Color="Color.Success"
+                                                   Size="Size.Medium"
+                                                   IconSize="Size.Large"
+                                                   Variant="Variant.Filled"
+                                                   Class="mud-rounded-circle"
+                                                   OnClick="@(() => { if (OnNavigateNext.HasDelegate) OnNavigateNext.InvokeAsync(ProjectId); })" />
+                                </MudItem>
+                            </div>
+                        </div>
+
+                    </MudCardContent>
+                </MudCard>
+                <MudCard Elevation="0" Outlined="false" Style="background-color:transparent;">
+                    <MudCardContent>
+                        @if (!ViewSettings.IsKioskMode)
                         {
-                            <div class="markdown-body">@((MarkupString)_convertedMarkdown)</div>
+
+
+                            <MudBreakpointProvider OnBreakpointChanged="b => bp = b">
+                                <div style=" display:flex;
+                                        gap: @(bp >= Breakpoint.Md ? "10px" : "2px") ;
+                                        align-items:flex-start;
+                                        flex-direction:@(bp >= Breakpoint.Md ? "row" : "column");
+                                        flex-wrap:@(bp >= Breakpoint.Md ? "nowrap" : "wrap"); ">
+                                    @if (ViewSettings.ShowPropertiesInReadOnlyViews)
+                                    {
+                                        <div style="display:flex; align-items:center; gap:6px;">
+                                            <strong>ID : </strong>
+                                            <CopyableText TextToCopy="@_project.Id.ToString()" DisplayLength="8" />
+                                            <MudTooltip Text="Show in Tree View">
+                                                <MudIcon Icon="@Icons.Material.Filled.Park" Size="Size.Small" Class="mouse-pointer-icon" @onclick="async () => await findAndShowInTreeViewAsync()" />
+                                            </MudTooltip>
+                                        </div>
+                                        <div><strong> @(bp >= Breakpoint.Md ? "||" : "")  Status      : </strong> @_project.Status</div>
+                                        @if (!string.IsNullOrEmpty(_project.EstimationUnit))
+                                        {
+                                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation [@_project.EstimationUnit] : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
+                                        }
+                                        else
+                                        {
+                                            <div><strong>@(bp >= Breakpoint.Md ? "||" : "") Estimation : </strong>  @_project.OwnEstimation <b>|| Roll-Up</b> :@_project.RolledUpEstimation </div>
+                                        }
+                                    }
+                                </div>
+                            </MudBreakpointProvider>
+
+
+                            <br />
                         }
-                    </div>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-        <br />
-    }
-</MudGrid>
+                        <div class="custom-markdown-editor">
+                            @if (!string.IsNullOrEmpty(_project.Description))
+                            {
+                                <div class="markdown-body">@((MarkupString)_convertedMarkdown)</div>
+                            }
+                        </div>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <br />
+        }
+    </MudGrid>
+</div>
 
 @code {
     [Parameter] public Guid ProjectId { get; set; }
@@ -128,6 +131,12 @@
     private bool _needsRender = false;
 
     private Breakpoint bp;
+
+    // Swipe support (ElementReference-based)
+    private string _elementId => $"openrose-swipe-projectjson-{ProjectId}";
+    private ElementReference _swipeElementRef;
+    private DotNetObjectReference<ProjectReadOnlyComponentForJson>? _dotNetRef;
+    private bool _swipeRegistered = false;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -155,31 +164,32 @@
         }
     }
 
-    // protected override async Task OnAfterRenderAsync(bool firstRender)
-    // {
-    //     if (!firstRender) return;
-
-    //     initializingPage = true;
-    //     StateHasChanged();
-
-    //     _project = await JsonService.GetProjectDetailsAsync(ProjectId);
-
-    //     if (!string.IsNullOrEmpty(_project.Description))
-    //     {
-    //         var html = await JS.InvokeAsync<string>("markdownToHtml", _project.Description);
-    //         _convertedMarkdown = (MarkupString)html;
-    //     }
-    //     else
-    //     {
-    //         _convertedMarkdown = default;
-    //     }
-
-    //     initializingPage = false;
-    //     StateHasChanged();
-    // }
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // register swipe handlers
+            _dotNetRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _swipeRegistered = await JS.InvokeAsync<bool>("openRoseRegisterSwipeElement", _swipeElementRef, _dotNetRef);
+                if (!_swipeRegistered)
+                {
+                    _logger?.LogWarning("Swipe registration failed for {ElementId}", _elementId);
+                }
+            }
+            catch (JSException jsex)
+            {
+                _logger?.LogWarning(jsex, "JSException while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Unexpected exception while registering swipe for {ElementId}", _elementId);
+                _swipeRegistered = false;
+            }
+        }
+
         if (_needsRender)
         {
             _needsRender = false;
@@ -207,5 +217,48 @@
     private void toggleSplitBar()
     {
         SplitBarManagementService.ToggleSplitBar();
+    }
+
+    [JSInvokable("OnSwipe")]
+    public async Task OnSwipe(string direction)
+    {
+        // Book-style mapping: swipe left => Next (move forward)
+        if (direction == "left")
+        {
+            if (OnNavigateNext.HasDelegate)
+                await OnNavigateNext.InvokeAsync(ProjectId);
+        }
+    }
+
+    // IAsyncDisposable: unregister swipe handlers and dispose DotNetObjectReference
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_swipeRegistered)
+            {
+                await JS.InvokeAsync<bool>("openRoseUnregisterSwipeElement", _swipeElementRef);
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // circuit disconnected while disposing - ignore
+        }
+        catch (JSException jsex)
+        {
+            _logger?.LogWarning(jsex, "JSException while unregistering swipe for {ElementId}", _elementId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Unexpected exception while unregistering swipe for {ElementId}", _elementId);
+        }
+        finally
+        {
+            if (_dotNetRef != null)
+            {
+                _dotNetRef.Dispose();
+                _dotNetRef = null;
+            }
+        }
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,29 +4,30 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
-
-// Touch-only swipe detection (single-finger). Does NOT handle mouse/pointer events.
-// - Intercepts single-finger horizontal swipes and prevents browser history only for that gesture.
-// - Immediately cancels custom handling when a second finger is detected, allowing pinch/zoom.
-// - Moderate sensitivity: threshold=50px, restraint=120px, allowedTime=600ms.
-// - Set debug = true for logging during testing.
+// Touch-only swipe detection (single-finger).
+// - DOES NOT change touch-action or overscroll styles.
+// - Dynamically installs non-passive touchmove listener and only calls preventDefault
+//   when single-finger horizontal gesture is clearly detected.
+// - Cancels custom handling immediately when a second touch appears.
+// - Moderate sensitivity: threshold=50px swipe, earlyPrevent=30px to start preventing.
+// - Set debug = true for diagnostic logs.
 
 (function () {
     if (window.openRoseSwipeLibLoaded) return;
     window.openRoseSwipeLibLoaded = true;
     window.openRoseHandlers = window.openRoseHandlers || {};
 
-    var debug = false; // set to true while testing to get console logs
+    var debug = true; // set to true to enable console logs on device during testing
 
     function dlog() {
         if (!debug) return;
         try { console.log.apply(console, arguments); } catch (_) { }
     }
 
-    var DEFAULT_THRESHOLD = 50;   // px horizontal
-    var DEFAULT_RESTRAINT = 120;  // px vertical
-    var DEFAULT_ALLOWED_TIME = 600; // ms
-    var EARLY_MOVE_THRESHOLD = 10; // px; start preventing after small horizontal movement
+    var DEFAULT_THRESHOLD = 50;    // px horizontal movement required to count as a swipe on end
+    var DEFAULT_RESTRAINT = 120;   // px max vertical movement allowed for a swipe
+    var DEFAULT_ALLOWED_TIME = 600; // ms allowed duration for the swipe
+    var EARLY_PREVENT_THRESHOLD = 30; // px horizontal movement before we call preventDefault on touchmove
 
     function registerOnElement(el, dotNetRef, elementKey, opts) {
         if (!el) return false;
@@ -34,46 +35,30 @@
         var threshold = (opts && opts.threshold) || DEFAULT_THRESHOLD;
         var restraint = (opts && opts.restraint) || DEFAULT_RESTRAINT;
         var allowedTime = (opts && opts.allowedTime) || DEFAULT_ALLOWED_TIME;
+        var earlyPrevent = (opts && opts.earlyPrevent) || EARLY_PREVENT_THRESHOLD;
 
-        var activeTouch = null; // { id, startX, startY, startTime, prevented }
-        var docTouchMoveHandler = null;
-        var savedOverscroll = null;
-        var savedTouchAction = null;
+        // Track a single active touch for this element
+        var active = null; // { id, startX, startY, startTime, prevented }
+        var docMoveHandler = null;
 
-        function cleanupMoveHandler() {
-            if (docTouchMoveHandler) {
-                try { document.removeEventListener('touchmove', docTouchMoveHandler, { capture: true }); } catch (e) { /* ignore */ }
-                docTouchMoveHandler = null;
+        function cleanup() {
+            if (docMoveHandler) {
+                try { document.removeEventListener('touchmove', docMoveHandler, { capture: true }); } catch (e) { /* ignore */ }
+                docMoveHandler = null;
             }
-            try {
-                if (savedOverscroll !== null) {
-                    document.documentElement.style.overscrollBehavior = savedOverscroll;
-                    savedOverscroll = null;
-                } else {
-                    document.documentElement.style.overscrollBehavior = '';
-                }
-            } catch (e) { /* ignore */ }
-
-            try {
-                if (savedTouchAction !== null) {
-                    el.style.touchAction = savedTouchAction;
-                    savedTouchAction = null;
-                } else {
-                    el.style.touchAction = '';
-                }
-            } catch (e) { /* ignore */ }
+            active = null;
         }
 
         function onTouchStart(ev) {
             try {
                 if (!ev || !ev.touches) return;
-                // Only begin tracking when exactly one touch is present
+                // Start tracking only if exactly one touch is present
                 if (ev.touches.length !== 1) {
-                    activeTouch = null;
+                    active = null;
                     return;
                 }
                 var t = ev.touches[0];
-                activeTouch = {
+                active = {
                     id: t.identifier,
                     startX: t.clientX,
                     startY: t.clientY,
@@ -81,130 +66,117 @@
                     prevented: false
                 };
 
-                dlog("swipe: touchstart id", activeTouch.id, "element", elementKey);
+                dlog("swipe: touchstart id", active.id, "element", elementKey);
 
-                // Temporarily reduce overscroll behavior so browsers are less likely to interpret horizontal swipe as nav.
-                try {
-                    savedOverscroll = document.documentElement.style.overscrollBehavior || '';
-                    document.documentElement.style.overscrollBehavior = 'none';
-                } catch (e) { savedOverscroll = null; }
-
-                try {
-                    savedTouchAction = el.style.touchAction || '';
-                    el.style.touchAction = 'pan-y';
-                } catch (e) { savedTouchAction = null; }
-
-                // Install document-level touchmove (non-passive) so we can preventDefault when we detect horizontal gesture
-                docTouchMoveHandler = function (moveEv) {
+                // Install non-passive document touchmove so we can call preventDefault when needed
+                docMoveHandler = function (moveEv) {
                     try {
-                        if (!activeTouch) return;
+                        if (!active) return;
 
-                        // If multi-touch occurs, cancel custom handling immediately and restore defaults
+                        // If multi-touch starts, cancel our swipe tracking and allow browser to handle it
                         if (moveEv.touches && moveEv.touches.length > 1) {
-                            dlog("swipe: multi-touch detected -> cancel custom swipe handling", elementKey);
-                            cleanupMoveHandler();
-                            activeTouch = null;
+                            dlog("swipe: multi-touch detected -> cancel custom handling", elementKey);
+                            cleanup();
                             return;
                         }
 
                         // find tracked touch
                         var found = null;
                         for (var i = 0; i < moveEv.touches.length; i++) {
-                            if (moveEv.touches[i].identifier === activeTouch.id) { found = moveEv.touches[i]; break; }
+                            if (moveEv.touches[i].identifier === active.id) { found = moveEv.touches[i]; break; }
                         }
                         if (!found) return;
 
-                        var dx = found.clientX - activeTouch.startX;
-                        var dy = found.clientY - activeTouch.startY;
+                        var dx = found.clientX - active.startX;
+                        var dy = found.clientY - active.startY;
                         var absDx = Math.abs(dx), absDy = Math.abs(dy);
 
-                        // If horizontal dominant and passes a small early threshold, prevent default to stop browser nav
-                        if (!activeTouch.prevented && absDx > EARLY_MOVE_THRESHOLD && absDx > absDy) {
+                        // Only prevent default when movement is clearly horizontal and exceeds earlyPrevent
+                        if (!active.prevented && absDx > earlyPrevent && absDx > absDy) {
                             try {
-                                moveEv.preventDefault();
-                                activeTouch.prevented = true;
+                                moveEv.preventDefault(); // prevents browser history navigation in many browsers
+                                active.prevented = true;
                                 dlog("swipe: prevented default on touchmove (element)", elementKey);
-                            } catch (e) { /* ignore */ }
-                        } else if (activeTouch.prevented) {
+                            } catch (e) {
+                                // ignore errors from preventDefault if any
+                            }
+                        } else if (active.prevented) {
+                            // Continue to prevent if we've already started preventing
                             try { moveEv.preventDefault(); } catch (e) { /* ignore */ }
                         }
-                    } catch (e) { /* ignore */ }
+                    } catch (e) {
+                        // ignore
+                    }
                 };
 
-                document.addEventListener('touchmove', docTouchMoveHandler, { passive: false, capture: true });
-
-            } catch (err) {
-                dlog("swipe: onTouchStart error", err);
+                document.addEventListener('touchmove', docMoveHandler, { passive: false, capture: true });
+            } catch (ex) {
+                dlog("swipe: onTouchStart error", ex);
+                cleanup();
             }
         }
 
         function onTouchEnd(ev) {
             try {
-                if (!activeTouch) {
-                    cleanupMoveHandler();
+                if (!active) {
+                    cleanup();
                     return;
                 }
 
                 if (!ev.changedTouches) {
-                    cleanupMoveHandler();
-                    activeTouch = null;
+                    cleanup();
                     return;
                 }
 
                 var matched = null;
                 for (var i = 0; i < ev.changedTouches.length; i++) {
-                    if (ev.changedTouches[i].identifier === activeTouch.id) { matched = ev.changedTouches[i]; break; }
+                    if (ev.changedTouches[i].identifier === active.id) { matched = ev.changedTouches[i]; break; }
                 }
 
                 if (!matched) {
-                    // touch ended but not the tracked one -> cleanup and return
-                    cleanupMoveHandler();
-                    activeTouch = null;
+                    // Not the tracked touch; just cleanup
+                    cleanup();
                     return;
                 }
 
-                var dx = matched.clientX - activeTouch.startX;
-                var dy = matched.clientY - activeTouch.startY;
-                var dt = Date.now() - activeTouch.startTime;
+                var dx = matched.clientX - active.startX;
+                var dy = matched.clientY - active.startY;
+                var dt = Date.now() - active.startTime;
 
-                dlog("swipe: touchend id", activeTouch.id, "dx", dx, "dy", dy, "dt", dt, "prevented", activeTouch.prevented);
+                dlog("swipe: touchend id", active.id, "dx", dx, "dy", dy, "dt", dt, "prevented", active.prevented);
 
-                cleanupMoveHandler();
+                cleanup();
 
                 if (dt <= allowedTime && Math.abs(dx) >= threshold && Math.abs(dy) <= restraint) {
                     if (dx < 0) {
-                        dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /*ignore*/ });
+                        dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
                         dlog("swipe: invoked left for", elementKey);
                     } else {
-                        dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /*ignore*/ });
+                        dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
                         dlog("swipe: invoked right for", elementKey);
                     }
                 }
-
-                activeTouch = null;
-            } catch (err) {
-                dlog("swipe: onTouchEnd error", err);
-                cleanupMoveHandler();
-                activeTouch = null;
+            } catch (ex) {
+                dlog("swipe: onTouchEnd error", ex);
+                cleanup();
             }
         }
 
         function onTouchCancel(ev) {
             try {
-                dlog("swipe: touchcancel for", elementKey);
-                cleanupMoveHandler();
-                activeTouch = null;
+                dlog("swipe: touchcancel", elementKey);
+                cleanup();
             } catch (e) { /* ignore */ }
         }
 
-        // Attach element-level touch listeners. Do NOT attach pointer/mouse handlers.
+        // Attach touch handlers to the element (no mouse/pointer handlers)
         try {
             el.addEventListener('touchstart', onTouchStart, { passive: false });
             el.addEventListener('touchend', onTouchEnd, { passive: true });
             el.addEventListener('touchcancel', onTouchCancel, { passive: true });
             dlog("swipe: attached touch handlers for element", elementKey);
         } catch (e) {
-            // fallback
+            // older browsers fallback
             el.addEventListener('touchstart', onTouchStart);
             el.addEventListener('touchend', onTouchEnd);
             el.addEventListener('touchcancel', onTouchCancel);
@@ -240,7 +212,6 @@
         }
     }
 
-    // API for Blazor
     window.openRoseRegisterSwipeElement = function (element, dotNetRef, options) {
         try {
             if (!element) return false;

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,359 +4,360 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
-// Hybrid approach: element-level start + global end handlers.
-// - Preserves button clicks (no pointer capture).
-// - Detects single-finger swipes reliably on mobile.
-// - Preserves multi-touch pinch/zoom (we ignore multi-touch).
-// - Default sensitivity: threshold=50px, restraint=120px, allowedTime=600ms.
-// Set debug = true to enable console logging for troubleshooting.
+// wwwroot/js/swipe.js
+// Hybrid element-level start + dynamic move-handler approach.
+// - Prevents browser history swipe for single-finger horizontal swipes by calling preventDefault on move,
+//   but only after detecting a single-finger horizontal gesture in progress.
+// - Preserves pinch/zoom (multi-touch) and normal clicks (no pointer capture).
+// - Moderate sensitivity: threshold=50px, restraint=120px, allowedTime=600ms.
+// - Set debug = true for console logs during testing.
 
 (function () {
-    if (window.openRoseSwipeLibLoaded) {
-        return;
-    }
+    if (window.openRoseSwipeLibLoaded) return;
     window.openRoseSwipeLibLoaded = true;
     window.openRoseHandlers = window.openRoseHandlers || {};
-    window.openRoseActivePointers = window.openRoseActivePointers || {}; // pointerId -> { elementKey, meta }
-    window.openRoseActiveTouches = window.openRoseActiveTouches || {};   // touchId -> { elementKey, meta }
-    window.openRoseGlobalHandlersInstalled = window.openRoseGlobalHandlersInstalled || false;
 
-    var debug = false; // set to true when testing to get console logs
+    var debug = true; // set true while testing to get console logs
 
-    function log() {
+    function dlog() {
         if (!debug) return;
         console.log.apply(console, arguments);
     }
 
-    // Sensitivity default (moderate)
-    var defaultThreshold = 50;    // px horizontal
-    var defaultRestraint = 120;   // px vertical
-    var defaultAllowedTime = 600;  // ms
+    // Sensitivity defaults (tweak if needed)
+    var DEFAULT_THRESHOLD = 50;   // px horizontal
+    var DEFAULT_RESTRAINT = 120;  // px vertical
+    var DEFAULT_ALLOWED_TIME = 600; // ms
 
-    function installGlobalHandlersIfNeeded() {
-        if (window.openRoseGlobalHandlersInstalled) return;
-        // Pointer global handlers (handle pointerup/pointercancel regardless of where pointer moved)
-        if (window.PointerEvent) {
-            document.addEventListener('pointerup', globalPointerUp, { passive: true });
-            document.addEventListener('pointercancel', globalPointerCancel, { passive: true });
-            document.addEventListener('pointerdown', globalPointerDownCapture, { passive: true, capture: true });
-            window.openRoseGlobalHandlersInstalled = true;
-            log("swipe: installed global pointer handlers");
-        } else {
-            // touch fallback
-            document.addEventListener('touchend', globalTouchEnd, { passive: true });
-            document.addEventListener('touchcancel', globalTouchCancel, { passive: true });
-            // Also capture touchstart at document capture phase to ensure we see starts that might not reach elements (rare)
-            document.addEventListener('touchstart', globalTouchStartCapture, { passive: true, capture: true });
-            window.openRoseGlobalHandlersInstalled = true;
-            log("swipe: installed global touch handlers");
-        }
-    }
-
-    // Helper: remove global handlers (rarely needed)
-    function removeGlobalHandlers() {
-        if (!window.openRoseGlobalHandlersInstalled) return;
-        if (window.PointerEvent) {
-            document.removeEventListener('pointerup', globalPointerUp, { passive: true });
-            document.removeEventListener('pointercancel', globalPointerCancel, { passive: true });
-            document.removeEventListener('pointerdown', globalPointerDownCapture, { passive: true, capture: true });
-        } else {
-            document.removeEventListener('touchend', globalTouchEnd, { passive: true });
-            document.removeEventListener('touchcancel', globalTouchCancel, { passive: true });
-            document.removeEventListener('touchstart', globalTouchStartCapture, { passive: true, capture: true });
-        }
-        window.openRoseGlobalHandlersInstalled = false;
-    }
-
-    // Global capture to detect pointerdown that may not bubble (fallback); we don't use it to start gesture processing here.
-    function globalPointerDownCapture(ev) {
-        // noop for now, but installed to ensure pointer events are possible in some environments
-    }
-    function globalTouchStartCapture(ev) {
-        // noop
-    }
-
-    // Global pointer end handlers
-    function globalPointerUp(ev) {
-        try {
-            var pid = ev.pointerId;
-            var rec = window.openRoseActivePointers[pid];
-            if (!rec) return;
-            // rec: { elementKey, startX, startY, startTime, threshold, restraint, allowedTime, dotNetRef }
-            // compute deltas
-            var dx = ev.clientX - rec.startX;
-            var dy = ev.clientY - rec.startY;
-            var dt = Date.now() - rec.startTime;
-
-            log("swipe: globalPointerUp", pid, "dx=", dx, "dy=", dy, "dt=", dt);
-
-            // cleanup
-            delete window.openRoseActivePointers[pid];
-
-            if (dt <= rec.allowedTime && Math.abs(dx) >= rec.threshold && Math.abs(dy) <= rec.restraint) {
-                if (dx < 0) {
-                    rec.dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
-                    log("swipe: invoked left for element", rec.elementKey);
-                } else {
-                    rec.dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
-                    log("swipe: invoked right for element", rec.elementKey);
-                }
-            }
-        } catch (e) {
-            // ignore
-            log("swipe: globalPointerUp error", e);
-        }
-    }
-
-    function globalPointerCancel(ev) {
-        try {
-            var pid = ev.pointerId;
-            if (window.openRoseActivePointers[pid]) {
-                delete window.openRoseActivePointers[pid];
-                log("swipe: pointer cancel cleaned", pid);
-            }
-        } catch (e) { /* ignore */ }
-    }
-
-    // Global touch end handlers
-    function globalTouchEnd(ev) {
-        try {
-            if (!ev.changedTouches) return;
-            for (var i = 0; i < ev.changedTouches.length; i++) {
-                var t = ev.changedTouches[i];
-                var touchId = t.identifier;
-                var rec = window.openRoseActiveTouches[touchId];
-                if (!rec) continue;
-                var dx = t.clientX - rec.startX;
-                var dy = t.clientY - rec.startY;
-                var dt = Date.now() - rec.startTime;
-
-                log("swipe: globalTouchEnd id=", touchId, "dx=", dx, "dy=", dy, "dt=", dt);
-
-                delete window.openRoseActiveTouches[touchId];
-
-                if (dt <= rec.allowedTime && Math.abs(dx) >= rec.threshold && Math.abs(dy) <= rec.restraint) {
-                    if (dx < 0) {
-                        rec.dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
-                        log("swipe: invoked left for element", rec.elementKey);
-                    } else {
-                        rec.dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
-                        log("swipe: invoked right for element", rec.elementKey);
-                    }
-                }
-            }
-        } catch (e) {
-            log("swipe: globalTouchEnd error", e);
-        }
-    }
-
-    function globalTouchCancel(ev) {
-        try {
-            if (!ev.changedTouches) return;
-            for (var i = 0; i < ev.changedTouches.length; i++) {
-                var t = ev.changedTouches[i];
-                var touchId = t.identifier;
-                if (window.openRoseActiveTouches[touchId]) {
-                    delete window.openRoseActiveTouches[touchId];
-                }
-            }
-            log("swipe: globalTouchCancel cleaned");
-        } catch (e) { /* ignore */ }
-    }
-
-    // Register an element to start tracking gestures when start occurs inside element.
+    // Helper: attach and remove with stored refs
     function registerOnElement(el, dotNetRef, elementKey, opts) {
         if (!el) return false;
 
-        // per-element parameters (use defaults unless overridden)
-        var threshold = (opts && opts.threshold) || defaultThreshold;
-        var restraint = (opts && opts.restraint) || defaultRestraint;
-        var allowedTime = (opts && opts.allowedTime) || defaultAllowedTime;
+        var threshold = (opts && opts.threshold) || DEFAULT_THRESHOLD;
+        var restraint = (opts && opts.restraint) || DEFAULT_RESTRAINT;
+        var allowedTime = (opts && opts.allowedTime) || DEFAULT_ALLOWED_TIME;
 
-        // Pointerstart handler attached to element (bubble phase)
-        function elementPointerDown(ev) {
-            try {
-                // Only consider primary buttons for mouse
-                if (ev.pointerType === 'mouse' && ev.button !== 0) return;
+        // Per-interaction state
+        // For pointer events: keep map from pointerId to meta { startX, startY, startTime, movedHorizontally }
+        var pointerMeta = {};
 
-                // Only start if the gesture begins inside this element (we are on element so OK)
-                // Ignore multi-touch: if there is already a pointer tracked with a different pointerId for this browser,
-                // we still treat each pointer independently but we will only process the first for a given pointerId.
-                var pid = ev.pointerId;
+        // For touch fallback (touch identifiers)
+        // Map touchId -> meta
+        var touchMeta = {};
 
-                // store meta for this pointerId keyed globally
-                window.openRoseActivePointers[pid] = {
-                    elementKey: elementKey,
-                    startX: ev.clientX,
-                    startY: ev.clientY,
-                    startTime: Date.now(),
-                    threshold: threshold,
-                    restraint: restraint,
-                    allowedTime: allowedTime,
-                    dotNetRef: dotNetRef
-                };
+        // Move handler refs so we can remove them
+        var currentPointerMoveHandler = null;
+        var currentTouchMoveHandler = null;
 
-                log("swipe: elementPointerDown registered for pid", pid, "element", elementKey);
-            } catch (e) {
-                log("swipe: elementPointerDown error", e);
-            }
+        // --- ELEMENT-LEVEL START HANDLERS ---
+
+        function onElementPointerDown(ev) {
+            // Only care about primary mouse button or touch
+            if (ev.pointerType === 'mouse' && ev.button !== 0) return;
+
+            // Record start for this pointer
+            pointerMeta[ev.pointerId] = {
+                startX: ev.clientX,
+                startY: ev.clientY,
+                startTime: Date.now(),
+                prevented: false // whether we've prevented default (to block browser gestures)
+            };
+
+            // Install a pointermove handler on document so we can call preventDefault when necessary.
+            // Use passive: false so preventDefault works.
+            currentPointerMoveHandler = function (moveEv) {
+                try {
+                    // Only handle same pointerId
+                    var meta = pointerMeta[ev.pointerId];
+                    if (!meta) return;
+
+                    // If pointer is not touch, don't call preventDefault (mouse dragging should not be blocked)
+                    if (ev.pointerType !== 'touch') return;
+
+                    var dx = moveEv.clientX - meta.startX;
+                    var dy = moveEv.clientY - meta.startY;
+                    var absDx = Math.abs(dx), absDy = Math.abs(dy);
+
+                    // If multi-pointer active (additional pointers), abort preventing (preserve pinch)
+                    // We can detect additional pointers via navigator.maxTouchPoints? Not reliable; check pointer events currently active:
+                    // If any other pointer id exists in pointerMeta besides ev.pointerId, treat as multi-touch and skip.
+                    var multi = false;
+                    for (var pid in pointerMeta) {
+                        if (pid !== String(ev.pointerId)) { multi = true; break; }
+                    }
+                    if (multi) return;
+
+                    // If horizontal dominant and passes small movement threshold (not final swipe threshold)
+                    var earlyThreshold = 10; // small: start preventing only if user moves noticeably horizontally
+                    if (!meta.prevented && absDx > earlyThreshold && absDx > absDy) {
+                        // prevent browser horizontal gestures (history) for this pointer
+                        try {
+                            moveEv.preventDefault();
+                            meta.prevented = true;
+                            dlog("swipe: prevented default on pointermove (element)", elementKey);
+                        } catch (e) {
+                            // Some browsers ignore preventDefault if passive true on some targets.
+                        }
+                    } else if (meta.prevented) {
+                        // already prevented once, keep preventing
+                        try { moveEv.preventDefault(); } catch (e) { }
+                    }
+                } catch (e) { /* ignore */ }
+            };
+
+            // attach to document
+            document.addEventListener('pointermove', currentPointerMoveHandler, { passive: false, capture: true });
+
+            dlog("swipe: pointerdown registered", ev.pointerId, elementKey);
         }
 
-        function elementPointerUp(ev) {
-            // We purposely avoid processing up here, global handler will do it.
-        }
-
-        function elementPointerCancel(ev) {
+        function onElementPointerUp(ev) {
+            // compute and clean up
             try {
-                var pid = ev.pointerId;
-                if (window.openRoseActivePointers[pid]) {
-                    delete window.openRoseActivePointers[pid];
-                    log("swipe: elementPointerCancel cleaned", pid);
+                var meta = pointerMeta[ev.pointerId];
+                // remove move handler
+                if (currentPointerMoveHandler) {
+                    document.removeEventListener('pointermove', currentPointerMoveHandler, { capture: true });
+                    currentPointerMoveHandler = null;
                 }
+
+                if (!meta) return;
+
+                var dx = ev.clientX - meta.startX;
+                var dy = ev.clientY - meta.startY;
+                var dt = Date.now() - meta.startTime;
+
+                dlog("swipe: pointerup", ev.pointerId, "dx", dx, "dy", dy, "dt", dt, "meta.prevented", meta.prevented);
+
+                // cleanup meta
+                delete pointerMeta[ev.pointerId];
+
+                if (dt <= allowedTime && Math.abs(dx) >= threshold && Math.abs(dy) <= restraint) {
+                    if (dx < 0) {
+                        dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
+                        dlog("swipe: invoke left", elementKey);
+                    } else {
+                        dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
+                        dlog("swipe: invoke right", elementKey);
+                    }
+                }
+            } catch (e) { dlog("swipe: elementPointerUp error", e); }
+        }
+
+        function onElementPointerCancel(ev) {
+            try {
+                if (currentPointerMoveHandler) {
+                    document.removeEventListener('pointermove', currentPointerMoveHandler, { capture: true });
+                    currentPointerMoveHandler = null;
+                }
+                delete pointerMeta[ev.pointerId];
+                dlog("swipe: pointercancel cleaned", ev.pointerId);
             } catch (e) { /* ignore */ }
         }
 
-        // Touchstart on element -> store touch meta keyed by touch.identifier
-        function elementTouchStart(ev) {
+        // --- TOUCH fallback ---
+
+        function onElementTouchStart(ev) {
             try {
                 if (!ev || !ev.touches) return;
+                // If a multi-touch begins, ignore swipe tracking for those touches (preserve pinch)
                 if (ev.touches.length !== 1) {
-                    // multi-touch start: mark nothing for swipe
+                    // mark nothing
                     return;
                 }
                 var t = ev.touches[0];
-                window.openRoseActiveTouches[t.identifier] = {
-                    elementKey: elementKey,
+                touchMeta[t.identifier] = {
                     startX: t.clientX,
                     startY: t.clientY,
                     startTime: Date.now(),
-                    threshold: threshold,
-                    restraint: restraint,
-                    allowedTime: allowedTime,
-                    dotNetRef: dotNetRef
+                    prevented: false
                 };
-                log("swipe: elementTouchStart registered id", t.identifier, "element", elementKey);
-            } catch (e) { log("swipe: elementTouchStart error", e); }
+
+                // install touchmove on document (non-passive) to be able to prevent default if horizontal gesture detected
+                currentTouchMoveHandler = function (moveEv) {
+                    try {
+                        if (!moveEv || !moveEv.touches) return;
+                        // find the touch with same identifier if present in touches or changedTouches
+                        var found = null;
+                        for (var i = 0; i < moveEv.touches.length; i++) {
+                            if (touchMeta[moveEv.touches[i].identifier]) { found = moveEv.touches[i]; break; }
+                        }
+                        // If multiple touches present => abort preventing
+                        if (moveEv.touches.length > 1) return;
+
+                        // If found our tracked touch
+                        if (!found) {
+                            // maybe it's in changedTouches
+                            for (var j = 0; j < moveEv.changedTouches.length; j++) {
+                                if (touchMeta[moveEv.changedTouches[j].identifier]) { found = moveEv.changedTouches[j]; break; }
+                            }
+                        }
+                        if (!found) return;
+                        var meta = touchMeta[found.identifier];
+                        if (!meta) return;
+
+                        var dx = found.clientX - meta.startX;
+                        var dy = found.clientY - meta.startY;
+                        var absDx = Math.abs(dx), absDy = Math.abs(dy);
+
+                        var earlyThreshold = 10;
+                        if (!meta.prevented && absDx > earlyThreshold && absDx > absDy) {
+                            try {
+                                moveEv.preventDefault(); // stops browser back/forward swipe
+                                meta.prevented = true;
+                                dlog("swipe: prevented default on touchmove (element)", elementKey);
+                            } catch (e) {
+                                // ignore
+                            }
+                        } else if (meta.prevented) {
+                            try { moveEv.preventDefault(); } catch (e) { }
+                        }
+                    } catch (e) { /* ignore */ }
+                };
+
+                document.addEventListener('touchmove', currentTouchMoveHandler, { passive: false, capture: true });
+
+                dlog("swipe: touchstart registered id", t.identifier, elementKey);
+            } catch (e) { dlog("swipe: elementTouchStart error", e); }
         }
 
-        function elementTouchEnd(ev) {
-            // global handler will process
-        }
-
-        function elementTouchCancel(ev) {
+        function onElementTouchEnd(ev) {
             try {
+                // remove move handler
+                if (currentTouchMoveHandler) {
+                    document.removeEventListener('touchmove', currentTouchMoveHandler, { capture: true });
+                    currentTouchMoveHandler = null;
+                }
+
                 if (!ev.changedTouches) return;
                 for (var i = 0; i < ev.changedTouches.length; i++) {
-                    var t = ev.changedTouches[i];
-                    if (window.openRoseActiveTouches[t.identifier]) {
-                        delete window.openRoseActiveTouches[t.identifier];
+                    var ct = ev.changedTouches[i];
+                    var meta = touchMeta[ct.identifier];
+                    if (!meta) continue;
+
+                    var dx = ct.clientX - meta.startX;
+                    var dy = ct.clientY - meta.startY;
+                    var dt = Date.now() - meta.startTime;
+
+                    dlog("swipe: touchend id", ct.identifier, "dx", dx, "dy", dy, "dt", dt, "meta.prevented", meta.prevented);
+
+                    delete touchMeta[ct.identifier];
+
+                    if (dt <= allowedTime && Math.abs(dx) >= threshold && Math.abs(dy) <= restraint) {
+                        if (dx < 0) {
+                            dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
+                            dlog("swipe: invoke left (touch)", elementKey);
+                        } else {
+                            dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
+                            dlog("swipe: invoke right (touch)", elementKey);
+                        }
                     }
                 }
+            } catch (e) { dlog("swipe: elementTouchEnd error", e); }
+        }
+
+        function onElementTouchCancel(ev) {
+            try {
+                if (currentTouchMoveHandler) {
+                    document.removeEventListener('touchmove', currentTouchMoveHandler, { capture: true });
+                    currentTouchMoveHandler = null;
+                }
+                if (!ev.changedTouches) return;
+                for (var i = 0; i < ev.changedTouches.length; i++) {
+                    var ct = ev.changedTouches[i];
+                    delete touchMeta[ct.identifier];
+                }
+                dlog("swipe: touchcancel cleaned", elementKey);
             } catch (e) { /* ignore */ }
         }
 
-        // Attach element-level listeners (bubble phase)
-        var handlers = {};
+        // Attach element-level listeners (we want bubble phase so button clicks still get processed)
+        var rec = { el: el, dotNetRef: dotNetRef, handlers: {} };
 
         if (window.PointerEvent) {
-            handlers.pointerdown = elementPointerDown;
-            handlers.pointerup = elementPointerUp;
-            handlers.pointercancel = elementPointerCancel;
+            rec.handlers.pointerdown = onElementPointerDown;
+            rec.handlers.pointerup = onElementPointerUp;
+            rec.handlers.pointercancel = onElementPointerCancel;
 
-            el.addEventListener('pointerdown', handlers.pointerdown, { passive: true });
-            // pointerup on element not required; global will handle actual up event
-            el.addEventListener('pointercancel', handlers.pointercancel, { passive: true });
+            el.addEventListener('pointerdown', rec.handlers.pointerdown, { passive: true });
+            el.addEventListener('pointerup', rec.handlers.pointerup, { passive: true });
+            el.addEventListener('pointercancel', rec.handlers.pointercancel, { passive: true });
 
-            // store handler refs for removal later
-            window.openRoseHandlers[elementKey] = {
-                el: el,
-                mode: 'pointer',
-                handlers: handlers,
-                dotNetRef: dotNetRef
-            };
-
-            log("swipe: registered element-level pointer handlers for", elementKey);
+            rec.mode = 'pointer';
+            dlog("swipe: element pointer handlers attached", elementKey);
         } else {
-            // touch/mouse fallback
-            handlers.touchstart = elementTouchStart;
-            handlers.touchend = elementTouchEnd;
-            handlers.touchcancel = elementTouchCancel;
-            handlers.mousedown = elementPointerDown; // treat mouse down similarly
-            handlers.mouseup = elementPointerUp;
+            rec.handlers.touchstart = onElementTouchStart;
+            rec.handlers.touchend = onElementTouchEnd;
+            rec.handlers.touchcancel = onElementTouchCancel;
 
-            el.addEventListener('touchstart', handlers.touchstart, { passive: true });
-            el.addEventListener('touchcancel', handlers.touchcancel, { passive: true });
-            el.addEventListener('mousedown', handlers.mousedown, { passive: true });
+            el.addEventListener('touchstart', rec.handlers.touchstart, { passive: false }); // passive:false so we can preventDefault later
+            el.addEventListener('touchend', rec.handlers.touchend, { passive: true });
+            el.addEventListener('touchcancel', rec.handlers.touchcancel, { passive: true });
 
-            window.openRoseHandlers[elementKey] = {
-                el: el,
-                mode: 'touchmouse',
-                handlers: handlers,
-                dotNetRef: dotNetRef
-            };
-            log("swipe: registered element-level touch/mouse handlers for", elementKey);
+            // mouse fallback for desktop
+            rec.handlers.mousedown = function (ev) { onElementPointerDown({ pointerId: 'mouse', clientX: ev.clientX, clientY: ev.clientY, pointerType: 'mouse', button: ev.button }); };
+            rec.handlers.mouseup = function (ev) { onElementPointerUp({ pointerId: 'mouse', clientX: ev.clientX, clientY: ev.clientY }); };
+
+            el.addEventListener('mousedown', rec.handlers.mousedown, { passive: true });
+            el.addEventListener('mouseup', rec.handlers.mouseup, { passive: true });
+
+            rec.mode = 'touchmouse';
+            dlog("swipe: element touch handlers attached", elementKey);
         }
 
-        // ensure globals are installed (do once)
-        installGlobalHandlersIfNeeded();
+        window.openRoseHandlers[elementKey] = rec;
 
         return true;
     }
 
-    // Public API: register/unregister functions expected by Blazor
+    function unregisterElement(element) {
+        if (!element) return false;
+        var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : null;
+        if (!elementKey) return false;
+        var rec = window.openRoseHandlers[elementKey];
+        if (!rec) return false;
+        var el = rec.el;
+        var h = rec.handlers || {};
+        try {
+            if (rec.mode === 'pointer') {
+                el.removeEventListener('pointerdown', h.pointerdown);
+                el.removeEventListener('pointerup', h.pointerup);
+                el.removeEventListener('pointercancel', h.pointercancel);
+            } else {
+                el.removeEventListener('touchstart', h.touchstart);
+                el.removeEventListener('touchend', h.touchend);
+                el.removeEventListener('touchcancel', h.touchcancel);
+                el.removeEventListener('mousedown', h.mousedown);
+                el.removeEventListener('mouseup', h.mouseup);
+            }
+        } catch (e) { /* ignore */ }
+
+        // cleanup any active touch/pointer metas referencing this element
+        for (var pid in window.openRoseHandlers) {
+            // nothing per-pointer stored globally here except within element; we used closures, so nothing else to do
+        }
+        delete window.openRoseHandlers[elementKey];
+        try { delete element.dataset.openroseId; } catch (e) { /* ignore */ }
+        dlog("swipe: unregistered", elementKey);
+        return true;
+    }
+
+    // Exposed API for Blazor
     window.openRoseRegisterSwipeElement = function (element, dotNetRef, options) {
         try {
             if (!element) return false;
             var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : ("el-" + Math.random().toString(36).substr(2, 9));
             try { element.dataset.openroseId = elementKey; } catch (e) { /* ignore */ }
-            return registerOnElement(element, dotNetRef, elementKey, options || {});
-        } catch (err) {
-            log("swipe: openRoseRegisterSwipeElement error", err);
-            return false;
-        }
+            var ok = registerOnElement(element, dotNetRef, elementKey, options || {});
+            dlog("swipe: register result for", elementKey, ok);
+            return ok;
+        } catch (err) { dlog("swipe: register error", err); return false; }
     };
 
     window.openRoseUnregisterSwipeElement = function (element) {
         try {
-            if (!element) return false;
-            var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : null;
-            if (!elementKey) return false;
-            var rec = window.openRoseHandlers[elementKey];
-            if (!rec) return false;
-
-            var mode = rec.mode;
-            var h = rec.handlers || {};
-            try {
-                if (mode === 'pointer') {
-                    element.removeEventListener('pointerdown', h.pointerdown);
-                    element.removeEventListener('pointercancel', h.pointercancel);
-                } else {
-                    element.removeEventListener('touchstart', h.touchstart);
-                    element.removeEventListener('touchcancel', h.touchcancel);
-                    element.removeEventListener('mousedown', h.mousedown);
-                }
-            } catch (er) { /* ignore */ }
-
-            // cleanup any active pointers/touches associated with this element
-            for (var pid in window.openRoseActivePointers) {
-                if (window.openRoseActivePointers[pid] && window.openRoseActivePointers[pid].elementKey === elementKey) {
-                    delete window.openRoseActivePointers[pid];
-                }
-            }
-            for (var tid in window.openRoseActiveTouches) {
-                if (window.openRoseActiveTouches[tid] && window.openRoseActiveTouches[tid].elementKey === elementKey) {
-                    delete window.openRoseActiveTouches[tid];
-                }
-            }
-
-            delete window.openRoseHandlers[elementKey];
-            try { delete element.dataset.openroseId; } catch (e) { }
-            try { delete element.__swipeTouchMeta; } catch (e) { }
-            log("swipe: unregistered element", elementKey);
-            return true;
-        } catch (err) {
-            log("swipe: openRoseUnregisterSwipeElement error", err);
-            return false;
-        }
+            return unregisterElement(element);
+        } catch (err) { dlog("swipe: unregister error", err); return false; }
     };
+
 })();

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,32 +4,30 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
-// wwwroot/js/swipe.js
-// Hybrid element-level start + dynamic move-handler approach.
-// - Prevents browser history swipe for single-finger horizontal swipes by calling preventDefault on move,
-//   but only after detecting a single-finger horizontal gesture in progress.
-// - Preserves pinch/zoom (multi-touch) and normal clicks (no pointer capture).
+// Touch-only swipe detection (single-finger). Does NOT handle mouse/pointer events.
+// - Preserves mouse clicks completely (no mouse handlers attached).
+// - Preserves pinch/zoom (multi-touch ignored).
+// - Dynamically prevents browser history navigation for one-finger horizontal gestures.
 // - Moderate sensitivity: threshold=50px, restraint=120px, allowedTime=600ms.
-// - Set debug = true for console logs during testing.
+// - Set debug = true for logging during testing.
 
 (function () {
     if (window.openRoseSwipeLibLoaded) return;
     window.openRoseSwipeLibLoaded = true;
     window.openRoseHandlers = window.openRoseHandlers || {};
 
-    var debug = true; // set true while testing to get console logs
+    var debug = true; // set to true for device logs
 
     function dlog() {
         if (!debug) return;
-        console.log.apply(console, arguments);
+        try { console.log.apply(console, arguments); } catch (_) { }
     }
 
-    // Sensitivity defaults (tweak if needed)
     var DEFAULT_THRESHOLD = 50;   // px horizontal
     var DEFAULT_RESTRAINT = 120;  // px vertical
     var DEFAULT_ALLOWED_TIME = 600; // ms
+    var EARLY_MOVE_THRESHOLD = 10; // px; start preventing after small horizontal movement
 
-    // Helper: attach and remove with stored refs
     function registerOnElement(el, dotNetRef, elementKey, opts) {
         if (!el) return false;
 
@@ -37,312 +35,238 @@
         var restraint = (opts && opts.restraint) || DEFAULT_RESTRAINT;
         var allowedTime = (opts && opts.allowedTime) || DEFAULT_ALLOWED_TIME;
 
-        // Per-interaction state
-        // For pointer events: keep map from pointerId to meta { startX, startY, startTime, movedHorizontally }
-        var pointerMeta = {};
+        var activeTouch = null; // { id, startX, startY, startTime, prevented }
+        var docTouchMoveHandler = null;
+        var savedOverscroll = null;
+        var savedTouchAction = null;
 
-        // For touch fallback (touch identifiers)
-        // Map touchId -> meta
-        var touchMeta = {};
-
-        // Move handler refs so we can remove them
-        var currentPointerMoveHandler = null;
-        var currentTouchMoveHandler = null;
-
-        // --- ELEMENT-LEVEL START HANDLERS ---
-
-        function onElementPointerDown(ev) {
-            // Only care about primary mouse button or touch
-            if (ev.pointerType === 'mouse' && ev.button !== 0) return;
-
-            // Record start for this pointer
-            pointerMeta[ev.pointerId] = {
-                startX: ev.clientX,
-                startY: ev.clientY,
-                startTime: Date.now(),
-                prevented: false // whether we've prevented default (to block browser gestures)
-            };
-
-            // Install a pointermove handler on document so we can call preventDefault when necessary.
-            // Use passive: false so preventDefault works.
-            currentPointerMoveHandler = function (moveEv) {
-                try {
-                    // Only handle same pointerId
-                    var meta = pointerMeta[ev.pointerId];
-                    if (!meta) return;
-
-                    // If pointer is not touch, don't call preventDefault (mouse dragging should not be blocked)
-                    if (ev.pointerType !== 'touch') return;
-
-                    var dx = moveEv.clientX - meta.startX;
-                    var dy = moveEv.clientY - meta.startY;
-                    var absDx = Math.abs(dx), absDy = Math.abs(dy);
-
-                    // If multi-pointer active (additional pointers), abort preventing (preserve pinch)
-                    // We can detect additional pointers via navigator.maxTouchPoints? Not reliable; check pointer events currently active:
-                    // If any other pointer id exists in pointerMeta besides ev.pointerId, treat as multi-touch and skip.
-                    var multi = false;
-                    for (var pid in pointerMeta) {
-                        if (pid !== String(ev.pointerId)) { multi = true; break; }
-                    }
-                    if (multi) return;
-
-                    // If horizontal dominant and passes small movement threshold (not final swipe threshold)
-                    var earlyThreshold = 10; // small: start preventing only if user moves noticeably horizontally
-                    if (!meta.prevented && absDx > earlyThreshold && absDx > absDy) {
-                        // prevent browser horizontal gestures (history) for this pointer
-                        try {
-                            moveEv.preventDefault();
-                            meta.prevented = true;
-                            dlog("swipe: prevented default on pointermove (element)", elementKey);
-                        } catch (e) {
-                            // Some browsers ignore preventDefault if passive true on some targets.
-                        }
-                    } else if (meta.prevented) {
-                        // already prevented once, keep preventing
-                        try { moveEv.preventDefault(); } catch (e) { }
-                    }
-                } catch (e) { /* ignore */ }
-            };
-
-            // attach to document
-            document.addEventListener('pointermove', currentPointerMoveHandler, { passive: false, capture: true });
-
-            dlog("swipe: pointerdown registered", ev.pointerId, elementKey);
-        }
-
-        function onElementPointerUp(ev) {
-            // compute and clean up
+        function cleanupMoveHandler() {
+            if (docTouchMoveHandler) {
+                try { document.removeEventListener('touchmove', docTouchMoveHandler, { capture: true }); } catch (e) { /* ignore */ }
+                docTouchMoveHandler = null;
+            }
+            // restore overscroll behavior & touch-action
             try {
-                var meta = pointerMeta[ev.pointerId];
-                // remove move handler
-                if (currentPointerMoveHandler) {
-                    document.removeEventListener('pointermove', currentPointerMoveHandler, { capture: true });
-                    currentPointerMoveHandler = null;
+                if (savedOverscroll !== null) {
+                    document.documentElement.style.overscrollBehavior = savedOverscroll;
+                    savedOverscroll = null;
+                } else {
+                    // if there was no saved value, remove explicit style (let CSS decide)
+                    document.documentElement.style.overscrollBehavior = '';
                 }
+            } catch (e) { /* ignore */ }
 
-                if (!meta) return;
-
-                var dx = ev.clientX - meta.startX;
-                var dy = ev.clientY - meta.startY;
-                var dt = Date.now() - meta.startTime;
-
-                dlog("swipe: pointerup", ev.pointerId, "dx", dx, "dy", dy, "dt", dt, "meta.prevented", meta.prevented);
-
-                // cleanup meta
-                delete pointerMeta[ev.pointerId];
-
-                if (dt <= allowedTime && Math.abs(dx) >= threshold && Math.abs(dy) <= restraint) {
-                    if (dx < 0) {
-                        dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
-                        dlog("swipe: invoke left", elementKey);
-                    } else {
-                        dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
-                        dlog("swipe: invoke right", elementKey);
-                    }
-                }
-            } catch (e) { dlog("swipe: elementPointerUp error", e); }
-        }
-
-        function onElementPointerCancel(ev) {
             try {
-                if (currentPointerMoveHandler) {
-                    document.removeEventListener('pointermove', currentPointerMoveHandler, { capture: true });
-                    currentPointerMoveHandler = null;
+                if (savedTouchAction !== null) {
+                    el.style.touchAction = savedTouchAction;
+                    savedTouchAction = null;
+                } else {
+                    el.style.touchAction = '';
                 }
-                delete pointerMeta[ev.pointerId];
-                dlog("swipe: pointercancel cleaned", ev.pointerId);
             } catch (e) { /* ignore */ }
         }
 
-        // --- TOUCH fallback ---
-
-        function onElementTouchStart(ev) {
+        function onTouchStart(ev) {
             try {
                 if (!ev || !ev.touches) return;
-                // If a multi-touch begins, ignore swipe tracking for those touches (preserve pinch)
+                // Only one-finger gestures: if more than 1, ignore to preserve pinch
                 if (ev.touches.length !== 1) {
-                    // mark nothing
+                    activeTouch = null;
                     return;
                 }
+
                 var t = ev.touches[0];
-                touchMeta[t.identifier] = {
+                activeTouch = {
+                    id: t.identifier,
                     startX: t.clientX,
                     startY: t.clientY,
                     startTime: Date.now(),
                     prevented: false
                 };
 
-                // install touchmove on document (non-passive) to be able to prevent default if horizontal gesture detected
-                currentTouchMoveHandler = function (moveEv) {
+                dlog("swipe: touchstart registered id", activeTouch.id, "element", elementKey);
+
+                // Save current overscroll & touch-action and set temporary values that help block nav on Chromium
+                try {
+                    // Save and then set overscroll to 'none' to block "swipe to navigate" on Chromium browsers
+                    savedOverscroll = document.documentElement.style.overscrollBehavior || '';
+                    document.documentElement.style.overscrollBehavior = 'none';
+                } catch (e) { savedOverscroll = null; }
+
+                try {
+                    savedTouchAction = el.style.touchAction || '';
+                    // Hint: allow vertical panning but make horizontal available for JS handling
+                    el.style.touchAction = 'pan-y';
+                } catch (e) { savedTouchAction = null; }
+
+                // Install document-level touchmove with passive: false so we can preventDefault when we detect horizontal gesture
+                docTouchMoveHandler = function (moveEv) {
                     try {
-                        if (!moveEv || !moveEv.touches) return;
-                        // find the touch with same identifier if present in touches or changedTouches
+                        if (!activeTouch) return;
+
+                        // find the tracked touch in the current touches
                         var found = null;
                         for (var i = 0; i < moveEv.touches.length; i++) {
-                            if (touchMeta[moveEv.touches[i].identifier]) { found = moveEv.touches[i]; break; }
-                        }
-                        // If multiple touches present => abort preventing
-                        if (moveEv.touches.length > 1) return;
-
-                        // If found our tracked touch
-                        if (!found) {
-                            // maybe it's in changedTouches
-                            for (var j = 0; j < moveEv.changedTouches.length; j++) {
-                                if (touchMeta[moveEv.changedTouches[j].identifier]) { found = moveEv.changedTouches[j]; break; }
+                            if (moveEv.touches[i].identifier === activeTouch.id) {
+                                found = moveEv.touches[i];
+                                break;
                             }
                         }
                         if (!found) return;
-                        var meta = touchMeta[found.identifier];
-                        if (!meta) return;
 
-                        var dx = found.clientX - meta.startX;
-                        var dy = found.clientY - meta.startY;
+                        // If more than one touch currently active, abort preventing (user used another finger)
+                        if (moveEv.touches.length > 1) return;
+
+                        var dx = found.clientX - activeTouch.startX;
+                        var dy = found.clientY - activeTouch.startY;
                         var absDx = Math.abs(dx), absDy = Math.abs(dy);
 
-                        var earlyThreshold = 10;
-                        if (!meta.prevented && absDx > earlyThreshold && absDx > absDy) {
+                        // If horizontal movement is dominant and exceeds early threshold, prevent default to stop browser nav
+                        if (!activeTouch.prevented && absDx > EARLY_MOVE_THRESHOLD && absDx > absDy) {
                             try {
-                                moveEv.preventDefault(); // stops browser back/forward swipe
-                                meta.prevented = true;
+                                moveEv.preventDefault(); // this prevents browser swipe-to-navigate on many browsers
+                                activeTouch.prevented = true;
                                 dlog("swipe: prevented default on touchmove (element)", elementKey);
                             } catch (e) {
-                                // ignore
+                                // some browsers restrict preventDefault if listener is passive (we used non-passive) or other constraints
                             }
-                        } else if (meta.prevented) {
-                            try { moveEv.preventDefault(); } catch (e) { }
+                        } else if (activeTouch.prevented) {
+                            // keep preventing if we've started preventing
+                            try { moveEv.preventDefault(); } catch (e) { /* ignore */ }
                         }
                     } catch (e) { /* ignore */ }
                 };
 
-                document.addEventListener('touchmove', currentTouchMoveHandler, { passive: false, capture: true });
+                document.addEventListener('touchmove', docTouchMoveHandler, { passive: false, capture: true });
 
-                dlog("swipe: touchstart registered id", t.identifier, elementKey);
-            } catch (e) { dlog("swipe: elementTouchStart error", e); }
+            } catch (err) {
+                dlog("swipe: onTouchStart error", err);
+            }
         }
 
-        function onElementTouchEnd(ev) {
+        function onTouchEnd(ev) {
             try {
-                // remove move handler
-                if (currentTouchMoveHandler) {
-                    document.removeEventListener('touchmove', currentTouchMoveHandler, { capture: true });
-                    currentTouchMoveHandler = null;
+                if (!activeTouch) {
+                    cleanupMoveHandler();
+                    return;
                 }
 
-                if (!ev.changedTouches) return;
+                // find changedTouches that match the tracked touch id
+                if (!ev.changedTouches) {
+                    cleanupMoveHandler();
+                    activeTouch = null;
+                    return;
+                }
+
+                var matched = null;
                 for (var i = 0; i < ev.changedTouches.length; i++) {
-                    var ct = ev.changedTouches[i];
-                    var meta = touchMeta[ct.identifier];
-                    if (!meta) continue;
-
-                    var dx = ct.clientX - meta.startX;
-                    var dy = ct.clientY - meta.startY;
-                    var dt = Date.now() - meta.startTime;
-
-                    dlog("swipe: touchend id", ct.identifier, "dx", dx, "dy", dy, "dt", dt, "meta.prevented", meta.prevented);
-
-                    delete touchMeta[ct.identifier];
-
-                    if (dt <= allowedTime && Math.abs(dx) >= threshold && Math.abs(dy) <= restraint) {
-                        if (dx < 0) {
-                            dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
-                            dlog("swipe: invoke left (touch)", elementKey);
-                        } else {
-                            dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
-                            dlog("swipe: invoke right (touch)", elementKey);
-                        }
+                    if (ev.changedTouches[i].identifier === activeTouch.id) {
+                        matched = ev.changedTouches[i];
+                        break;
                     }
                 }
-            } catch (e) { dlog("swipe: elementTouchEnd error", e); }
+
+                if (!matched) {
+                    // Might have ended elsewhere; just cleanup
+                    cleanupMoveHandler();
+                    activeTouch = null;
+                    return;
+                }
+
+                var dx = matched.clientX - activeTouch.startX;
+                var dy = matched.clientY - activeTouch.startY;
+                var dt = Date.now() - activeTouch.startTime;
+
+                dlog("swipe: touchend id", activeTouch.id, "dx", dx, "dy", dy, "dt", dt, "prevented", activeTouch.prevented);
+
+                // cleanup move handler and styles
+                cleanupMoveHandler();
+
+                // evaluate threshold
+                if (dt <= allowedTime && Math.abs(dx) >= threshold && Math.abs(dy) <= restraint) {
+                    if (dx < 0) {
+                        dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /*ignore*/ });
+                        dlog("swipe: invoked left for", elementKey);
+                    } else {
+                        dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /*ignore*/ });
+                        dlog("swipe: invoked right for", elementKey);
+                    }
+                }
+
+                activeTouch = null;
+            } catch (err) {
+                dlog("swipe: onTouchEnd error", err);
+                cleanupMoveHandler();
+                activeTouch = null;
+            }
         }
 
-        function onElementTouchCancel(ev) {
+        function onTouchCancel(ev) {
             try {
-                if (currentTouchMoveHandler) {
-                    document.removeEventListener('touchmove', currentTouchMoveHandler, { capture: true });
-                    currentTouchMoveHandler = null;
-                }
-                if (!ev.changedTouches) return;
-                for (var i = 0; i < ev.changedTouches.length; i++) {
-                    var ct = ev.changedTouches[i];
-                    delete touchMeta[ct.identifier];
-                }
-                dlog("swipe: touchcancel cleaned", elementKey);
+                cleanupMoveHandler();
+                activeTouch = null;
+                dlog("swipe: touchcancel for", elementKey);
             } catch (e) { /* ignore */ }
         }
 
-        // Attach element-level listeners (we want bubble phase so button clicks still get processed)
-        var rec = { el: el, dotNetRef: dotNetRef, handlers: {} };
+        // Attach element-level touch listeners. We don't add pointer or mouse listeners at all.
+        var handlers = {
+            touchstart: onTouchStart,
+            touchend: onTouchEnd,
+            touchcancel: onTouchCancel
+        };
 
-        if (window.PointerEvent) {
-            rec.handlers.pointerdown = onElementPointerDown;
-            rec.handlers.pointerup = onElementPointerUp;
-            rec.handlers.pointercancel = onElementPointerCancel;
-
-            el.addEventListener('pointerdown', rec.handlers.pointerdown, { passive: true });
-            el.addEventListener('pointerup', rec.handlers.pointerup, { passive: true });
-            el.addEventListener('pointercancel', rec.handlers.pointercancel, { passive: true });
-
-            rec.mode = 'pointer';
-            dlog("swipe: element pointer handlers attached", elementKey);
-        } else {
-            rec.handlers.touchstart = onElementTouchStart;
-            rec.handlers.touchend = onElementTouchEnd;
-            rec.handlers.touchcancel = onElementTouchCancel;
-
-            el.addEventListener('touchstart', rec.handlers.touchstart, { passive: false }); // passive:false so we can preventDefault later
-            el.addEventListener('touchend', rec.handlers.touchend, { passive: true });
-            el.addEventListener('touchcancel', rec.handlers.touchcancel, { passive: true });
-
-            // mouse fallback for desktop
-            rec.handlers.mousedown = function (ev) { onElementPointerDown({ pointerId: 'mouse', clientX: ev.clientX, clientY: ev.clientY, pointerType: 'mouse', button: ev.button }); };
-            rec.handlers.mouseup = function (ev) { onElementPointerUp({ pointerId: 'mouse', clientX: ev.clientX, clientY: ev.clientY }); };
-
-            el.addEventListener('mousedown', rec.handlers.mousedown, { passive: true });
-            el.addEventListener('mouseup', rec.handlers.mouseup, { passive: true });
-
-            rec.mode = 'touchmouse';
-            dlog("swipe: element touch handlers attached", elementKey);
+        try {
+            // attach touchstart non-passive? touchstart cannot be passive (spec default is non-passive). But to be safe we attach with passive:false so that preventDefault in move works reliably later.
+            el.addEventListener('touchstart', handlers.touchstart, { passive: false });
+            el.addEventListener('touchend', handlers.touchend, { passive: true });
+            el.addEventListener('touchcancel', handlers.touchcancel, { passive: true });
+            dlog("swipe: attached touch handlers for element", elementKey);
+        } catch (e) {
+            // older browsers fallback
+            el.addEventListener('touchstart', handlers.touchstart);
+            el.addEventListener('touchend', handlers.touchend);
+            el.addEventListener('touchcancel', handlers.touchcancel);
         }
 
-        window.openRoseHandlers[elementKey] = rec;
+        // Store registered handlers so we can unregister later
+        window.openRoseHandlers[elementKey] = {
+            el: el,
+            handlers: handlers,
+            dotNetRef: dotNetRef
+        };
 
+        dlog("swipe: registered touch-only element", elementKey);
         return true;
     }
 
     function unregisterElement(element) {
-        if (!element) return false;
-        var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : null;
-        if (!elementKey) return false;
-        var rec = window.openRoseHandlers[elementKey];
-        if (!rec) return false;
-        var el = rec.el;
-        var h = rec.handlers || {};
         try {
-            if (rec.mode === 'pointer') {
-                el.removeEventListener('pointerdown', h.pointerdown);
-                el.removeEventListener('pointerup', h.pointerup);
-                el.removeEventListener('pointercancel', h.pointercancel);
-            } else {
-                el.removeEventListener('touchstart', h.touchstart);
-                el.removeEventListener('touchend', h.touchend);
-                el.removeEventListener('touchcancel', h.touchcancel);
-                el.removeEventListener('mousedown', h.mousedown);
-                el.removeEventListener('mouseup', h.mouseup);
+            if (!element) return false;
+            var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : null;
+            if (!elementKey) return false;
+            var rec = window.openRoseHandlers[elementKey];
+            if (!rec) return false;
+            var el = rec.el;
+            var h = rec.handlers || {};
+            try {
+                el.removeEventListener('touchstart', h.touchstart, { passive: false });
+                el.removeEventListener('touchend', h.touchend, { passive: true });
+                el.removeEventListener('touchcancel', h.touchcancel, { passive: true });
+            } catch (e) {
+                try { el.removeEventListener('touchstart', h.touchstart); el.removeEventListener('touchend', h.touchend); el.removeEventListener('touchcancel', h.touchcancel); } catch (_) { }
             }
-        } catch (e) { /* ignore */ }
-
-        // cleanup any active touch/pointer metas referencing this element
-        for (var pid in window.openRoseHandlers) {
-            // nothing per-pointer stored globally here except within element; we used closures, so nothing else to do
+            delete window.openRoseHandlers[elementKey];
+            try { delete element.dataset.openroseId; } catch (_) { }
+            dlog("swipe: unregistered element", elementKey);
+            return true;
+        } catch (err) {
+            dlog("swipe: unregister error", err);
+            return false;
         }
-        delete window.openRoseHandlers[elementKey];
-        try { delete element.dataset.openroseId; } catch (e) { /* ignore */ }
-        dlog("swipe: unregistered", elementKey);
-        return true;
     }
 
-    // Exposed API for Blazor
+    // Exposed API used by Blazor
     window.openRoseRegisterSwipeElement = function (element, dotNetRef, options) {
         try {
             if (!element) return false;
@@ -351,13 +275,18 @@
             var ok = registerOnElement(element, dotNetRef, elementKey, options || {});
             dlog("swipe: register result for", elementKey, ok);
             return ok;
-        } catch (err) { dlog("swipe: register error", err); return false; }
+        } catch (err) {
+            dlog("swipe: register error", err);
+            return false;
+        }
     };
 
     window.openRoseUnregisterSwipeElement = function (element) {
         try {
             return unregisterElement(element);
-        } catch (err) { dlog("swipe: unregister error", err); return false; }
+        } catch (err) {
+            dlog("swipe: unregister error", err);
+            return false;
+        }
     };
-
 })();

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,43 +4,64 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
-// Touch-only swipe detection (single-finger).
-// - DOES NOT change touch-action or overscroll styles.
-// - Dynamically installs non-passive touchmove listener and only calls preventDefault
-//   when single-finger horizontal gesture is clearly detected.
-// - Cancels custom handling immediately when a second touch appears.
-// - Moderate sensitivity: threshold=50px swipe, earlyPrevent=30px to start preventing.
-// - Set debug = true for diagnostic logs.
+
+/*
+ * Touch-only swipe detection for OpenRose read-only views.
+ *
+ * Purpose:
+ *  - Detect single-finger left/right swipe gestures on touch devices
+ *    and call the Blazor callback dotNetRef.OnSwipe('left'|'right').
+ *  - Preserve multi-finger gestures (pinch/zoom) and normal mouse clicks.
+ *  - Avoid global style changes; only temporarily install a non-passive
+ *    touchmove handler during an active single-finger gesture and call
+ *    preventDefault only once horizontal motion is clearly detected.
+ *
+ * Usage:
+ *  - Blazor components call `openRoseRegisterSwipeElement(element, dotNetRef)`
+ *    passing the ElementReference and a DotNetObjectReference for callbacks.
+ *  - Unregister with `openRoseUnregisterSwipeElement(element)` on dispose.
+ *
+ * Notes / tradeoffs:
+ *  - Edge swipes initiated at the very device edge may still be handled by the OS/browser.
+ *  - If a single-finger gesture begins and we already prevented default, then adding a second finger
+ *    mid-gesture may not immediately recover browser pinch support until fingers are lifted and a new gesture starts.
+ *  - Keep debug=false in production.
+ */
 
 (function () {
     if (window.openRoseSwipeLibLoaded) return;
     window.openRoseSwipeLibLoaded = true;
     window.openRoseHandlers = window.openRoseHandlers || {};
 
-    var debug = true; // set to true to enable console logs on device during testing
+    // Toggle for development diagnostics; set to `true` to capture remote device console logs.
+    var debug = false;
 
     function dlog() {
         if (!debug) return;
         try { console.log.apply(console, arguments); } catch (_) { }
     }
 
-    var DEFAULT_THRESHOLD = 50;    // px horizontal movement required to count as a swipe on end
-    var DEFAULT_RESTRAINT = 120;   // px max vertical movement allowed for a swipe
-    var DEFAULT_ALLOWED_TIME = 600; // ms allowed duration for the swipe
-    var EARLY_PREVENT_THRESHOLD = 30; // px horizontal movement before we call preventDefault on touchmove
+    // Tuning parameters (moderate defaults)
+    var DEFAULT_THRESHOLD = 50;    // px horizontal movement required on touchend to count as swipe
+    var DEFAULT_RESTRAINT = 120;   // px max vertical movement allowed
+    var DEFAULT_ALLOWED_TIME = 600; // ms allowed for the swipe duration
+    var EARLY_PREVENT_THRESHOLD = 30; // px horizontal movement on touchmove before we call preventDefault
 
+    // Register a DOM element for touch swipe detection
     function registerOnElement(el, dotNetRef, elementKey, opts) {
         if (!el) return false;
 
+        // Merge per-element options or fall back to defaults
         var threshold = (opts && opts.threshold) || DEFAULT_THRESHOLD;
         var restraint = (opts && opts.restraint) || DEFAULT_RESTRAINT;
         var allowedTime = (opts && opts.allowedTime) || DEFAULT_ALLOWED_TIME;
         var earlyPrevent = (opts && opts.earlyPrevent) || EARLY_PREVENT_THRESHOLD;
 
-        // Track a single active touch for this element
+        // State for the active single-touch being tracked (if any)
         var active = null; // { id, startX, startY, startTime, prevented }
-        var docMoveHandler = null;
+        var docMoveHandler = null; // reference to the installed document touchmove handler
 
+        // Cleanup helper removes the document move handler and resets state
         function cleanup() {
             if (docMoveHandler) {
                 try { document.removeEventListener('touchmove', docMoveHandler, { capture: true }); } catch (e) { /* ignore */ }
@@ -49,14 +70,12 @@
             active = null;
         }
 
+        // Element-level touchstart: start tracking only for single-finger touches
         function onTouchStart(ev) {
             try {
                 if (!ev || !ev.touches) return;
-                // Start tracking only if exactly one touch is present
-                if (ev.touches.length !== 1) {
-                    active = null;
-                    return;
-                }
+                if (ev.touches.length !== 1) { active = null; return; } // multi-touch → ignore
+
                 var t = ev.touches[0];
                 active = {
                     id: t.identifier,
@@ -68,19 +87,21 @@
 
                 dlog("swipe: touchstart id", active.id, "element", elementKey);
 
-                // Install non-passive document touchmove so we can call preventDefault when needed
+                // Install a non-passive document touchmove so we can call preventDefault when the gesture is clearly horizontal.
+                // This prevents browser history navigation for single-finger swipes in many browsers;
+                // we call preventDefault only after earlyPrevent threshold and only when horizontal motion dominates.
                 docMoveHandler = function (moveEv) {
                     try {
                         if (!active) return;
 
-                        // If multi-touch starts, cancel our swipe tracking and allow browser to handle it
+                        // If multi-touch appears while moving, cancel our handling immediately and let browser take over (pinch preserved).
                         if (moveEv.touches && moveEv.touches.length > 1) {
                             dlog("swipe: multi-touch detected -> cancel custom handling", elementKey);
                             cleanup();
                             return;
                         }
 
-                        // find tracked touch
+                        // Find the tracked touch in the current touches
                         var found = null;
                         for (var i = 0; i < moveEv.touches.length; i++) {
                             if (moveEv.touches[i].identifier === active.id) { found = moveEv.touches[i]; break; }
@@ -91,21 +112,19 @@
                         var dy = found.clientY - active.startY;
                         var absDx = Math.abs(dx), absDy = Math.abs(dy);
 
-                        // Only prevent default when movement is clearly horizontal and exceeds earlyPrevent
+                        // Call preventDefault only when horizontal motion is clearly dominant and exceeds earlyPrevent.
                         if (!active.prevented && absDx > earlyPrevent && absDx > absDy) {
                             try {
-                                moveEv.preventDefault(); // prevents browser history navigation in many browsers
+                                moveEv.preventDefault();
                                 active.prevented = true;
                                 dlog("swipe: prevented default on touchmove (element)", elementKey);
-                            } catch (e) {
-                                // ignore errors from preventDefault if any
-                            }
+                            } catch (e) { /* ignore */ }
                         } else if (active.prevented) {
-                            // Continue to prevent if we've already started preventing
+                            // Keep preventing once we've started preventing
                             try { moveEv.preventDefault(); } catch (e) { /* ignore */ }
                         }
                     } catch (e) {
-                        // ignore
+                        // swallow to avoid breaking the page
                     }
                 };
 
@@ -116,28 +135,17 @@
             }
         }
 
+        // Element-level touchend: compute deltas and fire swipe if thresholds pass
         function onTouchEnd(ev) {
             try {
-                if (!active) {
-                    cleanup();
-                    return;
-                }
-
-                if (!ev.changedTouches) {
-                    cleanup();
-                    return;
-                }
+                if (!active) { cleanup(); return; }
+                if (!ev.changedTouches) { cleanup(); return; }
 
                 var matched = null;
                 for (var i = 0; i < ev.changedTouches.length; i++) {
                     if (ev.changedTouches[i].identifier === active.id) { matched = ev.changedTouches[i]; break; }
                 }
-
-                if (!matched) {
-                    // Not the tracked touch; just cleanup
-                    cleanup();
-                    return;
-                }
+                if (!matched) { cleanup(); return; }
 
                 var dx = matched.clientX - active.startX;
                 var dy = matched.clientY - active.startY;
@@ -162,6 +170,7 @@
             }
         }
 
+        // Element-level touchcancel: abort tracking
         function onTouchCancel(ev) {
             try {
                 dlog("swipe: touchcancel", elementKey);
@@ -169,23 +178,34 @@
             } catch (e) { /* ignore */ }
         }
 
-        // Attach touch handlers to the element (no mouse/pointer handlers)
+        // Attach element-level touch listeners.
+        // We do not attach pointer/mouse handlers here — mouse behavior remains unchanged.
         try {
             el.addEventListener('touchstart', onTouchStart, { passive: false });
             el.addEventListener('touchend', onTouchEnd, { passive: true });
             el.addEventListener('touchcancel', onTouchCancel, { passive: true });
             dlog("swipe: attached touch handlers for element", elementKey);
         } catch (e) {
-            // older browsers fallback
+            // Fallback for older browsers
             el.addEventListener('touchstart', onTouchStart);
             el.addEventListener('touchend', onTouchEnd);
             el.addEventListener('touchcancel', onTouchCancel);
         }
 
-        window.openRoseHandlers[elementKey] = { el: el, handlers: { onTouchStart: onTouchStart, onTouchEnd: onTouchEnd, onTouchCancel: onTouchCancel }, dotNetRef: dotNetRef };
+        // Store handler references to support unregister
+        window.openRoseHandlers[elementKey] = {
+            el: el,
+            handlers: {
+                onTouchStart: onTouchStart,
+                onTouchEnd: onTouchEnd,
+                onTouchCancel: onTouchCancel
+            },
+            dotNetRef: dotNetRef
+        };
         return true;
     }
 
+    // Remove attached listeners and cleanup references
     function unregisterElement(element) {
         try {
             if (!element) return false;
@@ -193,13 +213,13 @@
             if (!elementKey) return false;
             var rec = window.openRoseHandlers[elementKey];
             if (!rec) return false;
-            var el = rec.el;
-            var h = rec.handlers || {};
+            var el = rec.el, h = rec.handlers || {};
             try {
                 el.removeEventListener('touchstart', h.onTouchStart, { passive: false });
                 el.removeEventListener('touchend', h.onTouchEnd, { passive: true });
                 el.removeEventListener('touchcancel', h.onTouchCancel, { passive: true });
             } catch (e) {
+                // Greaceful fallback removal for browsers that don't honor options on removeEventListener
                 try { el.removeEventListener('touchstart', h.onTouchStart); el.removeEventListener('touchend', h.onTouchEnd); el.removeEventListener('touchcancel', h.onTouchCancel); } catch (_) { }
             }
             delete window.openRoseHandlers[elementKey];
@@ -212,6 +232,7 @@
         }
     }
 
+    // Blazor-callable registration/unregistration
     window.openRoseRegisterSwipeElement = function (element, dotNetRef, options) {
         try {
             if (!element) return false;

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,9 +4,7 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
-// Production-ready, robust touch/pointer swipe detection (document-level, capture-phase).
-
-
+// Production-ready: one-finger swipe detection (medium sensitivity), preserves pinch/zoom and scrolling.
 (function () {
     if (window.openRoseSwipeLibLoaded) {
         return;
@@ -17,27 +15,92 @@
     function registerOnElement(el, dotNetRef, elementKey) {
         if (!el) return false;
 
-        // Hint browser how to treat touch gestures:
-        // pan-y allows vertical scrolling while enabling horizontal gestures to be used by JS.
-        try { el.style.touchAction = 'pan-y'; } catch (e) { }
+        // Medium sensitivity parameters
+        var threshold = 80;     // min horizontal movement (px) to count as swipe
+        var restraint = 150;    // max vertical movement allowed (px)
+        var allowedTime = 700;  // max ms for the swipe gesture
 
-        var startX = 0, startY = 0, startTime = 0;
-        var threshold = 50; // pixels min for swipe
-        var restraint = 120; // max y delta
-        var allowedTime = 600; // ms
+        // For pointer events tracking
+        var activePointers = {}; // map pointerId => {startX,startY,startTime}
+        var trackedPointerId = null; // pointer we are tracking for this element
 
-        function onStart(e) {
-            var p = (e.touches && e.touches[0]) || e;
-            startX = p.clientX;
-            startY = p.clientY;
-            startTime = Date.now();
+        function onPointerDown(ev) {
+            // Only track single-finger touch (pointerType === 'touch') or mouse left button.
+            // If multiple pointers exist, we ignore to preserve multi-finger gestures (pinch).
+            if (ev.pointerType === 'touch') {
+                // If there are any active pointers already, don't start a new one (multi-touch)
+                if (Object.keys(activePointers).length > 0) {
+                    activePointers[ev.pointerId] = null; // mark but don't track
+                    return;
+                }
+            }
+
+            // record start values
+            activePointers[ev.pointerId] = {
+                startX: ev.clientX,
+                startY: ev.clientY,
+                startTime: Date.now()
+            };
+
+            // If this is the first/only pointer, mark it tracked
+            if (trackedPointerId === null) trackedPointerId = ev.pointerId;
         }
 
-        function onEnd(e) {
-            var p = (e.changedTouches && e.changedTouches[0]) || e;
-            var distX = p.clientX - startX;
-            var distY = p.clientY - startY;
-            var elapsed = Date.now() - startTime;
+        function onPointerUp(ev) {
+            var meta = activePointers[ev.pointerId];
+            // Clean up the activePointers entry (we'll compute before deleting)
+            delete activePointers[ev.pointerId];
+
+            // Only react if this pointer was the tracked one and we had no other pointers when it started
+            if (trackedPointerId !== ev.pointerId) {
+                // if the pointer we tracked isn't this one, ignore
+                if (Object.keys(activePointers).length === 0) trackedPointerId = null;
+                return;
+            }
+
+            trackedPointerId = null; // reset tracked pointer
+
+            if (!meta) return; // not a tracked single-finger start
+
+            var distX = ev.clientX - meta.startX;
+            var distY = ev.clientY - meta.startY;
+            var elapsed = Date.now() - meta.startTime;
+
+            if (elapsed <= allowedTime && Math.abs(distX) >= threshold && Math.abs(distY) <= restraint) {
+                if (distX < 0) {
+                    // left swipe => Next (book style)
+                    dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
+                } else {
+                    // right swipe => Previous
+                    dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
+                }
+            }
+        }
+
+        // Touch fallback for browsers not using PointerEvent
+        // We will ignore multi-touch (touches.length !== 1) to preserve pinch gestures
+        function onTouchStart(ev) {
+            if (!el.contains(ev.target)) return;
+            if (ev.touches.length !== 1) {
+                // multi-touch start -> ignore for swipe detection
+                el.__swipeTouchMeta = null;
+                return;
+            }
+            var t = ev.touches[0];
+            el.__swipeTouchMeta = { startX: t.clientX, startY: t.clientY, startTime: Date.now() };
+        }
+
+        function onTouchEnd(ev) {
+            if (!el.__swipeTouchMeta) return;
+            var t = (ev.changedTouches && ev.changedTouches[0]) || null;
+            if (!t) { el.__swipeTouchMeta = null; return; }
+
+            var meta = el.__swipeTouchMeta;
+            el.__swipeTouchMeta = null;
+
+            var distX = t.clientX - meta.startX;
+            var distY = t.clientY - meta.startY;
+            var elapsed = Date.now() - meta.startTime;
 
             if (elapsed <= allowedTime && Math.abs(distX) >= threshold && Math.abs(distY) <= restraint) {
                 if (distX < 0) {
@@ -48,55 +111,64 @@
             }
         }
 
-        // Document-level capture handlers that filter by el.contains(target)
-        function makeDocPointerDown() {
-            return function (ev) {
-                // only start if gesture begins inside element
-                try {
-                    if (el.contains(ev.target)) onStart(ev);
-                } catch (e) { /* ignore */ }
-            };
+        // Document-level handlers in capture phase, but we still ensure gesture starts inside element.
+        // We use capture so parent/child elements that call stopPropagation in bubble phase won't block us.
+        function docPointerDown(ev) {
+            try {
+                if (!el.contains(ev.target)) return;
+                onPointerDown(ev);
+            } catch (e) { /* ignore */ }
         }
-        function makeDocPointerUp() {
-            return function (ev) {
-                try {
-                    if (el.contains(ev.target)) onEnd(ev);
-                } catch (e) { /* ignore */ }
-            };
+        function docPointerUp(ev) {
+            try {
+                if (!el.contains(ev.target)) return;
+                onPointerUp(ev);
+            } catch (e) { /* ignore */ }
+        }
+        function docTouchStart(ev) {
+            try {
+                // Only care if touchstart happened inside element
+                if (!el.contains(ev.target)) return;
+                onTouchStart(ev);
+            } catch (e) { /* ignore */ }
+        }
+        function docTouchEnd(ev) {
+            try {
+                // touchend target may be different; use the stored meta only
+                onTouchEnd(ev);
+            } catch (e) { /* ignore */ }
         }
 
-        var handlers = {
-            pointerDown: makeDocPointerDown(),
-            pointerUp: makeDocPointerUp(),
-            touchStart: makeDocPointerDown(),
-            touchEnd: makeDocPointerUp(),
-            mouseDown: makeDocPointerDown(),
-            mouseUp: makeDocPointerUp()
-        };
-
-        var uses = [];
-
-        // Prefer pointer events where available
+        // Attach handlers
         if (window.PointerEvent) {
-            document.addEventListener('pointerdown', handlers.pointerDown, { passive: true, capture: true });
-            document.addEventListener('pointerup', handlers.pointerUp, { passive: true, capture: true });
-            uses.push('pointer');
+            document.addEventListener('pointerdown', docPointerDown, { passive: true, capture: true });
+            document.addEventListener('pointerup', docPointerUp, { passive: true, capture: true });
+            // Store record
+            window.openRoseHandlers[elementKey] = {
+                el: el,
+                mode: 'pointer',
+                handlers: { docPointerDown: docPointerDown, docPointerUp: docPointerUp },
+                dotNetRef: dotNetRef
+            };
         } else {
-            // touch
-            document.addEventListener('touchstart', handlers.touchStart, { passive: true, capture: true });
-            document.addEventListener('touchend', handlers.touchEnd, { passive: true, capture: true });
-            // mouse as fallback
-            document.addEventListener('mousedown', handlers.mouseDown, { passive: true, capture: true });
-            document.addEventListener('mouseup', handlers.mouseUp, { passive: true, capture: true });
-            uses.push('touch', 'mouse');
-        }
+            // touch + mouse fallback
+            document.addEventListener('touchstart', docTouchStart, { passive: true, capture: true });
+            document.addEventListener('touchend', docTouchEnd, { passive: true, capture: true });
+            document.addEventListener('mousedown', docPointerDown, { passive: true, capture: true });
+            document.addEventListener('mouseup', docPointerUp, { passive: true, capture: true });
 
-        window.openRoseHandlers[elementKey] = {
-            el: el,
-            handlers: handlers,
-            uses: uses,
-            dotNetRef: dotNetRef
-        };
+            window.openRoseHandlers[elementKey] = {
+                el: el,
+                mode: 'touchmouse',
+                handlers: {
+                    docTouchStart: docTouchStart,
+                    docTouchEnd: docTouchEnd,
+                    docPointerDown: docPointerDown,
+                    docPointerUp: docPointerUp
+                },
+                dotNetRef: dotNetRef
+            };
+        }
 
         return true;
     }
@@ -120,23 +192,23 @@
             var rec = window.openRoseHandlers[elementKey];
             if (!rec) return false;
 
-            var handlers = rec.handlers || {};
-            var uses = rec.uses || [];
-
+            var mode = rec.mode;
+            var h = rec.handlers || {};
             try {
-                if (uses.indexOf('pointer') >= 0) {
-                    document.removeEventListener('pointerdown', handlers.pointerDown, { capture: true });
-                    document.removeEventListener('pointerup', handlers.pointerUp, { capture: true });
+                if (mode === 'pointer') {
+                    document.removeEventListener('pointerdown', h.docPointerDown, { capture: true });
+                    document.removeEventListener('pointerup', h.docPointerUp, { capture: true });
                 } else {
-                    document.removeEventListener('touchstart', handlers.touchStart, { capture: true });
-                    document.removeEventListener('touchend', handlers.touchEnd, { capture: true });
-                    document.removeEventListener('mousedown', handlers.mouseDown, { capture: true });
-                    document.removeEventListener('mouseup', handlers.mouseUp, { capture: true });
+                    document.removeEventListener('touchstart', h.docTouchStart, { capture: true });
+                    document.removeEventListener('touchend', h.docTouchEnd, { capture: true });
+                    document.removeEventListener('mousedown', h.docPointerDown, { capture: true });
+                    document.removeEventListener('mouseup', h.docPointerUp, { capture: true });
                 }
             } catch (er) { /* ignore */ }
 
             delete window.openRoseHandlers[elementKey];
             try { delete element.dataset.openroseId; } catch (e) { }
+            try { delete element.__swipeTouchMeta; } catch (e) { }
             return true;
         } catch (err) {
             return false;

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,202 +4,314 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
-// wwwroot/js/swipe.js
-// Production: one-finger swipe detection, preserves pinch/zoom and scrolling.
-// Document-level capture listeners, start-inside-element + end-anywhere, pointer+touch fallback.
+// Hybrid approach: element-level start + global end handlers.
+// - Preserves button clicks (no pointer capture).
+// - Detects single-finger swipes reliably on mobile.
+// - Preserves multi-touch pinch/zoom (we ignore multi-touch).
+// - Default sensitivity: threshold=50px, restraint=120px, allowedTime=600ms.
+// Set debug = true to enable console logging for troubleshooting.
+
 (function () {
     if (window.openRoseSwipeLibLoaded) {
         return;
     }
     window.openRoseSwipeLibLoaded = true;
     window.openRoseHandlers = window.openRoseHandlers || {};
+    window.openRoseActivePointers = window.openRoseActivePointers || {}; // pointerId -> { elementKey, meta }
+    window.openRoseActiveTouches = window.openRoseActiveTouches || {};   // touchId -> { elementKey, meta }
+    window.openRoseGlobalHandlersInstalled = window.openRoseGlobalHandlersInstalled || false;
 
-    function registerOnElement(el, dotNetRef, elementKey) {
+    var debug = false; // set to true when testing to get console logs
+
+    function log() {
+        if (!debug) return;
+        console.log.apply(console, arguments);
+    }
+
+    // Sensitivity default (moderate)
+    var defaultThreshold = 50;    // px horizontal
+    var defaultRestraint = 120;   // px vertical
+    var defaultAllowedTime = 600;  // ms
+
+    function installGlobalHandlersIfNeeded() {
+        if (window.openRoseGlobalHandlersInstalled) return;
+        // Pointer global handlers (handle pointerup/pointercancel regardless of where pointer moved)
+        if (window.PointerEvent) {
+            document.addEventListener('pointerup', globalPointerUp, { passive: true });
+            document.addEventListener('pointercancel', globalPointerCancel, { passive: true });
+            document.addEventListener('pointerdown', globalPointerDownCapture, { passive: true, capture: true });
+            window.openRoseGlobalHandlersInstalled = true;
+            log("swipe: installed global pointer handlers");
+        } else {
+            // touch fallback
+            document.addEventListener('touchend', globalTouchEnd, { passive: true });
+            document.addEventListener('touchcancel', globalTouchCancel, { passive: true });
+            // Also capture touchstart at document capture phase to ensure we see starts that might not reach elements (rare)
+            document.addEventListener('touchstart', globalTouchStartCapture, { passive: true, capture: true });
+            window.openRoseGlobalHandlersInstalled = true;
+            log("swipe: installed global touch handlers");
+        }
+    }
+
+    // Helper: remove global handlers (rarely needed)
+    function removeGlobalHandlers() {
+        if (!window.openRoseGlobalHandlersInstalled) return;
+        if (window.PointerEvent) {
+            document.removeEventListener('pointerup', globalPointerUp, { passive: true });
+            document.removeEventListener('pointercancel', globalPointerCancel, { passive: true });
+            document.removeEventListener('pointerdown', globalPointerDownCapture, { passive: true, capture: true });
+        } else {
+            document.removeEventListener('touchend', globalTouchEnd, { passive: true });
+            document.removeEventListener('touchcancel', globalTouchCancel, { passive: true });
+            document.removeEventListener('touchstart', globalTouchStartCapture, { passive: true, capture: true });
+        }
+        window.openRoseGlobalHandlersInstalled = false;
+    }
+
+    // Global capture to detect pointerdown that may not bubble (fallback); we don't use it to start gesture processing here.
+    function globalPointerDownCapture(ev) {
+        // noop for now, but installed to ensure pointer events are possible in some environments
+    }
+    function globalTouchStartCapture(ev) {
+        // noop
+    }
+
+    // Global pointer end handlers
+    function globalPointerUp(ev) {
+        try {
+            var pid = ev.pointerId;
+            var rec = window.openRoseActivePointers[pid];
+            if (!rec) return;
+            // rec: { elementKey, startX, startY, startTime, threshold, restraint, allowedTime, dotNetRef }
+            // compute deltas
+            var dx = ev.clientX - rec.startX;
+            var dy = ev.clientY - rec.startY;
+            var dt = Date.now() - rec.startTime;
+
+            log("swipe: globalPointerUp", pid, "dx=", dx, "dy=", dy, "dt=", dt);
+
+            // cleanup
+            delete window.openRoseActivePointers[pid];
+
+            if (dt <= rec.allowedTime && Math.abs(dx) >= rec.threshold && Math.abs(dy) <= rec.restraint) {
+                if (dx < 0) {
+                    rec.dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
+                    log("swipe: invoked left for element", rec.elementKey);
+                } else {
+                    rec.dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
+                    log("swipe: invoked right for element", rec.elementKey);
+                }
+            }
+        } catch (e) {
+            // ignore
+            log("swipe: globalPointerUp error", e);
+        }
+    }
+
+    function globalPointerCancel(ev) {
+        try {
+            var pid = ev.pointerId;
+            if (window.openRoseActivePointers[pid]) {
+                delete window.openRoseActivePointers[pid];
+                log("swipe: pointer cancel cleaned", pid);
+            }
+        } catch (e) { /* ignore */ }
+    }
+
+    // Global touch end handlers
+    function globalTouchEnd(ev) {
+        try {
+            if (!ev.changedTouches) return;
+            for (var i = 0; i < ev.changedTouches.length; i++) {
+                var t = ev.changedTouches[i];
+                var touchId = t.identifier;
+                var rec = window.openRoseActiveTouches[touchId];
+                if (!rec) continue;
+                var dx = t.clientX - rec.startX;
+                var dy = t.clientY - rec.startY;
+                var dt = Date.now() - rec.startTime;
+
+                log("swipe: globalTouchEnd id=", touchId, "dx=", dx, "dy=", dy, "dt=", dt);
+
+                delete window.openRoseActiveTouches[touchId];
+
+                if (dt <= rec.allowedTime && Math.abs(dx) >= rec.threshold && Math.abs(dy) <= rec.restraint) {
+                    if (dx < 0) {
+                        rec.dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
+                        log("swipe: invoked left for element", rec.elementKey);
+                    } else {
+                        rec.dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
+                        log("swipe: invoked right for element", rec.elementKey);
+                    }
+                }
+            }
+        } catch (e) {
+            log("swipe: globalTouchEnd error", e);
+        }
+    }
+
+    function globalTouchCancel(ev) {
+        try {
+            if (!ev.changedTouches) return;
+            for (var i = 0; i < ev.changedTouches.length; i++) {
+                var t = ev.changedTouches[i];
+                var touchId = t.identifier;
+                if (window.openRoseActiveTouches[touchId]) {
+                    delete window.openRoseActiveTouches[touchId];
+                }
+            }
+            log("swipe: globalTouchCancel cleaned");
+        } catch (e) { /* ignore */ }
+    }
+
+    // Register an element to start tracking gestures when start occurs inside element.
+    function registerOnElement(el, dotNetRef, elementKey, opts) {
         if (!el) return false;
 
-        // Sensitivity parameters (moderate -> more lenient than high sensitivity)
-        var threshold = 50;     // px horizontal required to count as swipe
-        var restraint = 120;    // px max vertical movement allowed
-        var allowedTime = 600;  // ms max duration
+        // per-element parameters (use defaults unless overridden)
+        var threshold = (opts && opts.threshold) || defaultThreshold;
+        var restraint = (opts && opts.restraint) || defaultRestraint;
+        var allowedTime = (opts && opts.allowedTime) || defaultAllowedTime;
 
-        // Pointer tracking
-        var activePointers = {};   // pointerId -> { startX, startY, startTime }
-        var trackedPointerId = null;
+        // Pointerstart handler attached to element (bubble phase)
+        function elementPointerDown(ev) {
+            try {
+                // Only consider primary buttons for mouse
+                if (ev.pointerType === 'mouse' && ev.button !== 0) return;
 
-        function onPointerDown(ev) {
-            // only start if gesture begins inside element (doc handler ensures this)
-            // For touch pointer types ensure we're not already tracking another pointer (multi-touch)
-            if (ev.pointerType === 'touch') {
-                if (Object.keys(activePointers).length > 0) {
-                    // mark presence, but do not track as single-finger
-                    activePointers[ev.pointerId] = null;
+                // Only start if the gesture begins inside this element (we are on element so OK)
+                // Ignore multi-touch: if there is already a pointer tracked with a different pointerId for this browser,
+                // we still treat each pointer independently but we will only process the first for a given pointerId.
+                var pid = ev.pointerId;
+
+                // store meta for this pointerId keyed globally
+                window.openRoseActivePointers[pid] = {
+                    elementKey: elementKey,
+                    startX: ev.clientX,
+                    startY: ev.clientY,
+                    startTime: Date.now(),
+                    threshold: threshold,
+                    restraint: restraint,
+                    allowedTime: allowedTime,
+                    dotNetRef: dotNetRef
+                };
+
+                log("swipe: elementPointerDown registered for pid", pid, "element", elementKey);
+            } catch (e) {
+                log("swipe: elementPointerDown error", e);
+            }
+        }
+
+        function elementPointerUp(ev) {
+            // We purposely avoid processing up here, global handler will do it.
+        }
+
+        function elementPointerCancel(ev) {
+            try {
+                var pid = ev.pointerId;
+                if (window.openRoseActivePointers[pid]) {
+                    delete window.openRoseActivePointers[pid];
+                    log("swipe: elementPointerCancel cleaned", pid);
+                }
+            } catch (e) { /* ignore */ }
+        }
+
+        // Touchstart on element -> store touch meta keyed by touch.identifier
+        function elementTouchStart(ev) {
+            try {
+                if (!ev || !ev.touches) return;
+                if (ev.touches.length !== 1) {
+                    // multi-touch start: mark nothing for swipe
                     return;
                 }
-            }
-
-            activePointers[ev.pointerId] = {
-                startX: ev.clientX,
-                startY: ev.clientY,
-                startTime: Date.now()
-            };
-
-            if (trackedPointerId === null) trackedPointerId = ev.pointerId;
+                var t = ev.touches[0];
+                window.openRoseActiveTouches[t.identifier] = {
+                    elementKey: elementKey,
+                    startX: t.clientX,
+                    startY: t.clientY,
+                    startTime: Date.now(),
+                    threshold: threshold,
+                    restraint: restraint,
+                    allowedTime: allowedTime,
+                    dotNetRef: dotNetRef
+                };
+                log("swipe: elementTouchStart registered id", t.identifier, "element", elementKey);
+            } catch (e) { log("swipe: elementTouchStart error", e); }
         }
 
-        function onPointerUp(ev) {
-            var meta = activePointers[ev.pointerId];
-            // always remove the pointer entry
-            delete activePointers[ev.pointerId];
+        function elementTouchEnd(ev) {
+            // global handler will process
+        }
 
-            // Only react if this was the tracked single-finger pointer
-            if (trackedPointerId !== ev.pointerId) {
-                // if no pointers remain, reset tracked pointer
-                if (Object.keys(activePointers).length === 0) trackedPointerId = null;
-                return;
-            }
-            trackedPointerId = null;
-
-            if (!meta) return;
-
-            var distX = ev.clientX - meta.startX;
-            var distY = ev.clientY - meta.startY;
-            var elapsed = Date.now() - meta.startTime;
-
-            if (elapsed <= allowedTime && Math.abs(distX) >= threshold && Math.abs(distY) <= restraint) {
-                if (distX < 0) {
-                    // left swipe => Next (book style)
-                    dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
-                } else {
-                    // right swipe => Previous
-                    dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
+        function elementTouchCancel(ev) {
+            try {
+                if (!ev.changedTouches) return;
+                for (var i = 0; i < ev.changedTouches.length; i++) {
+                    var t = ev.changedTouches[i];
+                    if (window.openRoseActiveTouches[t.identifier]) {
+                        delete window.openRoseActiveTouches[t.identifier];
+                    }
                 }
-            }
-        }
-
-        function onPointerCancel(ev) {
-            // Cleanup
-            delete activePointers[ev.pointerId];
-            if (trackedPointerId === ev.pointerId) trackedPointerId = null;
-        }
-
-        // Touch fallback (for older browsers)
-        function onTouchStart(ev) {
-            if (!el.contains(ev.target)) return;
-            if (ev.touches.length !== 1) {
-                el.__swipeTouchMeta = null;
-                return;
-            }
-            var t = ev.touches[0];
-            el.__swipeTouchMeta = { startX: t.clientX, startY: t.clientY, startTime: Date.now() };
-        }
-
-        function onTouchEnd(ev) {
-            var meta = el.__swipeTouchMeta;
-            el.__swipeTouchMeta = null;
-            if (!meta) return;
-
-            var t = (ev.changedTouches && ev.changedTouches[0]) || null;
-            if (!t) return;
-
-            var distX = t.clientX - meta.startX;
-            var distY = t.clientY - meta.startY;
-            var elapsed = Date.now() - meta.startTime;
-
-            if (elapsed <= allowedTime && Math.abs(distX) >= threshold && Math.abs(distY) <= restraint) {
-                if (distX < 0) {
-                    dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
-                } else {
-                    dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
-                }
-            }
-        }
-
-        function onTouchCancel(ev) {
-            el.__swipeTouchMeta = null;
-        }
-
-        // Document-level handlers (capture phase). Start only when start inside element.
-        function docPointerDown(ev) {
-            try {
-                if (!el.contains(ev.target)) return;
-                onPointerDown(ev);
-            } catch (e) { /* ignore */ }
-        }
-        function docPointerUp(ev) {
-            try {
-                // Do NOT require ev.target to be inside element; user may lift finger outside.
-                onPointerUp(ev);
-            } catch (e) { /* ignore */ }
-        }
-        function docPointerCancel(ev) {
-            try {
-                onPointerCancel(ev);
             } catch (e) { /* ignore */ }
         }
 
-        function docTouchStart(ev) {
-            try {
-                if (!el.contains(ev.target)) return;
-                onTouchStart(ev);
-            } catch (e) { /* ignore */ }
-        }
-        function docTouchEnd(ev) {
-            try {
-                onTouchEnd(ev);
-            } catch (e) { /* ignore */ }
-        }
-        function docTouchCancel(ev) {
-            try {
-                onTouchCancel(ev);
-            } catch (e) { /* ignore */ }
-        }
+        // Attach element-level listeners (bubble phase)
+        var handlers = {};
 
-        // Attach listeners
         if (window.PointerEvent) {
-            document.addEventListener('pointerdown', docPointerDown, { passive: true, capture: true });
-            document.addEventListener('pointerup', docPointerUp, { passive: true, capture: true });
-            document.addEventListener('pointercancel', docPointerCancel, { passive: true, capture: true });
+            handlers.pointerdown = elementPointerDown;
+            handlers.pointerup = elementPointerUp;
+            handlers.pointercancel = elementPointerCancel;
 
+            el.addEventListener('pointerdown', handlers.pointerdown, { passive: true });
+            // pointerup on element not required; global will handle actual up event
+            el.addEventListener('pointercancel', handlers.pointercancel, { passive: true });
+
+            // store handler refs for removal later
             window.openRoseHandlers[elementKey] = {
                 el: el,
                 mode: 'pointer',
-                handlers: { docPointerDown: docPointerDown, docPointerUp: docPointerUp, docPointerCancel: docPointerCancel },
+                handlers: handlers,
                 dotNetRef: dotNetRef
             };
-        } else {
-            // touch + mouse fallback
-            document.addEventListener('touchstart', docTouchStart, { passive: true, capture: true });
-            document.addEventListener('touchend', docTouchEnd, { passive: true, capture: true });
-            document.addEventListener('touchcancel', docTouchCancel, { passive: true, capture: true });
 
-            // mouse fallback (desktop)
-            document.addEventListener('mousedown', docPointerDown, { passive: true, capture: true });
-            document.addEventListener('mouseup', docPointerUp, { passive: true, capture: true });
+            log("swipe: registered element-level pointer handlers for", elementKey);
+        } else {
+            // touch/mouse fallback
+            handlers.touchstart = elementTouchStart;
+            handlers.touchend = elementTouchEnd;
+            handlers.touchcancel = elementTouchCancel;
+            handlers.mousedown = elementPointerDown; // treat mouse down similarly
+            handlers.mouseup = elementPointerUp;
+
+            el.addEventListener('touchstart', handlers.touchstart, { passive: true });
+            el.addEventListener('touchcancel', handlers.touchcancel, { passive: true });
+            el.addEventListener('mousedown', handlers.mousedown, { passive: true });
 
             window.openRoseHandlers[elementKey] = {
                 el: el,
                 mode: 'touchmouse',
-                handlers: {
-                    docTouchStart: docTouchStart,
-                    docTouchEnd: docTouchEnd,
-                    docTouchCancel: docTouchCancel,
-                    docPointerDown: docPointerDown,
-                    docPointerUp: docPointerUp
-                },
+                handlers: handlers,
                 dotNetRef: dotNetRef
             };
+            log("swipe: registered element-level touch/mouse handlers for", elementKey);
         }
+
+        // ensure globals are installed (do once)
+        installGlobalHandlersIfNeeded();
 
         return true;
     }
 
-    window.openRoseRegisterSwipeElement = function (element, dotNetRef) {
+    // Public API: register/unregister functions expected by Blazor
+    window.openRoseRegisterSwipeElement = function (element, dotNetRef, options) {
         try {
             if (!element) return false;
             var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : ("el-" + Math.random().toString(36).substr(2, 9));
-            try { element.dataset.openroseId = elementKey; } catch (e) { }
-            return registerOnElement(element, dotNetRef, elementKey);
+            try { element.dataset.openroseId = elementKey; } catch (e) { /* ignore */ }
+            return registerOnElement(element, dotNetRef, elementKey, options || {});
         } catch (err) {
+            log("swipe: openRoseRegisterSwipeElement error", err);
             return false;
         }
     };
@@ -216,23 +328,34 @@
             var h = rec.handlers || {};
             try {
                 if (mode === 'pointer') {
-                    document.removeEventListener('pointerdown', h.docPointerDown, { capture: true });
-                    document.removeEventListener('pointerup', h.docPointerUp, { capture: true });
-                    document.removeEventListener('pointercancel', h.docPointerCancel, { capture: true });
+                    element.removeEventListener('pointerdown', h.pointerdown);
+                    element.removeEventListener('pointercancel', h.pointercancel);
                 } else {
-                    document.removeEventListener('touchstart', h.docTouchStart, { capture: true });
-                    document.removeEventListener('touchend', h.docTouchEnd, { capture: true });
-                    document.removeEventListener('touchcancel', h.docTouchCancel, { capture: true });
-                    document.removeEventListener('mousedown', h.docPointerDown, { capture: true });
-                    document.removeEventListener('mouseup', h.docPointerUp, { capture: true });
+                    element.removeEventListener('touchstart', h.touchstart);
+                    element.removeEventListener('touchcancel', h.touchcancel);
+                    element.removeEventListener('mousedown', h.mousedown);
                 }
             } catch (er) { /* ignore */ }
+
+            // cleanup any active pointers/touches associated with this element
+            for (var pid in window.openRoseActivePointers) {
+                if (window.openRoseActivePointers[pid] && window.openRoseActivePointers[pid].elementKey === elementKey) {
+                    delete window.openRoseActivePointers[pid];
+                }
+            }
+            for (var tid in window.openRoseActiveTouches) {
+                if (window.openRoseActiveTouches[tid] && window.openRoseActiveTouches[tid].elementKey === elementKey) {
+                    delete window.openRoseActiveTouches[tid];
+                }
+            }
 
             delete window.openRoseHandlers[elementKey];
             try { delete element.dataset.openroseId; } catch (e) { }
             try { delete element.__swipeTouchMeta; } catch (e) { }
+            log("swipe: unregistered element", elementKey);
             return true;
         } catch (err) {
+            log("swipe: openRoseUnregisterSwipeElement error", err);
             return false;
         }
     };

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -1,0 +1,130 @@
+﻿/*
+ * OpenRose - Requirements Management
+    * Licensed under the Apache License, Version 2.0.
+ * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+*/
+// wwwroot/js/swipe.js
+
+// wwwroot/js/swipe.js (production)
+(function () {
+    if (window.openRoseSwipeLibLoaded) {
+        return;
+    }
+    window.openRoseSwipeLibLoaded = true;
+
+    window.openRoseHandlers = window.openRoseHandlers || {};
+
+    function registerOnElement(el, dotNetRef, elementKey) {
+        if (!el) {
+            return false;
+        }
+
+        var startX = 0, startY = 0, startTime = 0;
+        var threshold = 50;
+        var restraint = 120;
+        var allowedTime = 600;
+
+        function onStart(e) {
+            var p = (e.touches && e.touches[0]) || e;
+            startX = p.clientX;
+            startY = p.clientY;
+            startTime = Date.now();
+        }
+
+        function onEnd(e) {
+            var p = (e.changedTouches && e.changedTouches[0]) || e;
+            var distX = p.clientX - startX;
+            var distY = p.clientY - startY;
+            var elapsed = Date.now() - startTime;
+
+            if (elapsed <= allowedTime && Math.abs(distX) >= threshold && Math.abs(distY) <= restraint) {
+                if (distX < 0) {
+                    dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /* ignore */ });
+                } else {
+                    dotNetRef.invokeMethodAsync('OnSwipe', 'right').catch(function () { /* ignore */ });
+                }
+            }
+        }
+
+        function onPointerDown(e) { onStart(e); }
+        function onPointerUp(e) { onEnd(e); }
+        function onTouchStart(e) { onStart(e); }
+        function onTouchEnd(e) { onEnd(e); }
+        function onMouseDown(e) { onStart(e); }
+        function onMouseUp(e) { onEnd(e); }
+
+        var uses = [];
+        if (window.PointerEvent) {
+            el.addEventListener('pointerdown', onPointerDown, { passive: true });
+            el.addEventListener('pointerup', onPointerUp, { passive: true });
+            uses.push('pointer');
+        } else {
+            if ('ontouchstart' in window || navigator.maxTouchPoints > 0) {
+                el.addEventListener('touchstart', onTouchStart, { passive: true });
+                el.addEventListener('touchend', onTouchEnd, { passive: true });
+                uses.push('touch');
+            }
+            el.addEventListener('mousedown', onMouseDown, { passive: true });
+            el.addEventListener('mouseup', onMouseUp, { passive: true });
+            uses.push('mouse');
+        }
+
+        window.openRoseHandlers[elementKey] = {
+            el: el,
+            handlers: {
+                onPointerDown: onPointerDown, onPointerUp: onPointerUp,
+                onTouchStart: onTouchStart, onTouchEnd: onTouchEnd,
+                onMouseDown: onMouseDown, onMouseUp: onMouseUp
+            },
+            uses: uses,
+            dotNetRef: dotNetRef
+        };
+
+        return true;
+    }
+
+    window.openRoseRegisterSwipeElement = function (element, dotNetRef) {
+        try {
+            if (!element) return false;
+            var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : ("el-" + Math.random().toString(36).substr(2, 9));
+            try { element.dataset.openroseId = elementKey; } catch (e) { }
+            return registerOnElement(element, dotNetRef, elementKey);
+        } catch (err) {
+            return false;
+        }
+    };
+
+    window.openRoseUnregisterSwipeElement = function (element) {
+        try {
+            if (!element) return false;
+            var elementKey = element.dataset && element.dataset.openroseId ? element.dataset.openroseId : null;
+            if (!elementKey) return false;
+            var rec = window.openRoseHandlers[elementKey];
+            if (!rec) return false;
+
+            var el = rec.el;
+            var uses = rec.uses || [];
+
+            try {
+                if (uses.indexOf('pointer') >= 0) {
+                    el.removeEventListener('pointerdown', rec.handlers.onPointerDown);
+                    el.removeEventListener('pointerup', rec.handlers.onPointerUp);
+                }
+                if (uses.indexOf('touch') >= 0) {
+                    el.removeEventListener('touchstart', rec.handlers.onTouchStart);
+                    el.removeEventListener('touchend', rec.handlers.onTouchEnd);
+                }
+                if (uses.indexOf('mouse') >= 0) {
+                    el.removeEventListener('mousedown', rec.handlers.onMouseDown);
+                    el.removeEventListener('mouseup', rec.handlers.onMouseUp);
+                }
+            } catch (er) { /* ignore */ }
+
+            delete window.openRoseHandlers[elementKey];
+            try { delete element.dataset.openroseId; } catch (e) { }
+            return true;
+        } catch (err) {
+            return false;
+        }
+    };
+})();

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,10 +4,10 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
+
 // Touch-only swipe detection (single-finger). Does NOT handle mouse/pointer events.
-// - Preserves mouse clicks completely (no mouse handlers attached).
-// - Preserves pinch/zoom (multi-touch ignored).
-// - Dynamically prevents browser history navigation for one-finger horizontal gestures.
+// - Intercepts single-finger horizontal swipes and prevents browser history only for that gesture.
+// - Immediately cancels custom handling when a second finger is detected, allowing pinch/zoom.
 // - Moderate sensitivity: threshold=50px, restraint=120px, allowedTime=600ms.
 // - Set debug = true for logging during testing.
 
@@ -16,7 +16,7 @@
     window.openRoseSwipeLibLoaded = true;
     window.openRoseHandlers = window.openRoseHandlers || {};
 
-    var debug = true; // set to true for device logs
+    var debug = false; // set to true while testing to get console logs
 
     function dlog() {
         if (!debug) return;
@@ -45,13 +45,11 @@
                 try { document.removeEventListener('touchmove', docTouchMoveHandler, { capture: true }); } catch (e) { /* ignore */ }
                 docTouchMoveHandler = null;
             }
-            // restore overscroll behavior & touch-action
             try {
                 if (savedOverscroll !== null) {
                     document.documentElement.style.overscrollBehavior = savedOverscroll;
                     savedOverscroll = null;
                 } else {
-                    // if there was no saved value, remove explicit style (let CSS decide)
                     document.documentElement.style.overscrollBehavior = '';
                 }
             } catch (e) { /* ignore */ }
@@ -69,12 +67,11 @@
         function onTouchStart(ev) {
             try {
                 if (!ev || !ev.touches) return;
-                // Only one-finger gestures: if more than 1, ignore to preserve pinch
+                // Only begin tracking when exactly one touch is present
                 if (ev.touches.length !== 1) {
                     activeTouch = null;
                     return;
                 }
-
                 var t = ev.touches[0];
                 activeTouch = {
                     id: t.identifier,
@@ -84,54 +81,51 @@
                     prevented: false
                 };
 
-                dlog("swipe: touchstart registered id", activeTouch.id, "element", elementKey);
+                dlog("swipe: touchstart id", activeTouch.id, "element", elementKey);
 
-                // Save current overscroll & touch-action and set temporary values that help block nav on Chromium
+                // Temporarily reduce overscroll behavior so browsers are less likely to interpret horizontal swipe as nav.
                 try {
-                    // Save and then set overscroll to 'none' to block "swipe to navigate" on Chromium browsers
                     savedOverscroll = document.documentElement.style.overscrollBehavior || '';
                     document.documentElement.style.overscrollBehavior = 'none';
                 } catch (e) { savedOverscroll = null; }
 
                 try {
                     savedTouchAction = el.style.touchAction || '';
-                    // Hint: allow vertical panning but make horizontal available for JS handling
                     el.style.touchAction = 'pan-y';
                 } catch (e) { savedTouchAction = null; }
 
-                // Install document-level touchmove with passive: false so we can preventDefault when we detect horizontal gesture
+                // Install document-level touchmove (non-passive) so we can preventDefault when we detect horizontal gesture
                 docTouchMoveHandler = function (moveEv) {
                     try {
                         if (!activeTouch) return;
 
-                        // find the tracked touch in the current touches
+                        // If multi-touch occurs, cancel custom handling immediately and restore defaults
+                        if (moveEv.touches && moveEv.touches.length > 1) {
+                            dlog("swipe: multi-touch detected -> cancel custom swipe handling", elementKey);
+                            cleanupMoveHandler();
+                            activeTouch = null;
+                            return;
+                        }
+
+                        // find tracked touch
                         var found = null;
                         for (var i = 0; i < moveEv.touches.length; i++) {
-                            if (moveEv.touches[i].identifier === activeTouch.id) {
-                                found = moveEv.touches[i];
-                                break;
-                            }
+                            if (moveEv.touches[i].identifier === activeTouch.id) { found = moveEv.touches[i]; break; }
                         }
                         if (!found) return;
-
-                        // If more than one touch currently active, abort preventing (user used another finger)
-                        if (moveEv.touches.length > 1) return;
 
                         var dx = found.clientX - activeTouch.startX;
                         var dy = found.clientY - activeTouch.startY;
                         var absDx = Math.abs(dx), absDy = Math.abs(dy);
 
-                        // If horizontal movement is dominant and exceeds early threshold, prevent default to stop browser nav
+                        // If horizontal dominant and passes a small early threshold, prevent default to stop browser nav
                         if (!activeTouch.prevented && absDx > EARLY_MOVE_THRESHOLD && absDx > absDy) {
                             try {
-                                moveEv.preventDefault(); // this prevents browser swipe-to-navigate on many browsers
+                                moveEv.preventDefault();
                                 activeTouch.prevented = true;
                                 dlog("swipe: prevented default on touchmove (element)", elementKey);
-                            } catch (e) {
-                                // some browsers restrict preventDefault if listener is passive (we used non-passive) or other constraints
-                            }
+                            } catch (e) { /* ignore */ }
                         } else if (activeTouch.prevented) {
-                            // keep preventing if we've started preventing
                             try { moveEv.preventDefault(); } catch (e) { /* ignore */ }
                         }
                     } catch (e) { /* ignore */ }
@@ -151,7 +145,6 @@
                     return;
                 }
 
-                // find changedTouches that match the tracked touch id
                 if (!ev.changedTouches) {
                     cleanupMoveHandler();
                     activeTouch = null;
@@ -160,14 +153,11 @@
 
                 var matched = null;
                 for (var i = 0; i < ev.changedTouches.length; i++) {
-                    if (ev.changedTouches[i].identifier === activeTouch.id) {
-                        matched = ev.changedTouches[i];
-                        break;
-                    }
+                    if (ev.changedTouches[i].identifier === activeTouch.id) { matched = ev.changedTouches[i]; break; }
                 }
 
                 if (!matched) {
-                    // Might have ended elsewhere; just cleanup
+                    // touch ended but not the tracked one -> cleanup and return
                     cleanupMoveHandler();
                     activeTouch = null;
                     return;
@@ -179,10 +169,8 @@
 
                 dlog("swipe: touchend id", activeTouch.id, "dx", dx, "dy", dy, "dt", dt, "prevented", activeTouch.prevented);
 
-                // cleanup move handler and styles
                 cleanupMoveHandler();
 
-                // evaluate threshold
                 if (dt <= allowedTime && Math.abs(dx) >= threshold && Math.abs(dy) <= restraint) {
                     if (dx < 0) {
                         dotNetRef.invokeMethodAsync('OnSwipe', 'left').catch(function () { /*ignore*/ });
@@ -203,40 +191,26 @@
 
         function onTouchCancel(ev) {
             try {
+                dlog("swipe: touchcancel for", elementKey);
                 cleanupMoveHandler();
                 activeTouch = null;
-                dlog("swipe: touchcancel for", elementKey);
             } catch (e) { /* ignore */ }
         }
 
-        // Attach element-level touch listeners. We don't add pointer or mouse listeners at all.
-        var handlers = {
-            touchstart: onTouchStart,
-            touchend: onTouchEnd,
-            touchcancel: onTouchCancel
-        };
-
+        // Attach element-level touch listeners. Do NOT attach pointer/mouse handlers.
         try {
-            // attach touchstart non-passive? touchstart cannot be passive (spec default is non-passive). But to be safe we attach with passive:false so that preventDefault in move works reliably later.
-            el.addEventListener('touchstart', handlers.touchstart, { passive: false });
-            el.addEventListener('touchend', handlers.touchend, { passive: true });
-            el.addEventListener('touchcancel', handlers.touchcancel, { passive: true });
+            el.addEventListener('touchstart', onTouchStart, { passive: false });
+            el.addEventListener('touchend', onTouchEnd, { passive: true });
+            el.addEventListener('touchcancel', onTouchCancel, { passive: true });
             dlog("swipe: attached touch handlers for element", elementKey);
         } catch (e) {
-            // older browsers fallback
-            el.addEventListener('touchstart', handlers.touchstart);
-            el.addEventListener('touchend', handlers.touchend);
-            el.addEventListener('touchcancel', handlers.touchcancel);
+            // fallback
+            el.addEventListener('touchstart', onTouchStart);
+            el.addEventListener('touchend', onTouchEnd);
+            el.addEventListener('touchcancel', onTouchCancel);
         }
 
-        // Store registered handlers so we can unregister later
-        window.openRoseHandlers[elementKey] = {
-            el: el,
-            handlers: handlers,
-            dotNetRef: dotNetRef
-        };
-
-        dlog("swipe: registered touch-only element", elementKey);
+        window.openRoseHandlers[elementKey] = { el: el, handlers: { onTouchStart: onTouchStart, onTouchEnd: onTouchEnd, onTouchCancel: onTouchCancel }, dotNetRef: dotNetRef };
         return true;
     }
 
@@ -250,11 +224,11 @@
             var el = rec.el;
             var h = rec.handlers || {};
             try {
-                el.removeEventListener('touchstart', h.touchstart, { passive: false });
-                el.removeEventListener('touchend', h.touchend, { passive: true });
-                el.removeEventListener('touchcancel', h.touchcancel, { passive: true });
+                el.removeEventListener('touchstart', h.onTouchStart, { passive: false });
+                el.removeEventListener('touchend', h.onTouchEnd, { passive: true });
+                el.removeEventListener('touchcancel', h.onTouchCancel, { passive: true });
             } catch (e) {
-                try { el.removeEventListener('touchstart', h.touchstart); el.removeEventListener('touchend', h.touchend); el.removeEventListener('touchcancel', h.touchcancel); } catch (_) { }
+                try { el.removeEventListener('touchstart', h.onTouchStart); el.removeEventListener('touchend', h.onTouchEnd); el.removeEventListener('touchcancel', h.onTouchCancel); } catch (_) { }
             }
             delete window.openRoseHandlers[elementKey];
             try { delete element.dataset.openroseId; } catch (_) { }
@@ -266,7 +240,7 @@
         }
     }
 
-    // Exposed API used by Blazor
+    // API for Blazor
     window.openRoseRegisterSwipeElement = function (element, dotNetRef, options) {
         try {
             if (!element) return false;

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -3,26 +3,28 @@
     * Licensed under the Apache License, Version 2.0.
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
-// wwwroot/js/swipe.js
 
-// wwwroot/js/swipe.js (production)
+// Production-ready, robust touch/pointer swipe detection (document-level, capture-phase).
+
+
 (function () {
     if (window.openRoseSwipeLibLoaded) {
         return;
     }
     window.openRoseSwipeLibLoaded = true;
-
     window.openRoseHandlers = window.openRoseHandlers || {};
 
     function registerOnElement(el, dotNetRef, elementKey) {
-        if (!el) {
-            return false;
-        }
+        if (!el) return false;
+
+        // Hint browser how to treat touch gestures:
+        // pan-y allows vertical scrolling while enabling horizontal gestures to be used by JS.
+        try { el.style.touchAction = 'pan-y'; } catch (e) { }
 
         var startX = 0, startY = 0, startTime = 0;
-        var threshold = 50;
-        var restraint = 120;
-        var allowedTime = 600;
+        var threshold = 50; // pixels min for swipe
+        var restraint = 120; // max y delta
+        var allowedTime = 600; // ms
 
         function onStart(e) {
             var p = (e.touches && e.touches[0]) || e;
@@ -46,36 +48,52 @@
             }
         }
 
-        function onPointerDown(e) { onStart(e); }
-        function onPointerUp(e) { onEnd(e); }
-        function onTouchStart(e) { onStart(e); }
-        function onTouchEnd(e) { onEnd(e); }
-        function onMouseDown(e) { onStart(e); }
-        function onMouseUp(e) { onEnd(e); }
+        // Document-level capture handlers that filter by el.contains(target)
+        function makeDocPointerDown() {
+            return function (ev) {
+                // only start if gesture begins inside element
+                try {
+                    if (el.contains(ev.target)) onStart(ev);
+                } catch (e) { /* ignore */ }
+            };
+        }
+        function makeDocPointerUp() {
+            return function (ev) {
+                try {
+                    if (el.contains(ev.target)) onEnd(ev);
+                } catch (e) { /* ignore */ }
+            };
+        }
+
+        var handlers = {
+            pointerDown: makeDocPointerDown(),
+            pointerUp: makeDocPointerUp(),
+            touchStart: makeDocPointerDown(),
+            touchEnd: makeDocPointerUp(),
+            mouseDown: makeDocPointerDown(),
+            mouseUp: makeDocPointerUp()
+        };
 
         var uses = [];
+
+        // Prefer pointer events where available
         if (window.PointerEvent) {
-            el.addEventListener('pointerdown', onPointerDown, { passive: true });
-            el.addEventListener('pointerup', onPointerUp, { passive: true });
+            document.addEventListener('pointerdown', handlers.pointerDown, { passive: true, capture: true });
+            document.addEventListener('pointerup', handlers.pointerUp, { passive: true, capture: true });
             uses.push('pointer');
         } else {
-            if ('ontouchstart' in window || navigator.maxTouchPoints > 0) {
-                el.addEventListener('touchstart', onTouchStart, { passive: true });
-                el.addEventListener('touchend', onTouchEnd, { passive: true });
-                uses.push('touch');
-            }
-            el.addEventListener('mousedown', onMouseDown, { passive: true });
-            el.addEventListener('mouseup', onMouseUp, { passive: true });
-            uses.push('mouse');
+            // touch
+            document.addEventListener('touchstart', handlers.touchStart, { passive: true, capture: true });
+            document.addEventListener('touchend', handlers.touchEnd, { passive: true, capture: true });
+            // mouse as fallback
+            document.addEventListener('mousedown', handlers.mouseDown, { passive: true, capture: true });
+            document.addEventListener('mouseup', handlers.mouseUp, { passive: true, capture: true });
+            uses.push('touch', 'mouse');
         }
 
         window.openRoseHandlers[elementKey] = {
             el: el,
-            handlers: {
-                onPointerDown: onPointerDown, onPointerUp: onPointerUp,
-                onTouchStart: onTouchStart, onTouchEnd: onTouchEnd,
-                onMouseDown: onMouseDown, onMouseUp: onMouseUp
-            },
+            handlers: handlers,
             uses: uses,
             dotNetRef: dotNetRef
         };
@@ -102,21 +120,18 @@
             var rec = window.openRoseHandlers[elementKey];
             if (!rec) return false;
 
-            var el = rec.el;
+            var handlers = rec.handlers || {};
             var uses = rec.uses || [];
 
             try {
                 if (uses.indexOf('pointer') >= 0) {
-                    el.removeEventListener('pointerdown', rec.handlers.onPointerDown);
-                    el.removeEventListener('pointerup', rec.handlers.onPointerUp);
-                }
-                if (uses.indexOf('touch') >= 0) {
-                    el.removeEventListener('touchstart', rec.handlers.onTouchStart);
-                    el.removeEventListener('touchend', rec.handlers.onTouchEnd);
-                }
-                if (uses.indexOf('mouse') >= 0) {
-                    el.removeEventListener('mousedown', rec.handlers.onMouseDown);
-                    el.removeEventListener('mouseup', rec.handlers.onMouseUp);
+                    document.removeEventListener('pointerdown', handlers.pointerDown, { capture: true });
+                    document.removeEventListener('pointerup', handlers.pointerUp, { capture: true });
+                } else {
+                    document.removeEventListener('touchstart', handlers.touchStart, { capture: true });
+                    document.removeEventListener('touchend', handlers.touchEnd, { capture: true });
+                    document.removeEventListener('mousedown', handlers.mouseDown, { capture: true });
+                    document.removeEventListener('mouseup', handlers.mouseUp, { capture: true });
                 }
             } catch (er) { /* ignore */ }
 

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/swipe.js
@@ -4,7 +4,9 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
-// Production-ready: one-finger swipe detection (medium sensitivity), preserves pinch/zoom and scrolling.
+// wwwroot/js/swipe.js
+// Production: one-finger swipe detection, preserves pinch/zoom and scrolling.
+// Document-level capture listeners, start-inside-element + end-anywhere, pointer+touch fallback.
 (function () {
     if (window.openRoseSwipeLibLoaded) {
         return;
@@ -15,52 +17,49 @@
     function registerOnElement(el, dotNetRef, elementKey) {
         if (!el) return false;
 
-        // Medium sensitivity parameters
-        var threshold = 80;     // min horizontal movement (px) to count as swipe
-        var restraint = 150;    // max vertical movement allowed (px)
-        var allowedTime = 700;  // max ms for the swipe gesture
+        // Sensitivity parameters (moderate -> more lenient than high sensitivity)
+        var threshold = 50;     // px horizontal required to count as swipe
+        var restraint = 120;    // px max vertical movement allowed
+        var allowedTime = 600;  // ms max duration
 
-        // For pointer events tracking
-        var activePointers = {}; // map pointerId => {startX,startY,startTime}
-        var trackedPointerId = null; // pointer we are tracking for this element
+        // Pointer tracking
+        var activePointers = {};   // pointerId -> { startX, startY, startTime }
+        var trackedPointerId = null;
 
         function onPointerDown(ev) {
-            // Only track single-finger touch (pointerType === 'touch') or mouse left button.
-            // If multiple pointers exist, we ignore to preserve multi-finger gestures (pinch).
+            // only start if gesture begins inside element (doc handler ensures this)
+            // For touch pointer types ensure we're not already tracking another pointer (multi-touch)
             if (ev.pointerType === 'touch') {
-                // If there are any active pointers already, don't start a new one (multi-touch)
                 if (Object.keys(activePointers).length > 0) {
-                    activePointers[ev.pointerId] = null; // mark but don't track
+                    // mark presence, but do not track as single-finger
+                    activePointers[ev.pointerId] = null;
                     return;
                 }
             }
 
-            // record start values
             activePointers[ev.pointerId] = {
                 startX: ev.clientX,
                 startY: ev.clientY,
                 startTime: Date.now()
             };
 
-            // If this is the first/only pointer, mark it tracked
             if (trackedPointerId === null) trackedPointerId = ev.pointerId;
         }
 
         function onPointerUp(ev) {
             var meta = activePointers[ev.pointerId];
-            // Clean up the activePointers entry (we'll compute before deleting)
+            // always remove the pointer entry
             delete activePointers[ev.pointerId];
 
-            // Only react if this pointer was the tracked one and we had no other pointers when it started
+            // Only react if this was the tracked single-finger pointer
             if (trackedPointerId !== ev.pointerId) {
-                // if the pointer we tracked isn't this one, ignore
+                // if no pointers remain, reset tracked pointer
                 if (Object.keys(activePointers).length === 0) trackedPointerId = null;
                 return;
             }
+            trackedPointerId = null;
 
-            trackedPointerId = null; // reset tracked pointer
-
-            if (!meta) return; // not a tracked single-finger start
+            if (!meta) return;
 
             var distX = ev.clientX - meta.startX;
             var distY = ev.clientY - meta.startY;
@@ -77,12 +76,16 @@
             }
         }
 
-        // Touch fallback for browsers not using PointerEvent
-        // We will ignore multi-touch (touches.length !== 1) to preserve pinch gestures
+        function onPointerCancel(ev) {
+            // Cleanup
+            delete activePointers[ev.pointerId];
+            if (trackedPointerId === ev.pointerId) trackedPointerId = null;
+        }
+
+        // Touch fallback (for older browsers)
         function onTouchStart(ev) {
             if (!el.contains(ev.target)) return;
             if (ev.touches.length !== 1) {
-                // multi-touch start -> ignore for swipe detection
                 el.__swipeTouchMeta = null;
                 return;
             }
@@ -91,12 +94,12 @@
         }
 
         function onTouchEnd(ev) {
-            if (!el.__swipeTouchMeta) return;
-            var t = (ev.changedTouches && ev.changedTouches[0]) || null;
-            if (!t) { el.__swipeTouchMeta = null; return; }
-
             var meta = el.__swipeTouchMeta;
             el.__swipeTouchMeta = null;
+            if (!meta) return;
+
+            var t = (ev.changedTouches && ev.changedTouches[0]) || null;
+            if (!t) return;
 
             var distX = t.clientX - meta.startX;
             var distY = t.clientY - meta.startY;
@@ -111,8 +114,11 @@
             }
         }
 
-        // Document-level handlers in capture phase, but we still ensure gesture starts inside element.
-        // We use capture so parent/child elements that call stopPropagation in bubble phase won't block us.
+        function onTouchCancel(ev) {
+            el.__swipeTouchMeta = null;
+        }
+
+        // Document-level handlers (capture phase). Start only when start inside element.
         function docPointerDown(ev) {
             try {
                 if (!el.contains(ev.target)) return;
@@ -121,39 +127,52 @@
         }
         function docPointerUp(ev) {
             try {
-                if (!el.contains(ev.target)) return;
+                // Do NOT require ev.target to be inside element; user may lift finger outside.
                 onPointerUp(ev);
             } catch (e) { /* ignore */ }
         }
+        function docPointerCancel(ev) {
+            try {
+                onPointerCancel(ev);
+            } catch (e) { /* ignore */ }
+        }
+
         function docTouchStart(ev) {
             try {
-                // Only care if touchstart happened inside element
                 if (!el.contains(ev.target)) return;
                 onTouchStart(ev);
             } catch (e) { /* ignore */ }
         }
         function docTouchEnd(ev) {
             try {
-                // touchend target may be different; use the stored meta only
                 onTouchEnd(ev);
             } catch (e) { /* ignore */ }
         }
+        function docTouchCancel(ev) {
+            try {
+                onTouchCancel(ev);
+            } catch (e) { /* ignore */ }
+        }
 
-        // Attach handlers
+        // Attach listeners
         if (window.PointerEvent) {
             document.addEventListener('pointerdown', docPointerDown, { passive: true, capture: true });
             document.addEventListener('pointerup', docPointerUp, { passive: true, capture: true });
-            // Store record
+            document.addEventListener('pointercancel', docPointerCancel, { passive: true, capture: true });
+
             window.openRoseHandlers[elementKey] = {
                 el: el,
                 mode: 'pointer',
-                handlers: { docPointerDown: docPointerDown, docPointerUp: docPointerUp },
+                handlers: { docPointerDown: docPointerDown, docPointerUp: docPointerUp, docPointerCancel: docPointerCancel },
                 dotNetRef: dotNetRef
             };
         } else {
             // touch + mouse fallback
             document.addEventListener('touchstart', docTouchStart, { passive: true, capture: true });
             document.addEventListener('touchend', docTouchEnd, { passive: true, capture: true });
+            document.addEventListener('touchcancel', docTouchCancel, { passive: true, capture: true });
+
+            // mouse fallback (desktop)
             document.addEventListener('mousedown', docPointerDown, { passive: true, capture: true });
             document.addEventListener('mouseup', docPointerUp, { passive: true, capture: true });
 
@@ -163,6 +182,7 @@
                 handlers: {
                     docTouchStart: docTouchStart,
                     docTouchEnd: docTouchEnd,
+                    docTouchCancel: docTouchCancel,
                     docPointerDown: docPointerDown,
                     docPointerUp: docPointerUp
                 },
@@ -198,9 +218,11 @@
                 if (mode === 'pointer') {
                     document.removeEventListener('pointerdown', h.docPointerDown, { capture: true });
                     document.removeEventListener('pointerup', h.docPointerUp, { capture: true });
+                    document.removeEventListener('pointercancel', h.docPointerCancel, { capture: true });
                 } else {
                     document.removeEventListener('touchstart', h.docTouchStart, { capture: true });
                     document.removeEventListener('touchend', h.docTouchEnd, { capture: true });
+                    document.removeEventListener('touchcancel', h.docTouchCancel, { capture: true });
                     document.removeEventListener('mousedown', h.docPointerDown, { capture: true });
                     document.removeEventListener('mouseup', h.docPointerUp, { capture: true });
                 }


### PR DESCRIPTION

## Summary
- Adds one-finger left/right swipe navigation for read-only detail views (both API-backed and JSON-file-backed) used from the TreeView.
- Swipe behaves like paging through a book: swipe left → advance to next record; swipe right → go to previous record.
- Supports the following read-only record types and their JSON variants: Project, ItemzType (Requirement Item Type), Itemz (Requirement Item), Baseline, BaselineItemzType, BaselineItemz.
- Preserves native touch behaviors: pinch-to-zoom (two-finger) and vertical scrolling. Mouse clicks and keyboard interactions are not affected.

## User-facing changes
- On touch devices (phone/tablet/touch laptops), users can swipe left/right on the read-only panes to navigate to the next/previous record in the currently loaded TreeView ordering.
- Arrow / circular buttons and keyboard navigation remain available as fallbacks. Nothing changes for desktop mouse-only users except that mouse swipes are ignored by the touch-only JS (mouse click behavior preserved).
- JSON file read-only views behave identically to API-backed read-only views.

## High-level technical details
- New/changed files:
  - wwwroot/js/swipe.js — core touch-only swipe detection. Touch-only approach to avoid interfering with mouse clicks. Dynamically installs non-passive touchmove during a single-finger gesture to prevent browser history navigation only when needed. Ignores multi-touch to preserve pinch-to-zoom.
  - Changes to read-only Razor components (API and JSON variants) for Project, ItemzType, Itemz, Baseline, BaselineItemzType, BaselineItemz:
    - Adds ElementReference to wrapper div and registers it with swipe.js using JS interop: openRoseRegisterSwipeElement.
    - Provides a JSInvokable OnSwipe(string direction) method that maps 'left'/'right' to EventCallback invocations (OnNavigateNext / OnNavigatePrevious).
    - Implements IAsyncDisposable (DisposeAsync) to unregister swipe listeners using openRoseUnregisterSwipeElement and dispose DotNetObjectReference.
- Swipe mapping: book-style
  - swipe left → OnNavigateNext (move forward)
  - swipe right → OnNavigatePrevious (move back)
- Implementation highlights:
  - Touch-only detection (no mouse/pointer handlers) to avoid interfering with mouse clicks on desktop.
  - Dynamic non-passive touchmove registration so the browser’s built-in back/forward swipe is prevented only when our code detects a one-finger horizontal gesture in progress.
  - Multi-touch gestures are ignored to allow pinch/zoom to work.
  - Sensitivity defaults tuned (threshold, timing, vertical restraint). Values are configurable in the JS if needed.
  - No changes to server APIs or data models.

## Testing performed
- Real-device manual testing on Android and iOS phones and on Windows touch laptop:
  - One-finger left/right swipes navigate as intended.
  - Two-finger pinch-to-zoom works normally.
  - Buttons (Next/Previous / Fullscreen) are clickable and functional with mouse and touch.
- Verified JSON-backed read-only pages exhibit same behavior.

## How to review / test locally
1. Checkout branch Alpha-ImplementSwipeGestures.
2. Build and run the app (Blazor Server).
3. Ensure wwwroot/js/swipe.js is included in the app layout (it should be referenced already).
4. On a touch device or emulator:
   - Open a TreeView and select an item to show the read-only component.
   - Swipe left/right over the content area to navigate.
5. Verify:
   - Swipe left moves forward (next), swipe right moves backward (previous).
   - Pinch-to-zoom still works.
   - Mouse clicks on buttons are not blocked.

## Backward compatibility & known limitations
- Edge-start gestures (swipes that begin exactly at the device/browser viewport edge) may still be handled by the OS/browser and cannot always be intercepted reliably; recommend starting in the content area.
- Default sensitivity values were tuned for a broad set of devices. If you encounter false positives/negatives, thresholds can be tuned in wwwroot/js/swipe.js or passed as options on registration.
- Swipe behavior is implemented only for read-only detail views — intentionally; editing views remain unchanged.

## Operational notes
- Ensure swipe.js is referenced once so it’s available before components register.
- All components unregister on disposal to avoid leaks.
