### PR TITLE
Better support for Full screen on mobile devices in ReadOnly JSON data views

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
@@ -40,5 +40,20 @@ namespace OpenRose.WebUI.Components.EventServices
 		{
 			return IsCollapsed;
 		}
+
+		/// <summary>
+		/// Enables components to request the split bar to collapse to position ZERO.
+		/// </summary>
+		public void CollapseSplitBar()
+		{
+			// Only collapse if not already collapsed.
+			if (!IsCollapsed)
+			{
+				// Toggle the state before notifying listeners.
+				IsCollapsed = true;
+
+				OnToggleSplitBarRequested?.Invoke();
+			}
+		}
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Components/EventServices/SplitBarManagementService.cs
@@ -47,13 +47,13 @@ namespace OpenRose.WebUI.Components.EventServices
 		public void CollapseSplitBar()
 		{
 			// Only collapse if not already collapsed.
-			if (!IsCollapsed)
-			{
+			//if (!IsCollapsed)
+			//{
 				// Toggle the state before notifying listeners.
 				IsCollapsed = true;
 
 				OnToggleSplitBarRequested?.Invoke();
-			}
+			//}
 		}
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -24,6 +24,7 @@
 @inject SplitBarManagementService SplitBarManagementService
 @implements IDisposable
 
+<MudBreakpointProvider OnBreakpointChanged="HandleBreakpointChanged">
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"
                             OnDoubleClicked="@OnDoubleClicked"
@@ -167,6 +168,7 @@
         </MudPaper>
     </EndContent>
 </MudExtensions.MudSplitter>
+</MudBreakpointProvider>
 
 @code {
     /// <summary>
@@ -206,6 +208,8 @@
     private bool showEstimation = true; // Toggle to show estimation in end text
 
     private Breakpoint bp;
+
+    private bool _initialAutoCollapseDone = false;
 
     private Task OnDoubleClicked()
     {
@@ -354,26 +358,26 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            // ------------------------------------------------------------
-            // Auto-collapse logic for small devices.
-            // This runs only once because firstRender is true only once.
-            // We check the breakpoint AFTER MudBreakpointProvider has set it,
-            // ensuring responsive layout continues to work correctly.
-            // ------------------------------------------------------------
-            if (bp < Breakpoint.Md)
-            {
-                // _percentage = 0;
+        // if (firstRender)
+        // {
+        //     // ------------------------------------------------------------
+        //     // Auto-collapse logic for small devices.
+        //     // This runs only once because firstRender is true only once.
+        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
+        //     // ensuring responsive layout continues to work correctly.
+        //     // ------------------------------------------------------------
+        //     if (bp < Breakpoint.Md)
+        //     {
+        //         // _percentage = 0;
 
-                // await InvokeAsync(StateHasChanged);
-                // Only collapse if not already collapsed.
-                if (!SplitBarManagementService.IsCollapsed)
-                {
-                    SplitBarManagementService.ToggleSplitBar();
-                }
-            }
-        }
+        //         // await InvokeAsync(StateHasChanged);
+        //         // Only collapse if not already collapsed.
+        //         if (!SplitBarManagementService.IsCollapsed)
+        //         {
+        //             SplitBarManagementService.ToggleSplitBar();
+        //         }
+        //     }
+        // }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
@@ -793,6 +797,39 @@
 
         StateHasChanged();
     }
