### PR TITLE
Default to full screen on small devices like mobile phones in ReadOnly Views

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -205,6 +205,7 @@
 
     private bool showEstimation = true; // Toggle to show estimation in end text
 
+    private Breakpoint bp;
 
     private Task OnDoubleClicked()
     {
@@ -353,6 +354,27 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // ------------------------------------------------------------
+            // Auto-collapse logic for small devices.
+            // This runs only once because firstRender is true only once.
+            // We check the breakpoint AFTER MudBreakpointProvider has set it,
+            // ensuring responsive layout continues to work correctly.
+            // ------------------------------------------------------------
+            if (bp < Breakpoint.Md)
+            {
+                // _percentage = 0;
+
+                // await InvokeAsync(StateHasChanged);
+                // Only collapse if not already collapsed.
+                if (!SplitBarManagementService.IsCollapsed)
+                {
+                    SplitBarManagementService.ToggleSplitBar();
+                }
+            }
+        }
+
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
         if (resultShowProperties.Success)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -167,6 +167,8 @@
 
     private bool showEstimation = true; // Toggle to show estimation in end text
 
+    private Breakpoint bp;
+
     private Task OnDoubleClicked()
     {
         if (_percentage == 27)
@@ -250,6 +252,27 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // ------------------------------------------------------------
+            // Auto-collapse logic for small devices.
+            // This runs only once because firstRender is true only once.
+            // We check the breakpoint AFTER MudBreakpointProvider has set it,
+            // ensuring responsive layout continues to work correctly.
+            // ------------------------------------------------------------
+            if (bp < Breakpoint.Md)
+            {
+                // _percentage = 0;
+                
+                // await InvokeAsync(StateHasChanged);
+                // Only collapse if not already collapsed.
+                if (!SplitBarManagementService.IsCollapsed)
+                {
+                    SplitBarManagementService.ToggleSplitBar();
+                }
+            }
+        }
+
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
         if (resultShowProperties.Success)


### PR DESCRIPTION
With this change we have fixed #154

By default users who are opening either hosted JSON data file or client side JSON data will see full screen view. These change will work for all the following record types. 

- Project
- Requirement Item Type
- Requirement Item
- Baseline
- Baseline Requirement Item Type
- Baseline Requirement Item

This change is designed and targeted towards changing behavior for Mobile Data Only! 