### PR TITLE
Change default position of split bar to full screen.

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
@@ -1169,7 +1169,7 @@
 
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage == 27)
+        if (_percentage != 0)
         {
             _percentage = 0;   // collapse left panel
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -758,7 +758,7 @@
 
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage == 27)
+        if (_percentage != 0)
         {
             _percentage = 0;   // collapse left panel
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -1317,7 +1317,7 @@
 
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage == 27)
+        if (_percentage != 0)
         {
             _percentage = 0;   // collapse left panel
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -649,11 +649,9 @@
     }
 
 
-
-
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage == 27)
+        if (_percentage != 0)
         {
             _percentage = 0;   // collapse left panel
         }


### PR DESCRIPTION
Fixes #150 

As reported in the GitHub Issue #150, we are now implementing Required changes so that the user experience will be much better when they click on the full screen button especially while working in the tree view for project data as well as baseline data. 

Implementation was test and approved by Open Rose Team. 