+
+    private void HandleBreakpointChanged(Breakpoint newBreakpoint)
+    {
+        bp = newBreakpoint;
+
+        // ------------------------------------------------------------
+        // Auto-collapse logic for small devices.
+        // Runs ONLY ONCE per JSON file load.
+        // Does NOT run when navigating inside the tree.
+        // Does NOT run when clicking nodes.
+        // Does NOT run when using Next/Previous.
+        // Does NOT run when user manually expands.
+        // ------------------------------------------------------------
+        if (_initialAutoCollapseDone)
+            return;
+
+        _initialAutoCollapseDone = true;
+
+        bool shouldCollapse = bp < Breakpoint.Md;
+
+        // Use the service so the icon stays correct.
+        if (shouldCollapse)
+        {
+            if (!SplitBarManagementService.IsCollapsed)
+                SplitBarManagementService.ToggleSplitBar();
+        }
+        else
+        {
+            if (SplitBarManagementService.IsCollapsed)
+                SplitBarManagementService.ToggleSplitBar();
+        }
+    }
+
 
     public void Dispose()
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -358,6 +358,18 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+
+        if (firstRender)
+        {
+            if (SplitBarManagementService.IsCollapsed)
+            {
+                _percentage = 0;  // restore default
+            }
+            else
+            {
+                _percentage = 27;   // collapse left panel
+            }
+        }
         // if (firstRender)
         // {
         //     // ------------------------------------------------------------

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -358,27 +358,27 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            // ------------------------------------------------------------
-            // Auto-collapse logic for small devices.
-            // This runs only once because firstRender is true only once.
-            // We check the breakpoint AFTER MudBreakpointProvider has set it,
-            // ensuring responsive layout continues to work correctly.
-            // ------------------------------------------------------------
-            if (bp < Breakpoint.Md)
-            {
-                // _percentage = 0;
+        // if (firstRender)
+        // {
+        //     // ------------------------------------------------------------
+        //     // Auto-collapse logic for small devices.
+        //     // This runs only once because firstRender is true only once.
+        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
+        //     // ensuring responsive layout continues to work correctly.
+        //     // ------------------------------------------------------------
+        //     if (bp < Breakpoint.Md)
+        //     {
+        //         // _percentage = 0;
 
-                // await InvokeAsync(StateHasChanged);
-                // Only collapse if not already collapsed.
-                // if (!SplitBarManagementService.IsCollapsed)
-                // {
-                //     SplitBarManagementService.ToggleSplitBar();
-                // }
-                SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
-            }
-        }
+        //         // await InvokeAsync(StateHasChanged);
+        //         // Only collapse if not already collapsed.
+        //         // if (!SplitBarManagementService.IsCollapsed)
+        //         // {
+        //         //     SplitBarManagementService.ToggleSplitBar();
+        //         // }
+        //         SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
+        //     }
+        // }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
@@ -827,7 +827,7 @@
         else
         {
             if (SplitBarManagementService.IsCollapsed)
-                SplitBarManagementService.ToggleSplitBar();
+                SplitBarManagementService.CollapseSplitBar();
         }
     }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -361,6 +361,11 @@
 
         if (firstRender)
         {
+            // EXPLANATION : This is required to be in place because during OnAfterRenderAsync, we experienced that
+            // 'private Breakpoint bp' is set to default of 'Xs' and so any logic that we apply
+            // to set the Splitbar location for full screen or default screen would not work well
+            // when we fully rely on 'bp' variable to be valid!
+
             if (SplitBarManagementService.IsCollapsed)
             {
                 _percentage = 0;  // restore default
@@ -370,27 +375,6 @@
                 _percentage = 27;   // collapse left panel
             }
         }
-        // if (firstRender)
-        // {
-        //     // ------------------------------------------------------------
-        //     // Auto-collapse logic for small devices.
-        //     // This runs only once because firstRender is true only once.
-        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
-        //     // ensuring responsive layout continues to work correctly.
-        //     // ------------------------------------------------------------
-        //     if (bp < Breakpoint.Md)
-        //     {
-        //         // _percentage = 0;
-
-        //         // await InvokeAsync(StateHasChanged);
-        //         // Only collapse if not already collapsed.
-        //         // if (!SplitBarManagementService.IsCollapsed)
-        //         // {
-        //         //     SplitBarManagementService.ToggleSplitBar();
-        //         // }
-        //         SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
-        //     }
-        // }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -358,26 +358,27 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // if (firstRender)
-        // {
-        //     // ------------------------------------------------------------
-        //     // Auto-collapse logic for small devices.
-        //     // This runs only once because firstRender is true only once.
-        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
-        //     // ensuring responsive layout continues to work correctly.
-        //     // ------------------------------------------------------------
-        //     if (bp < Breakpoint.Md)
-        //     {
-        //         // _percentage = 0;
+        if (firstRender)
+        {
+            // ------------------------------------------------------------
+            // Auto-collapse logic for small devices.
+            // This runs only once because firstRender is true only once.
+            // We check the breakpoint AFTER MudBreakpointProvider has set it,
+            // ensuring responsive layout continues to work correctly.
+            // ------------------------------------------------------------
+            if (bp < Breakpoint.Md)
+            {
+                // _percentage = 0;
 
-        //         // await InvokeAsync(StateHasChanged);
-        //         // Only collapse if not already collapsed.
-        //         if (!SplitBarManagementService.IsCollapsed)
-        //         {
-        //             SplitBarManagementService.ToggleSplitBar();
-        //         }
-        //     }
-        // }
+                // await InvokeAsync(StateHasChanged);
+                // Only collapse if not already collapsed.
+                // if (!SplitBarManagementService.IsCollapsed)
+                // {
+                //     SplitBarManagementService.ToggleSplitBar();
+                // }
+                SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
+            }
+        }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
@@ -837,6 +838,7 @@
         JsonFileDataSource.OnJsonChanged -= HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged -= HandleStateChangedAsync;
         SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
