### PR TITLE
Enhancing the rendered HTML table background and text color in the dark mode

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/css/markdown-styles.css
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/css/markdown-styles.css
@@ -487,3 +487,57 @@
             text-decoration: underline;
         }
 }
+
+
+/* ============================================================
+    START - FORCING lighter background on a DARK browser theme 
+    for Table outputs
+============================================================ */
+
+    /* Header cells */
+    .markdown-body table th,
+    .custom-markdown-editor table th {
+        color: inherit;
+        background-color: var(--or-bg-lighter);
+    }
+
+    /* Remove the fixed background from all data cells */
+    .markdown-body table td,
+    .custom-markdown-editor table td {
+        background-color: transparent; /* key change */
+        color: inherit;
+    }
+
+    /* Striped body rows */
+    .markdown-body table tbody tr:nth-child(odd) td,
+    .custom-markdown-editor table tbody tr:nth-child(odd) td {
+        background-color: var(--or-bg-light); /* white */
+    }
+
+    .markdown-body table tbody tr:nth-child(even) td,
+    .custom-markdown-editor table tbody tr:nth-child(even) td {
+        background-color: var(--or-bg-lighter); /* light gray */
+    }
+
+    .markdown-body table tbody tr:hover td,
+    .custom-markdown-editor table tbody tr:hover td {
+        background-color: #cccccc; /* or whatever "moderately dark gray" you want */
+        color: inherit;
+    }
+
+    .markdown-body table code,
+    .custom-markdown-editor table code {
+        background-color: transparent;
+        color: inherit;
+    }
+
+    .markdown-body table pre,
+    .custom-markdown-editor table pre {
+        background-color: var(--or-bg-lighter);
+        color: inherit;
+    }
+
+/* ============================================================
+    END - FORCING lighter background on a DARK browser theme 
+    for Table outputs
+============================================================ */


### PR DESCRIPTION
fixes #156 

With this change we now have better nd more readable content produced when the markdown table is converted into HTML table. The background color and the text color is more readable and is using light color schemes. 

Until we have a full support implemented for light and dark modes within the application we are going to use more lighter color combinations for visualizing data in the HTML outputs.

