### PR TITLE
Support full screen and restore full screen as two UI icons based on users UI state

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
@@ -7,6 +7,14 @@ namespace OpenRose.WebUI.Components.EventServices
 	public class SplitBarManagementService
 	{
 		/// <summary>
+		/// Tracks whether the split bar is currently collapsed.
+		/// True means the split bar is at position ZERO.
+		/// False means the split bar is at its default expanded position.
+		/// This state is scoped per user session because the service is registered as Scoped.
+		/// </summary>
+		public bool IsCollapsed { get; private set; } = false;
+
+		/// <summary>
 		/// Fired when any component requests the split bar to toggle
 		/// between default and collapsed positions.
 		/// </summary>
@@ -14,11 +22,23 @@ namespace OpenRose.WebUI.Components.EventServices
 
 		/// <summary>
 		/// Components call this to toggle the split bar.
+		/// This method also updates the internal IsCollapsed state
+		/// so that UI components can query the current split bar position.
 		/// </summary>
 		public void ToggleSplitBar()
 		{
+			// Toggle the state before notifying listeners.
+			IsCollapsed = !IsCollapsed;
+
 			OnToggleSplitBarRequested?.Invoke();
+		}
+
+		/// <summary>
+		/// Helper method for UI components to check if the split bar is collapsed.
+		/// </summary>
+		public bool GetIsCollapsed()
+		{
+			return IsCollapsed;
 		}
 	}
 }
-

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineDetailsComponent.razor
@@ -43,7 +43,9 @@
 	@if (CalledFrom == nameof(BaselineTreeView))
 	{
 		<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-			<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+			<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+										? Icons.Material.Filled.FullscreenExit
+										: Icons.Material.Filled.Fullscreen)"
 						   Color="Color.Success"
 						   Size="Size.Medium"
 						   IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponent.razor
@@ -42,7 +42,9 @@
 				<MudCardContent Style="padding:6px">
 					<div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+								<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+															? Icons.Material.Filled.FullscreenExit
+															: Icons.Material.Filled.Fullscreen)"
 										   Color="Color.Success"
 										   Size="Size.Medium"
 										   IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineReadOnlyComponentForJson.razor
@@ -38,7 +38,9 @@
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                            ? Icons.Material.Filled.FullscreenExit
+                                                            : Icons.Material.Filled.Fullscreen)"
                                            Color="Color.Success"
                                            Size="Size.Medium"
                                            IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeView.razor
@@ -31,7 +31,7 @@
 @inject ViewSettingsService ViewSettings
 @inject ProtectedSessionStorage SessionStorage
 @inject SplitBarManagementService SplitBarManagementService
-
+@implements IDisposable
 
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
@@ -1169,7 +1169,9 @@
 
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage != 0)
+        // Query the service to determine the correct UI state.
+        // This ensures consistent behavior across all components.
+        if (SplitBarManagementService.IsCollapsed)
         {
             _percentage = 0;   // collapse left panel
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -758,7 +758,9 @@
 
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage != 0)
+        // Query the service to determine the correct UI state.
+        // This ensures consistent behavior across all components.
+        if (SplitBarManagementService.IsCollapsed)
         {
             _percentage = 0;   // collapse left panel
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponent.razor
@@ -44,7 +44,9 @@
 				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+								<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+															? Icons.Material.Filled.FullscreenExit
+															: Icons.Material.Filled.Fullscreen)"
 										   Color="Color.Success"
 										   Size="Size.Medium"
 										   IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzReadOnlyComponentForJson.razor
@@ -39,7 +39,9 @@
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                            ? Icons.Material.Filled.FullscreenExit
+                                                            : Icons.Material.Filled.Fullscreen)"
                                            Color="Color.Success"
                                            Size="Size.Medium"
                                            IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemz/BaselineItemzTreeViewComponent.razor
@@ -27,7 +27,9 @@
 
 <MudPaper Class="pa-4 mb-3 align-start d-flex" Style="width: auto" Outlined="false">
 	<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-		<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+		<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+									? Icons.Material.Filled.FullscreenExit
+									: Icons.Material.Filled.Fullscreen)"
 					   Color="Color.Success"
 					   Size="Size.Medium"
 					   IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponent.razor
@@ -41,7 +41,9 @@
 				<MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 						<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-							<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+								<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+														   	? Icons.Material.Filled.FullscreenExit
+														   	: Icons.Material.Filled.Fullscreen)"
 										   Color="Color.Success"
 										   Size="Size.Medium"
 										   IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeReadOnlyComponentForJson.razor
@@ -38,7 +38,9 @@
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                            ? Icons.Material.Filled.FullscreenExit
+                                                            : Icons.Material.Filled.Fullscreen)"
                                            Color="Color.Success"
                                            Size="Size.Medium"
                                            IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/BaselineItemzType/BaselineItemzTypeTreeViewComponent.razor
@@ -24,7 +24,9 @@
 
 <MudPaper Class="pa-4 mb-3 ml-1 align-start d-flex" Style="width: auto" Outlined="false">
 	<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-		<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+		<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+									? Icons.Material.Filled.FullscreenExit
+									: Icons.Material.Filled.Fullscreen)"
 					   Color="Color.Success"
 					   Size="Size.Medium"
 					   IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzDetailsComponent.razor
@@ -60,7 +60,9 @@
 		@if (CalledFrom == nameof(ProjectTreeView) )
 		{
 			<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-				<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+				<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+											? Icons.Material.Filled.FullscreenExit
+											: Icons.Material.Filled.Fullscreen)"
 				Color="Color.Success"
 				Size="Size.Medium"
 				IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponent.razor