+        _initialAutoCollapseDone = false;
     }
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -254,26 +254,27 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // if (firstRender)
-        // {
-        //     // ------------------------------------------------------------
-        //     // Auto-collapse logic for small devices.
-        //     // This runs only once because firstRender is true only once.
-        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
-        //     // ensuring responsive layout continues to work correctly.
-        //     // ------------------------------------------------------------
-        //     if (bp < Breakpoint.Md)
-        //     {
-        //         // _percentage = 0;
-                
-        //         // await InvokeAsync(StateHasChanged);
-        //         // Only collapse if not already collapsed.
-        //         if (!SplitBarManagementService.IsCollapsed)
-        //         {
-        //             SplitBarManagementService.ToggleSplitBar();
-        //         }
-        //     }
-        // }
+        if (firstRender)
+        {
+            // ------------------------------------------------------------
+            // Auto-collapse logic for small devices.
+            // This runs only once because firstRender is true only once.
+            // We check the breakpoint AFTER MudBreakpointProvider has set it,
+            // ensuring responsive layout continues to work correctly.
+            // ------------------------------------------------------------
+            if (bp < Breakpoint.Md)
+            {
+                // _percentage = 0;
+
+                // await InvokeAsync(StateHasChanged);
+                // Only collapse if not already collapsed.
+                // if (!SplitBarManagementService.IsCollapsed)
+                // {
+                //     SplitBarManagementService.ToggleSplitBar();
+                // }
+                SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
+            }
+        }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
@@ -424,17 +425,17 @@
             _ => Icons.Material.Filled.Cancel
         };
 
-            return new TreeItemPresenter(
-            value: dto.RecordId,
-            text: dto.Name ?? "(no name)",
-            icon: icon,
-            recordType: (dto.RecordType ?? "Unknown").ToLower(),
-            level: dto.Level ?? 0,
-            expandable: dto.Children != null && dto.Children.Count > 0,
-            hierarchyId: dto.HierarchyId,
-            estimationUnit: dto.EstimationUnit,
-            rolledUpEstimation: dto.RolledUpEstimation
-        );
+        return new TreeItemPresenter(
+        value: dto.RecordId,
+        text: dto.Name ?? "(no name)",
+        icon: icon,
+        recordType: (dto.RecordType ?? "Unknown").ToLower(),
+        level: dto.Level ?? 0,
+        expandable: dto.Children != null && dto.Children.Count > 0,
+        hierarchyId: dto.HierarchyId,
+        estimationUnit: dto.EstimationUnit,
+        rolledUpEstimation: dto.RolledUpEstimation
+    );
     }
 
     private async Task OnItemClick(TreeItemPresenter presenter)
@@ -483,13 +484,13 @@
         {
             return string.Empty;
         }
-        
+
         // If ShowPropertiesInReadOnlyViews is false, we skip showing estimation info
         if (ViewSettings.ShowPropertiesInReadOnlyViews == false)
         {
             return string.Empty;
         }
-        
+
         // NEW: Show estimation in read-only view if available
         if (showEstimation )
         {
@@ -722,12 +723,12 @@
         }
     }
 
-
     public void Dispose()
     {
         ItemzSelectionServiceForJson.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
         JsonFileDataSource.OnJsonChanged -= HandleStateChangedAsync;
         DataSourceState.OnDataSourceChanged -= HandleStateChangedAsync;
         SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
+        _initialAutoCollapseDone = false;
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -254,8 +254,14 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+
         if (firstRender)
         {
+            // EXPLANATION : This is required to be in place because during OnAfterRenderAsync, we experienced that
+            // 'private Breakpoint bp' is set to default of 'Xs' and so any logic that we apply
+            // to set the Splitbar location for full screen or default screen would not work well
+            // when we fully rely on 'bp' variable to be valid!
+
             if (SplitBarManagementService.IsCollapsed)
             {
                 _percentage = 0;  // restore default
@@ -265,32 +271,6 @@
                 _percentage = 27;   // collapse left panel
             }
         }
-        // if (firstRender)
-        // {
-        //     // ------------------------------------------------------------
-        //     // Auto-collapse logic for small devices.
-        //     // This runs only once because firstRender is true only once.
-        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
-        //     // ensuring responsive layout continues to work correctly.
-        //     // ------------------------------------------------------------
-
-        //     await Task.Delay(30); // allow MudBlazor to measure viewport
-
-        //     if (bp < Breakpoint.Md)
-        //     {
-        //         // _percentage = 0;
-
-        //         // await InvokeAsync(StateHasChanged);
-        //         // Only collapse if not already collapsed.
-        //         // if (!SplitBarManagementService.IsCollapsed)
-        //         // {
-        //         //     SplitBarManagementService.ToggleSplitBar();
-        //         // }
-        //         SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
-
-        //         await InvokeAsync(StateHasChanged);
-        //     }
-        // }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -254,27 +254,32 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            // ------------------------------------------------------------
-            // Auto-collapse logic for small devices.
-            // This runs only once because firstRender is true only once.
-            // We check the breakpoint AFTER MudBreakpointProvider has set it,
-            // ensuring responsive layout continues to work correctly.
-            // ------------------------------------------------------------
-            if (bp < Breakpoint.Md)
-            {
-                // _percentage = 0;
+        // if (firstRender)
+        // {
+        //     // ------------------------------------------------------------
+        //     // Auto-collapse logic for small devices.
+        //     // This runs only once because firstRender is true only once.
+        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
+        //     // ensuring responsive layout continues to work correctly.
+        //     // ------------------------------------------------------------
 
-                // await InvokeAsync(StateHasChanged);
-                // Only collapse if not already collapsed.
-                // if (!SplitBarManagementService.IsCollapsed)
-                // {
-                //     SplitBarManagementService.ToggleSplitBar();
-                // }
-                SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
-            }
-        }
+        //     await Task.Delay(30); // allow MudBlazor to measure viewport
+
+        //     if (bp < Breakpoint.Md)
+        //     {
+        //         // _percentage = 0;
+
+        //         // await InvokeAsync(StateHasChanged);
+        //         // Only collapse if not already collapsed.
+        //         // if (!SplitBarManagementService.IsCollapsed)
+        //         // {
+        //         //     SplitBarManagementService.ToggleSplitBar();
+        //         // }
+        //         SplitBarManagementService.CollapseSplitBar(); // Collapse left panel for small devices
+
+        //         await InvokeAsync(StateHasChanged);
+        //     }
+        // }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
@@ -719,7 +724,7 @@
         else
         {
             if (SplitBarManagementService.IsCollapsed)
-                SplitBarManagementService.ToggleSplitBar();
+                SplitBarManagementService.CollapseSplitBar();
         }
     }
 

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -254,6 +254,17 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            if (SplitBarManagementService.IsCollapsed)
+            {
+                _percentage = 0;  // restore default
+            }
+            else
+            {
+                _percentage = 27;   // collapse left panel
+            }
+        }
         // if (firstRender)
         // {
         //     // ------------------------------------------------------------

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -24,7 +24,7 @@
 @inject SplitBarManagementService SplitBarManagementService
 @implements IDisposable
 