@@ -47,7 +47,9 @@
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
 
                         <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                            ? Icons.Material.Filled.FullscreenExit
+                                                            : Icons.Material.Filled.Fullscreen)"
                                            Color="Color.Success"
                                            Size="Size.Medium"
                                            IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Itemz/ItemzReadOnlyComponentForJson.razor
@@ -39,7 +39,9 @@
                     <MudCardContent Style="padding : 6px">
                         <div class="d-flex align-start justify-space-between" style="gap:8px;">
                             <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                            ? Icons.Material.Filled.FullscreenExit
+                                                            : Icons.Material.Filled.Fullscreen)"
                                                Color="Color.Success"
                                                Size="Size.Medium"
                                                IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeDetailsComponent.razor
@@ -45,7 +45,9 @@
 	@if (CalledFrom == nameof(ProjectTreeView))
 	{
 		<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-			<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+				<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+											? Icons.Material.Filled.FullscreenExit
+											: Icons.Material.Filled.Fullscreen)"
 							Color="Color.Success"
 							Size="Size.Medium"
 							IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponent.razor
@@ -41,7 +41,9 @@
 					<MudCardContent Style="padding:6px">
 						<div class="d-flex align-start justify-space-between" style="gap:8px;">
 							<MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-								<MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+								<MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+															? Icons.Material.Filled.FullscreenExit
+															: Icons.Material.Filled.Fullscreen)"
 											   Color="Color.Success"
 											   Size="Size.Medium"
 											   IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ItemzType/ItemzTypeReadOnlyComponentForJson.razor
@@ -37,7 +37,9 @@
                 <MudCardContent Style="padding:6px">
                     <div class="d-flex align-start justify-space-between" style="gap:8px;">
                         <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                            <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                        ? Icons.Material.Filled.FullscreenExit
+                                                        : Icons.Material.Filled.Fullscreen)"
                                             Color="Color.Success"
                                             Size="Size.Medium"
                                             IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectDetailsComponent.razor
@@ -40,13 +40,15 @@
         @if (CalledFrom == nameof(ProjectTreeView))
         {
             <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
-                               Color="Color.Success"
-                               Size="Size.Medium"
-                               IconSize="Size.Large"
-                               Variant="Variant.Filled"
-                               Class="mud-rounded-circle me-2"
-                               @onclick="toggleSplitBar" />
+                <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                       ? Icons.Material.Filled.FullscreenExit
+                                                       : Icons.Material.Filled.Fullscreen)"
+                           Color="Color.Success"
+                           Size="Size.Medium"
+                           IconSize="Size.Large"
+                           Variant="Variant.Filled"
+                           Class="mud-rounded-circle me-2"
+                           @onclick="toggleSplitBar" />
 
             </MudTooltip>
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponent.razor
@@ -41,7 +41,9 @@
                         <MudCardContent Style="padding:6px">
                             <div class="d-flex align-start justify-space-between" style="gap:8px;">
                                 <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                                    <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                    <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                            ? Icons.Material.Filled.FullscreenExit
+                                                            : Icons.Material.Filled.Fullscreen)"
                                                    Color="Color.Success"
                                                    Size="Size.Medium"
                                                    IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectReadOnlyComponentForJson.razor
@@ -36,7 +36,9 @@
                     <MudCardContent Style="padding:6px">
                         <div class="d-flex align-start justify-space-between" style="gap:8px;">
                             <MudTooltip Text="Toggle Split Bar" Placement="Placement.Top">
-                                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen"
+                                <MudIconButton Icon="@(SplitBarManagementService.GetIsCollapsed()
+                                                            ? Icons.Material.Filled.FullscreenExit
+                                                            : Icons.Material.Filled.Fullscreen)"
                                                Color="Color.Success"
                                                Size="Size.Medium"
                                                IconSize="Size.Large"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -1317,7 +1317,9 @@
 
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage != 0)
+        // Query the service to determine the correct UI state.
+        // This ensures consistent behavior across all components.
+        if (SplitBarManagementService.IsCollapsed)
         {
             _percentage = 0;   // collapse left panel
         }
@@ -1328,7 +1330,6 @@
 
         StateHasChanged();
     }
-
 
     public async ValueTask DisposeAsync()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeView.razor
@@ -35,6 +35,7 @@
 @inject ProtectedSessionStorage SessionStorage
 @inject ProjectDeletionService DeletionService
 @inject SplitBarManagementService SplitBarManagementService
+@implements IAsyncDisposable
 
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -651,7 +651,9 @@
 
     private void HandleToggleSplitBarRequested()
     {
-        if (_percentage != 0)
+        // Query the service to determine the correct UI state.
+        // This ensures consistent behavior across all components.
+        if (SplitBarManagementService.IsCollapsed)
         {
             _percentage = 0;   // collapse left panel
         }


### PR DESCRIPTION
Fixes #152 

With this pull request we are fixing #152 by adding support for Displaying two different icons as how users would experience in other applications. When the screen is not fully expanded then full screen icon will be displayed. And when the screen is fully expanded then the Restore to default resolution icon will be displayed.

We have covered showing two different set of icons for full screen behavior to be implemented on different device sizes and touch screen devices. in Open Rose requirements management tool, We need to make sure that appropriate behavior is baked into the application when it comes to going into and coming out of full screen views. With this pull request, Open Rose Requirements Management Tools team have added support for look and feel as well as user experience when toggling between different view sizes. 

Our team implemented this change for all the different record types including their JSON variants to support dynamic full screen icons based on the views that users would be working in within TreeView components.