-
+<MudBreakpointProvider OnBreakpointChanged="HandleBreakpointChanged">
 <MudExtensions.MudSplitter @bind-Dimension="@_percentage"
                             Height="@_height"
                             OnDoubleClicked="@OnDoubleClicked"
@@ -135,7 +135,7 @@
     </EndContent>
 
 </MudExtensions.MudSplitter>
-
+</MudBreakpointProvider>
 @code {
     [Parameter] public Guid RootId { get; set; }
 
@@ -168,6 +168,8 @@
     private bool showEstimation = true; // Toggle to show estimation in end text
 
     private Breakpoint bp;
+
+    private bool _initialAutoCollapseDone = false;
 
     private Task OnDoubleClicked()
     {
@@ -252,26 +254,26 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            // ------------------------------------------------------------
-            // Auto-collapse logic for small devices.
-            // This runs only once because firstRender is true only once.
-            // We check the breakpoint AFTER MudBreakpointProvider has set it,
-            // ensuring responsive layout continues to work correctly.
-            // ------------------------------------------------------------
-            if (bp < Breakpoint.Md)
-            {
-                // _percentage = 0;
+        // if (firstRender)
+        // {
+        //     // ------------------------------------------------------------
+        //     // Auto-collapse logic for small devices.
+        //     // This runs only once because firstRender is true only once.
+        //     // We check the breakpoint AFTER MudBreakpointProvider has set it,
+        //     // ensuring responsive layout continues to work correctly.
+        //     // ------------------------------------------------------------
+        //     if (bp < Breakpoint.Md)
+        //     {
+        //         // _percentage = 0;
                 
-                // await InvokeAsync(StateHasChanged);
-                // Only collapse if not already collapsed.
-                if (!SplitBarManagementService.IsCollapsed)
-                {
-                    SplitBarManagementService.ToggleSplitBar();
-                }
-            }
-        }
+        //         // await InvokeAsync(StateHasChanged);
+        //         // Only collapse if not already collapsed.
+        //         if (!SplitBarManagementService.IsCollapsed)
+        //         {
+        //             SplitBarManagementService.ToggleSplitBar();
+        //         }
+        //     }
+        // }
 
         // Load view settings for ShowPropertiesInReadOnlyViews
         var resultShowProperties = await SessionStorage.GetAsync<bool>("SHOWPROPERTIESINREADONLYVIEWS");
@@ -687,6 +689,39 @@
 
         StateHasChanged();
     }
+
+    private void HandleBreakpointChanged(Breakpoint newBreakpoint)
+    {
+        bp = newBreakpoint;
+
+        // ------------------------------------------------------------
+        // Auto-collapse logic for small devices.
+        // Runs ONLY ONCE per JSON file load.
+        // Does NOT run when navigating inside the tree.
+        // Does NOT run when clicking nodes.
+        // Does NOT run when using Next/Previous.
+        // Does NOT run when user manually expands.
+        // ------------------------------------------------------------
+        if (_initialAutoCollapseDone)
+            return;
+
+        _initialAutoCollapseDone = true;
+
+        bool shouldCollapse = bp < Breakpoint.Md;
+
+        // Use the service so the icon stays correct.
+        if (shouldCollapse)
+        {
+            if (!SplitBarManagementService.IsCollapsed)
+                SplitBarManagementService.ToggleSplitBar();
+        }
+        else
+        {
+            if (SplitBarManagementService.IsCollapsed)
+                SplitBarManagementService.ToggleSplitBar();
+        }
+    }
+
 
     public void Dispose()
     {


### PR DESCRIPTION
Fixes #158 

OpenRose Requirements Management Tools team has now implemented necessary feature to show full screen on small devices like mobile phones while working in Read Only JSON data views.

The scope of this was only when user loads JSON data file in the WebUI via either 'Server Hosted JSON data file' or 'Client uploaded JSON data file'. 

We now support opening full screen view for following record types.

- Project
- Requirement Item Type
- Requirement Item
- Baseline
- Baseline Requirement Item Type
- Baseline Requirement Item

Users of OpenRose will have better experience working accessing read only hosted data over different devices with different sizes including touch screen devices.


