### PR TITLE
Refresh and Reload  implementation for Server Data File Mode

### DIFF
--- a/OpenRose.Web/OpenRose.WebUI/Components/App.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/App.razor
@@ -49,6 +49,7 @@
     <script src="@Assets["js/marked.min.js"]"></script> @* version 15.0.4 was downloaded in Dec 2024 *@
     <script src="@Assets["js/fullscreen.js"]"></script>
     <script src="@Assets["js/blockNavigation.js"]"></script>
+    <script src="@Assets["js/navigationEvents.js"]"></script>
     <script src="@Assets["js/clipboard.js"]"></script>
     <script src="@Assets["js/swipe.js"]"></script>
     <script src="@Assets["/_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js"]"></script>

--- a/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Layout/MainLayout.razor
@@ -21,6 +21,8 @@
 @* @inject IServiceProvider ServiceProviderForDependencyInjection *@
 @inject NavigationManager NavManager
 @inject StartupCapabilitiesService StartupCapabilities
+@inject RefreshRecoveryService RefreshRecovery
+@inject IHttpClientFactory ClientFactory
 
 <MudThemeProvider />
 <MudPopoverProvider />
@@ -321,6 +323,9 @@
 	bool drawerOpen = false;
 	public string CurrentPageTitle = "OpenRose";
 
+	private bool _restoreAttempted = false;
+
+
 	public void SetTitle(string value)
 	{
 		CurrentPageTitle = value;
@@ -344,6 +349,38 @@
 		// DataSourceStateServiceForDataSourceTracking.OnDataSourceChanged += OnDataSourceStateChangedCallback;
 
 		ViewSettingsServiceForUiState.OnKioskModeChanged += HandleKioskModeChanged;
+		
+		base.OnInitialized();
+	}
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (!firstRender)
+			return; // Only run restore/clear logic once per page load
+
+		// CASE A — Clear state (navigation, mode switch, tab close)
+		if (RefreshRecovery.ShouldClear)
+		{
+			await RefreshRecovery.ClearAllAsync();
+			return; // IMPORTANT: Do NOT attempt restore after clearing
+		}
+
+		// CASE B — Restore state (browser refresh)
+		if (!_restoreAttempted)
+		{
+			_restoreAttempted = true;
+
+			var savedFile = await RefreshRecovery.LoadJsonFileNameAsync();
+
+			if (!string.IsNullOrWhiteSpace(savedFile) &&
+				DataSourceStateServiceForDataSourceTracking.CurrentDataSourceState.IsServerJsonMode)
+			{
+				await RestoreServerJsonFileAsync(savedFile);
+
+				// Navigate AFTER restore
+				NavManager.NavigateTo("/jsonviewer", replace: true);
+			}
+		}
 	}
 
 	private void HandleKioskModeChanged()
@@ -632,6 +669,9 @@
 		bool canProceed = await FormStateService.ConfirmDiscardAllChangesAsync();
 		if (!canProceed)
 			return;
+
+		await RefreshRecovery.ClearAllAsync();
+		_restoreAttempted = true;
         NavManager.NavigateTo("/serverdatafiles", true);
 		//await ShowDataSourceSwitchDialogForSelectingServerJsonFileAsync();
 	}
@@ -660,6 +700,47 @@
 			dialogOptions
 		);
     }
+
+	private async Task RestoreServerJsonFileAsync(string fileName)
+	{
+		var httpClient = ClientFactory.CreateClient("WebUIInternal");
+		httpClient.BaseAddress = new Uri(NavManager.BaseUri);
+
+		// Ask server to activate the file
+		var response = await httpClient.PostAsJsonAsync("offline/select", new { fileName });
+
+		if (!response.IsSuccessStatusCode)
+			return;
+
+		var result = await response.Content.ReadFromJsonAsync<ServerSelectResponse>();
+		if (result is null || !result.success)
+			return;
+
+		// Load JSON content into memory
+		await JsonDataSource.LoadJsonFileDataFromStringAsync(result.jsonContent);
+
+		// Update data source state
+		DataSourceStateServiceForDataSourceTracking.SwitchToServerSideJsonFile(result.fileName);
+
+		// Update metadata
+		JsonDataSource.SetJsonViewerMetadata(new JsonViewerMetadata
+		{
+			FileName = result.fileName,
+			FileSizeBytes = result.jsonContent.Length,
+			LoadedAt = DateTime.Now,
+			IsServerSide = true
+		});
+
+		// Update UI mode
+		ViewSettingsServiceForUiState.IsOperatingInJsonFileDataSourceMode = true;
+	}
+
+	private class ServerSelectResponse
+	{
+		public bool success { get; set; }
+		public string fileName { get; set; }
+		public string jsonContent { get; set; }
+	}
 
 	public void Dispose()
 	{

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -22,6 +22,8 @@
 @inject IJSRuntime JS
 @inject ProtectedSessionStorage SessionStorage
 @inject SplitBarManagementService SplitBarManagementService
+@inject RefreshRecoveryService RefreshRecovery
+@inject NavigationManager NavManager
 @implements IDisposable
 
 <MudBreakpointProvider OnBreakpointChanged="HandleBreakpointChanged">
@@ -118,20 +120,20 @@
                 {
                     case "baseline":
                         <BaselineReadOnlyComponentForJson BaselineId="@selectedItem.Value"
-                                                          OnNavigateNext="NavigateNext" />
+                                                          OnNavigateNext="NavigateNextAsync" />
                         break;
 
                     case "baselineitemztype": 
                         <BaselineItemzTypeReadOnlyComponentForJson BaselineItemzTypeId="@selectedItem.Value"
-                                                                   OnNavigatePrevious="NavigatePrevious"
-                                                                   OnNavigateNext="NavigateNext" />
+                                                                   OnNavigatePrevious="NavigatePreviousAsync"
+                                                                   OnNavigateNext="NavigateNextAsync" />
                         break;
 
                     case "baselineitemz":
                         <BaselineItemzReadOnlyComponentForJson BaselineItemzId="@selectedItem.Value"
                                                                IsIncluded="@selectedItem.IsIncluded"
-                                                               OnNavigatePrevious="NavigatePrevious"
-                                                               OnNavigateNext="NavigateNext"
+                                                               OnNavigatePrevious="NavigatePreviousAsync"
+                                                               OnNavigateNext="NavigateNextAsync"
                                                                OnOpenTraceTarget="NavigateToTraceTarget" />
                         break;
 
@@ -276,6 +278,10 @@
         }
     }
 
+    private bool _shouldRestoreSelection = true;
+
+    private DotNetObjectReference<BaselineTreeViewForJson>? _dotNetRef;
+
     // protected override async Task OnInitializedAsync()
     // {
     //     BaselineItemzSelectionServiceForJson.OnScrollToTreeViewNode += async (recordId) =>
@@ -343,24 +349,28 @@
 
         // Subscribe to JSON + DataSource changes
         JsonFileDataSource.OnJsonChanged += HandleStateChangedAsync;
-        DataSourceState.OnDataSourceChanged += HandleStateChangedAsync;
+        DataSourceState.OnDataSourceChanged += HandleDataSourceChangedAsync;
+        NavManager.LocationChanged += HandleLocationChanged;
 
         SplitBarManagementService.OnToggleSplitBarRequested += HandleToggleSplitBarRequested;
 
 
-        // await ReloadTreeAsync();
-    }
-
-    protected override async Task OnParametersSetAsync()
-    {
         await ReloadTreeAsync();
     }
+
+    // protected override async Task OnParametersSetAsync()
+    // {
+    //     await ReloadTreeAsync();
+    // }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
 
         if (firstRender)
         {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("OpenRoseNavigation.registerNavigationHandler", _dotNetRef);
+
             // EXPLANATION : This is required to be in place because during OnAfterRenderAsync, we experienced that
             // 'private Breakpoint bp' is set to default of 'Xs' and so any logic that we apply
             // to set the Splitbar location for full screen or default screen would not work well
@@ -373,6 +383,24 @@
             else
             {
                 _percentage = 27;   // collapse left panel
+            }
+
+            if (RefreshRecovery.ShouldClear == false)
+            {
+                if (_shouldRestoreSelection)
+                {
+                    _shouldRestoreSelection = false;
+
+                    var savedSelected = await RefreshRecovery.LoadSelectedIdAsync();
+                    if (savedSelected.HasValue)
+                    {
+                        await SelectNodeById(savedSelected.Value);
+
+                        // Console.WriteLine($"[DEBUG] SelectNodeByID performed in OnAfterRenderAsync within ProjectTreeViewForJSON");
+
+                        StateHasChanged();
+                    }
+                }
             }
         }
 
@@ -397,9 +425,63 @@
         selectedItem = null;
         _selectedValue = Guid.Empty;
 
+        // Rebuild the tree
         await ReloadTreeAsync();
+        
+        // Instead of restoring immediately, mark for restore AFTER render
+        _shouldRestoreSelection = true;
+
         await InvokeAsync(StateHasChanged);
+
+        // Console.WriteLine("[DEBUG] HandleStateChangedAsync triggered.");
     }
+
+
+    private async Task HandleDataSourceChangedAsync()
+    {
+        // If we are leaving Server JSON mode, clear refresh recovery
+        if (!DataSourceState.CurrentDataSourceState.IsServerJsonMode)
+        {
+            // await RefreshRecovery.ClearAllAsync();
+            RefreshRecovery.MarkForClear();
+
+            // Console.WriteLine("[DEBUG] performed ClearAllAsync() from HandleDataSourceChangedAsync triggered.");
+        }
+
+        await HandleStateChangedAsync();
+    }
+
+
+    private async void HandleLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        // Console.WriteLine($"[DEBUG] Current location: {args.Location}");
+        // Console.WriteLine($"[DEBUG] Sender: {sender?.ToString()}");
+        // Console.WriteLine($"[DEBUG] IsNavigationIntercepted: {args.IsNavigationIntercepted}");
+
+        // EXPLANATION :
+        // Location can change due to several reasons including but not limited to ...
+        // 1. User clicking on a folder in Application Bar that unloads current component and loads a different one
+        // 2. User clicks on hyperlink that takes user to another location
+        // 3. User clicks on a button that takes user to anothe page / view
+        // 4. User clicks on the Navigation Bar and chooses another option to move away into that specific section.
+
+        // If user navigates AWAY from /jsonviewer, clear refresh recovery
+        if (args.Location.Contains("/jsonviewer", StringComparison.OrdinalIgnoreCase) ||
+            args.Location.Contains("/settings", StringComparison.OrdinalIgnoreCase))
+        {
+            RefreshRecovery.DontMarkForClear();
+        }
+        else
+        {
+            RefreshRecovery.MarkForClear();
+            // Instead of restoring immediately, mark for restore AFTER render
+            // because we have necessary logic implemented in OnAfterRenderAsync override
+            _shouldRestoreSelection = true;
+            // Console.WriteLine("[DEBUG] Setting RefreshRecovery.MarkForClear() to true from HandleLocationChanged triggered.");
+        }
+    }
+
+
 
     private async Task ReloadTreeAsync()
     {
@@ -565,6 +647,7 @@
             return;
 
         _selectedValue = presenter.Value;
+        await RefreshRecovery.SaveSelectedIdAsync(presenter.Value);
         presenter.IsSelected = true;
         baselineMudTreeView.SelectedValue = presenter.Value;
 
@@ -632,7 +715,7 @@
     private void NavigateToTraceTarget(Guid id)
         => SelectNodeById(id);
 
-    private async void SelectNodeById(Guid id)
+    private async Task SelectNodeById(Guid id)
     {
         if (!_nodeLookup.TryGetValue(id, out var node))
             return;
@@ -672,18 +755,24 @@
         return null;
     }
 
-    private void NavigatePrevious(Guid id)
+    private async Task NavigatePreviousAsync(Guid id)
     {
         var prev = GetPrevious(id);
         if (prev.HasValue)
-            SelectNodeById(prev.Value);
+        {
+            await RefreshRecovery.SaveSelectedIdAsync(prev.Value);
+            await SelectNodeById(prev.Value);
+        }
     }
 
-    private void NavigateNext(Guid id)
+    private async Task NavigateNextAsync(Guid id)
     {
         var next = GetNext(id);
         if (next.HasValue)
-            SelectNodeById(next.Value);
+        {
+            await RefreshRecovery.SaveSelectedIdAsync(next.Value);
+            await SelectNodeById(next.Value);
+        }
     }
 
 
@@ -828,13 +917,28 @@
     }
 
 
+    [JSInvokable]
+    public async Task OnBrowserNavigation(string navType)
+    {
+        // Console.WriteLine($"[DEBUG] Browser navigation type: {navType}");
+
+        // Only clear when NOT a refresh
+        if (!string.Equals(navType, "reload", StringComparison.OrdinalIgnoreCase))
+        {
+            // Console.WriteLine("[DEBUG] performing ClearAllAsync() from OnBrowserNavigation getting triggered.");
+            RefreshRecovery.MarkForClear();
+        }
+    }
+
     public void Dispose()
     {
         BaselineItemzSelectionServiceForJson.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
         JsonFileDataSource.OnJsonChanged -= HandleStateChangedAsync;
-        DataSourceState.OnDataSourceChanged -= HandleStateChangedAsync;
+        DataSourceState.OnDataSourceChanged -= HandleDataSourceChangedAsync;
+        NavManager.LocationChanged -= HandleLocationChanged;
         SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
         _initialAutoCollapseDone = false;
+        _dotNetRef?.Dispose();
     }
 
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Baseline/BaselineTreeViewForJson.razor
@@ -916,6 +916,15 @@
         }
     }
 
+    // EXPLANATION:
+    // This method is invoked from JavaScript whenever the browser triggers a
+    // 'beforeunload' event (refresh, tab close, external navigation). Blazor
+    // cannot detect these events natively because internal navigation does not
+    // unload the page. The [JSInvokable] attribute exposes this .NET method to
+    // JavaScript so the Navigation API can report the actual browser navigation
+    // type. If the event is anything other than a page reload, we mark the
+    // refresh‑recovery state for clearing so stale JSON viewer data does not
+    // persist across navigation.
 
     [JSInvokable]
     public async Task OnBrowserNavigation(string navType)

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Home.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Home.razor
@@ -61,7 +61,6 @@
     [Inject] private StartupCapabilitiesService StartupCapabilities { get; set; } = default!;
     [Inject] private DataSourceStateService DataSourceStateService { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
-    [Inject] private RefreshRecoveryService RefreshRecovery { get; set; } = default!;
 
     //[Inject] private IServiceProvider Services { get; set; } = default!;
 
@@ -80,23 +79,12 @@
 
     private static bool _redirectedOnce = false;
 
-    // protected override async Task OnInitializedAsync()
-    
     protected override void OnInitialized()
     {
 
         // Redirect ONLY when the application starts in Server JSON mode
         if (DataSourceStateService.CurrentDataSourceState.IsServerJsonMode)
         {
-
-            // var savedFile = await RefreshRecovery.LoadJsonFileNameAsync();
-            // if (!string.IsNullOrWhiteSpace(savedFile))
-            // {
-            //     Navigation.NavigateTo("/jsonviewer");
-            //     //Navigation.NavigateTo("/serverdatafiles", replace: true);
-            //     return; // Prevent further initialization
-            // }
-
             Navigation.NavigateTo("/serverdatafiles", replace: true);
             return; // Prevent further initialization
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Home.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Home.razor
@@ -61,6 +61,7 @@
     [Inject] private StartupCapabilitiesService StartupCapabilities { get; set; } = default!;
     [Inject] private DataSourceStateService DataSourceStateService { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private RefreshRecoveryService RefreshRecovery { get; set; } = default!;
 
     //[Inject] private IServiceProvider Services { get; set; } = default!;
 
@@ -79,12 +80,23 @@
 
     private static bool _redirectedOnce = false;
 
+    // protected override async Task OnInitializedAsync()
+    
     protected override void OnInitialized()
     {
 
         // Redirect ONLY when the application starts in Server JSON mode
         if (DataSourceStateService.CurrentDataSourceState.IsServerJsonMode)
         {
+
+            // var savedFile = await RefreshRecovery.LoadJsonFileNameAsync();
+            // if (!string.IsNullOrWhiteSpace(savedFile))
+            // {
+            //     Navigation.NavigateTo("/jsonviewer");
+            //     //Navigation.NavigateTo("/serverdatafiles", replace: true);
+            //     return; // Prevent further initialization
+            // }
+
             Navigation.NavigateTo("/serverdatafiles", replace: true);
             return; // Prevent further initialization
         }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -799,6 +799,15 @@
         }
     }
 
+    // EXPLANATION:
+    // This method is invoked from JavaScript whenever the browser triggers a
+    // 'beforeunload' event (refresh, tab close, external navigation). Blazor
+    // cannot detect these events natively because internal navigation does not
+    // unload the page. The [JSInvokable] attribute exposes this .NET method to
+    // JavaScript so the Navigation API can report the actual browser navigation
+    // type. If the event is anything other than a page reload, we mark the
+    // refresh‑recovery state for clearing so stale JSON viewer data does not
+    // persist across navigation.
     [JSInvokable]
     public async Task OnBrowserNavigation(string navType)
     {

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -22,6 +22,7 @@
 @inject IJSRuntime JS
 @inject ProtectedSessionStorage SessionStorage
 @inject SplitBarManagementService SplitBarManagementService
+@inject RefreshRecoveryService RefreshRecovery
 @implements IDisposable
 
 <MudBreakpointProvider OnBreakpointChanged="HandleBreakpointChanged">

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/Project/ProjectTreeViewForJson.razor
@@ -4,7 +4,6 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 *@
 
-
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using OpenRose.WebUI.Client.Services.JsonFile
 @using OpenRose.WebUI.Client.SharedModels
@@ -23,6 +22,8 @@
 @inject ProtectedSessionStorage SessionStorage
 @inject SplitBarManagementService SplitBarManagementService
 @inject RefreshRecoveryService RefreshRecovery
+@inject NavigationManager NavManager
+
 @implements IDisposable
 
 <MudBreakpointProvider OnBreakpointChanged="HandleBreakpointChanged">
@@ -102,19 +103,19 @@
                 {
                     case "project":
                         <ProjectReadOnlyComponentForJson ProjectId="@selectedItem.Value"
-                                                         OnNavigateNext="NavigateNext" />
+                                                    OnNavigateNext="NavigateNextAsync" />
                         break;
 
                     case "itemztype":
                         <ItemzTypeReadOnlyComponentForJson ItemzTypeId="@selectedItem.Value"
-                                                           OnNavigatePrevious="NavigatePrevious"
-                                                           OnNavigateNext="NavigateNext" />
+                                                               OnNavigatePrevious="NavigatePreviousAsync"
+                                                           OnNavigateNext="NavigateNextAsync" />
                         break;
 
                     case "itemz":
                         <ItemzReadOnlyComponentForJson ItemzId="@selectedItem.Value"
-                                                       OnNavigatePrevious="NavigatePrevious"
-                                                       OnNavigateNext="NavigateNext"
+                                                       OnNavigatePrevious="NavigatePreviousAsync"
+                                                       OnNavigateNext="NavigateNextAsync"
                                                        OnOpenTraceTarget="NavigateToTraceTarget" />
                         break;
 
@@ -229,6 +230,10 @@
         }
     }
 
+    private bool _shouldRestoreSelection = true;
+
+    private DotNetObjectReference<ProjectTreeViewForJson>? _dotNetRef;
+
     protected override async Task OnInitializedAsync()
     {
 
@@ -239,25 +244,23 @@
 
         // Subscribe to state changes
         JsonFileDataSource.OnJsonChanged += HandleStateChangedAsync;
-        DataSourceState.OnDataSourceChanged += HandleStateChangedAsync;
+        DataSourceState.OnDataSourceChanged += HandleDataSourceChangedAsync;
+        NavManager.LocationChanged += HandleLocationChanged;
 
         SplitBarManagementService.OnToggleSplitBarRequested += HandleToggleSplitBarRequested;
 
-        //  await ReloadTreeAsync();
+        await ReloadTreeAsync();
 
     }
-
-
-    protected override async Task OnParametersSetAsync()
-    {
-        await ReloadTreeAsync();
-    }   
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
 
         if (firstRender)
         {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("OpenRoseNavigation.registerNavigationHandler", _dotNetRef);
+
             // EXPLANATION : This is required to be in place because during OnAfterRenderAsync, we experienced that
             // 'private Breakpoint bp' is set to default of 'Xs' and so any logic that we apply
             // to set the Splitbar location for full screen or default screen would not work well
@@ -270,6 +273,24 @@
             else
             {
                 _percentage = 27;   // collapse left panel
+            }
+
+            if (RefreshRecovery.ShouldClear == false)
+            {
+                if (_shouldRestoreSelection)
+                {
+                    _shouldRestoreSelection = false;
+
+                    var savedSelected = await RefreshRecovery.LoadSelectedIdAsync();
+                    if (savedSelected.HasValue)
+                    {
+                        await SelectNodeById(savedSelected.Value);
+
+                        // Console.WriteLine($"[DEBUG] SelectNodeByID performed in OnAfterRenderAsync within ProjectTreeViewForJSON");
+
+                        StateHasChanged();
+                    }
+                }
             }
         }
 
@@ -290,15 +311,67 @@
 
     private async Task HandleStateChangedAsync()
     {
-
         // Reset selection BEFORE rebuilding the tree
         selectedItem = null;
         _selectedValue = Guid.Empty;
 
-        // Rebuild the tree when JSON or data source changes
+        // Rebuild the tree
         await ReloadTreeAsync();
+
+        // Instead of restoring immediately, mark for restore AFTER render
+        _shouldRestoreSelection = true;
+
         await InvokeAsync(StateHasChanged);
+
+        // Console.WriteLine("[DEBUG] HandleStateChangedAsync triggered.");
     }
+
+
+    private async Task HandleDataSourceChangedAsync()
+    {
+        // If we are leaving Server JSON mode, clear refresh recovery
+        if (!DataSourceState.CurrentDataSourceState.IsServerJsonMode)
+        {
+            // await RefreshRecovery.ClearAllAsync();
+            RefreshRecovery.MarkForClear();
+
+            // Console.WriteLine("[DEBUG] performed ClearAllAsync() from HandleDataSourceChangedAsync triggered.");
+        }
+
+        await HandleStateChangedAsync();
+    }
+
+
+    private async void HandleLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        // Console.WriteLine($"[DEBUG] Current location: {args.Location}");
+        // Console.WriteLine($"[DEBUG] Sender: {sender?.ToString()}");
+        // Console.WriteLine($"[DEBUG] IsNavigationIntercepted: {args.IsNavigationIntercepted}");
+
+        // EXPLANATION :
+        // Location can change due to several reasons including but not limited to ...
+        // 1. User clicking on a folder in Application Bar that unloads current component and loads a different one
+        // 2. User clicks on hyperlink that takes user to another location
+        // 3. User clicks on a button that takes user to anothe page / view
+        // 4. User clicks on the Navigation Bar and chooses another option to move away into that specific section.
+
+        // If user navigates AWAY from /jsonviewer, clear refresh recovery
+        if (args.Location.Contains("/jsonviewer", StringComparison.OrdinalIgnoreCase) ||
+            args.Location.Contains("/settings", StringComparison.OrdinalIgnoreCase))
+        {
+            RefreshRecovery.DontMarkForClear();
+        }
+        else
+        {
+            RefreshRecovery.MarkForClear();
+            // Instead of restoring immediately, mark for restore AFTER render
+            // because we have necessary logic implemented in OnAfterRenderAsync override
+            _shouldRestoreSelection = true;
+            // Console.WriteLine("[DEBUG] Setting RefreshRecovery.MarkForClear() to true from HandleLocationChanged triggered.");
+        }
+    }
+
+
 
 
     private async Task ReloadTreeAsync()
@@ -363,7 +436,6 @@
                     root.Expanded = true;
                 }
             }
-
         }
         catch (Exception ex)
         {
@@ -448,6 +520,7 @@
             return;
 
         _selectedValue = presenter.Value;
+        await RefreshRecovery.SaveSelectedIdAsync(presenter.Value);
         presenter.IsSelected = true;
         projectMudTreeView.SelectedValue = presenter.Value;
 
@@ -512,7 +585,7 @@
     private void NavigateToTraceTarget(Guid id)
         => SelectNodeById(id);
 
-    private async void SelectNodeById(Guid id)
+    private async Task SelectNodeById(Guid id)
     {
         if (!_nodeLookup.TryGetValue(id, out var node))
             return;
@@ -558,18 +631,24 @@
         return null;
     }
 
-    private void NavigatePrevious(Guid id)
+    private async Task NavigatePreviousAsync(Guid id)
     {
         var prev = GetPrevious(id);
         if (prev.HasValue)
-            SelectNodeById(prev.Value);
+        {
+            await RefreshRecovery.SaveSelectedIdAsync(prev.Value);
+            await SelectNodeById(prev.Value);
+        }
     }
 
-    private void NavigateNext(Guid id)
+    private async Task NavigateNextAsync(Guid id)
     {
         var next = GetNext(id);
         if (next.HasValue)
-            SelectNodeById(next.Value);
+        {
+            await RefreshRecovery.SaveSelectedIdAsync(next.Value);
+            await SelectNodeById(next.Value);
+        }
     }
 
     private void AssignParents(TreeItemPresenter parent)
@@ -720,12 +799,27 @@
         }
     }
 
+    [JSInvokable]
+    public async Task OnBrowserNavigation(string navType)
+    {
+        // Console.WriteLine($"[DEBUG] Browser navigation type: {navType}");
+
+        // Only clear when NOT a refresh
+        if (!string.Equals(navType, "reload", StringComparison.OrdinalIgnoreCase))
+        {
+            // Console.WriteLine("[DEBUG] performing ClearAllAsync() from OnBrowserNavigation getting triggered.");
+            RefreshRecovery.MarkForClear();
+        }
+    }
+
     public void Dispose()
     {
         ItemzSelectionServiceForJson.OnScrollToTreeViewNode -= HandleScrollToTreeViewNode;
         JsonFileDataSource.OnJsonChanged -= HandleStateChangedAsync;
-        DataSourceState.OnDataSourceChanged -= HandleStateChangedAsync;
+        DataSourceState.OnDataSourceChanged -= HandleDataSourceChangedAsync;
+        NavManager.LocationChanged -= HandleLocationChanged;
         SplitBarManagementService.OnToggleSplitBarRequested -= HandleToggleSplitBarRequested;
         _initialAutoCollapseDone = false;
+        _dotNetRef?.Dispose();
     }
 }

--- a/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
+++ b/OpenRose.Web/OpenRose.WebUI/Components/Pages/ServerDataFiles/ServerDataFiles.razor
@@ -9,6 +9,7 @@
 @inject JsonFileDataSourceService JsonDataSource
 @inject DataSourceStateService DataSourceStateService
 @inject ViewSettingsService ViewSettingsService
+@inject RefreshRecoveryService RefreshRecovery
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
 
@@ -160,6 +161,8 @@
                 LoadedAt = DateTime.Now,
                 IsServerSide = true
             });
+
+            await RefreshRecovery.SaveJsonFileNameAsync(result.fileName);
 
             ViewSettingsService.IsOperatingInJsonFileDataSourceMode = true;
 

--- a/OpenRose.Web/OpenRose.WebUI/Program.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Program.cs
@@ -303,6 +303,7 @@ builder.Services.AddScoped<JsonFileDataSourceService>(); // This service provide
 builder.Services.AddScoped<BaselineTreeNodeItemzSelectionServiceForJson>(); // Register the service
 builder.Services.AddScoped<TreeNodeItemzSelectionServiceForJson>(); // Register the service
 builder.Services.AddScoped<SplitBarManagementService>(); // Register the service
+builder.Services.AddScoped<RefreshRecoveryService>(); // Register the service
 
 
 

--- a/OpenRose.Web/OpenRose.WebUI/Services/RefreshRecoveryService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/RefreshRecoveryService.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. 
 // See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 
-
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace OpenRose.WebUI.Services
@@ -17,10 +16,25 @@ namespace OpenRose.WebUI.Services
 		private const string KEY_EXPANDED = "RR_EXPANDED_IDS";
 		private const string KEY_SCROLL = "RR_SCROLL_POS";
 
+		// NEW: Flag to indicate deferred clearing
+		public bool ShouldClear { get; private set; } = false;
+
 		public RefreshRecoveryService(ProtectedSessionStorage session)
 		{
 			_session = session;
 		}
+
+		// NEW: Mark that clearing should happen later (MainLayout)
+		public void MarkForClear()
+		{
+			ShouldClear = true;
+		}
+
+		public void DontMarkForClear()
+		{
+			ShouldClear = false;
+		}
+
 
 		// -----------------------------
 		// SAVE STATE
@@ -88,11 +102,20 @@ namespace OpenRose.WebUI.Services
 		// -----------------------------
 		public async Task ClearAllAsync()
 		{
+			// IMPORTANT:
+			// This must NEVER run inside component disposal or navigation events.
+			// otherwise it will reset SignalR connection with server 
+			// which will enforce reloading entire browser page 
+			//
+			// MainLayout will call this safely AFTER render.
+
 			await _session.DeleteAsync(KEY_JSON_FILE);
 			await _session.DeleteAsync(KEY_ROOT_ID);
 			await _session.DeleteAsync(KEY_SELECTED_ID);
 			await _session.DeleteAsync(KEY_EXPANDED);
 			await _session.DeleteAsync(KEY_SCROLL);
+
+			ShouldClear = false; // reset flag
 		}
 	}
 }

--- a/OpenRose.Web/OpenRose.WebUI/Services/RefreshRecoveryService.cs
+++ b/OpenRose.Web/OpenRose.WebUI/Services/RefreshRecoveryService.cs
@@ -1,0 +1,98 @@
+﻿// OpenRose - Requirements Management
+// Licensed under the Apache License, Version 2.0. 
+// See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+
+
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace OpenRose.WebUI.Services
+{
+	public class RefreshRecoveryService
+	{
+		private readonly ProtectedSessionStorage _session;
+
+		private const string KEY_JSON_FILE = "RR_JSON_FILE";
+		private const string KEY_ROOT_ID = "RR_ROOT_ID";
+		private const string KEY_SELECTED_ID = "RR_SELECTED_ID";
+		private const string KEY_EXPANDED = "RR_EXPANDED_IDS";
+		private const string KEY_SCROLL = "RR_SCROLL_POS";
+
+		public RefreshRecoveryService(ProtectedSessionStorage session)
+		{
+			_session = session;
+		}
+
+		// -----------------------------
+		// SAVE STATE
+		// -----------------------------
+		public async Task SaveJsonFileNameAsync(string fileName)
+		{
+			await _session.SetAsync(KEY_JSON_FILE, fileName);
+		}
+
+		public async Task SaveRootIdAsync(Guid rootId)
+		{
+			await _session.SetAsync(KEY_ROOT_ID, rootId);
+		}
+
+		public async Task SaveSelectedIdAsync(Guid selectedId)
+		{
+			await _session.SetAsync(KEY_SELECTED_ID, selectedId);
+		}
+
+		public async Task SaveExpandedNodesAsync(IEnumerable<Guid> expandedIds)
+		{
+			await _session.SetAsync(KEY_EXPANDED, expandedIds.ToList());
+		}
+
+		public async Task SaveScrollPositionAsync(double scrollY)
+		{
+			await _session.SetAsync(KEY_SCROLL, scrollY);
+		}
+
+		// -----------------------------
+		// LOAD STATE
+		// -----------------------------
+		public async Task<string?> LoadJsonFileNameAsync()
+		{
+			var result = await _session.GetAsync<string>(KEY_JSON_FILE);
+			return result.Success ? result.Value : null;
+		}
+
+		public async Task<Guid?> LoadRootIdAsync()
+		{
+			var result = await _session.GetAsync<Guid>(KEY_ROOT_ID);
+			return result.Success ? result.Value : null;
+		}
+
+		public async Task<Guid?> LoadSelectedIdAsync()
+		{
+			var result = await _session.GetAsync<Guid>(KEY_SELECTED_ID);
+			return result.Success ? result.Value : null;
+		}
+
+		public async Task<List<Guid>?> LoadExpandedNodesAsync()
+		{
+			var result = await _session.GetAsync<List<Guid>>(KEY_EXPANDED);
+			return result.Success ? result.Value : null;
+		}
+
+		public async Task<double?> LoadScrollPositionAsync()
+		{
+			var result = await _session.GetAsync<double>(KEY_SCROLL);
+			return result.Success ? result.Value : null;
+		}
+
+		// -----------------------------
+		// CLEAR STATE
+		// -----------------------------
+		public async Task ClearAllAsync()
+		{
+			await _session.DeleteAsync(KEY_JSON_FILE);
+			await _session.DeleteAsync(KEY_ROOT_ID);
+			await _session.DeleteAsync(KEY_SELECTED_ID);
+			await _session.DeleteAsync(KEY_EXPANDED);
+			await _session.DeleteAsync(KEY_SCROLL);
+		}
+	}
+}

--- a/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
+++ b/OpenRose.Web/OpenRose.WebUI/appsettings.Development.json
@@ -8,9 +8,9 @@
   "AllowedHosts": "*",
   "Http_Ports": "7673",
   // "Https_Ports": "47673",
-  "APISettings": {
-    "BaseUrl": "http://localhost:6736"
-  },
+//  "APISettings": {
+//    "BaseUrl": "http://localhost:6736"
+//  },
   "OfflineContent": {
     //"StorageFolder": "C:\\OpenRoseData\\OfflineFiles",
     "StorageFolder": "OpenRose/OfflineFiles",

--- a/OpenRose.Web/OpenRose.WebUI/appsettings.json
+++ b/OpenRose.Web/OpenRose.WebUI/appsettings.json
@@ -8,9 +8,9 @@
   "AllowedHosts": "*",
   "Http_Ports": "7673",
   // "Https_Ports": "47673",
-  "APISettings": {
-    "BaseUrl": "http://localhost:6736"
-  },
+//  "APISettings": {
+//    "BaseUrl": "http://localhost:6736"
+//  },
   "OfflineContent": {
     //  "StorageFolder": "C:\\OpenRoseData\\OfflineFiles",
     "StorageFolder": "OpenRose/OfflineFiles",

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/navigationEvents.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/navigationEvents.js
@@ -1,0 +1,18 @@
+﻿/*
+ * OpenRose - Requirements Management
+    * Licensed under the Apache License, Version 2.0.
+ * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
+*/
+
+window.OpenRoseNavigation = {
+    registerNavigationHandler: function (dotNetObj) {
+        window.addEventListener("beforeunload", function (event) {
+            const navEntry = performance.getEntriesByType("navigation")[0];
+            const navType = navEntry ? navEntry.type : "navigate";
+
+            // Send navigation type to .NET
+            dotNetObj.invokeMethodAsync("OnBrowserNavigation", navType);
+        });
+    }
+};
+

--- a/OpenRose.Web/OpenRose.WebUI/wwwroot/js/navigationEvents.js
+++ b/OpenRose.Web/OpenRose.WebUI/wwwroot/js/navigationEvents.js
@@ -4,6 +4,34 @@
  * See the LICENSE file or visit https://github.com/OpenRose/OpenRose for more details.
 */
 
+/*
+ * EXPLANATION:
+ * This script enables OpenRose to reliably detect browser‑level navigation
+ * events that Blazor cannot observe on its own. Blazor internal navigation
+ * (NavigationManager.NavigateTo) does NOT unload the page, so it never fires
+ * browser lifecycle events such as `beforeunload`. However, a full page
+ * refresh, tab close, window close, or external navigation DOES unload the
+ * document and triggers `beforeunload`.
+ *
+ * When `beforeunload` fires, we use the modern Navigation API
+ * (performance.getEntriesByType("navigation")[0].type) to determine the
+ * specific reason the browser is leaving the page:
+ *
+ *   - "reload"       → user refreshed the page
+ *   - "navigate"     → user navigated to a different URL outside Blazor
+ *   - "back_forward" → browser history navigation
+ *
+ * We then pass this navigation type into Blazor via a .NET callback
+ * (`OnBrowserNavigation`). Blazor uses this information to decide whether
+ * refresh‑recovery state should be preserved (on reload) or cleared (on
+ * external navigation, tab close, or history navigation).
+ *
+ * IMPORTANT:
+ * This script ONLY detects browser‑level unload events. It does NOT fire
+ * for Blazor internal navigation, which must be handled separately using
+ * NavigationManager.LocationChanged inside the Blazor application.
+ */
+
 window.OpenRoseNavigation = {
     registerNavigationHandler: function (dotNetObj) {
         window.addEventListener("beforeunload", function (event) {


### PR DESCRIPTION
This pull request introduces a new 'refresh and reload recovery' mechanism for the JSON Viewer components in OpenRose. We need to make sure that while pinching on a touch screen devices, users might accidentally refresh the screen and reload would take them back to the main page where uses will see list of cards representing each JSON server side data file hosted in OpenRose Server. We wanted to make sure that we support allowing users to reload and refresh page but then go back to the same record that they were looking at especially for the scenario where user is working with Server Hosted JSON Data file views.  

The goal of this change is to reliably distinguish between browser‑level refresh events and Blazor internal navigation events, something Blazor Server cannot do on its own. Previously, the application attempted to restore JSON viewer state on every page load, which caused stale data to persist when users navigated to other parts of the application. At the same time, clearing session storage during navigation or component disposal caused the SignalR circuit to reset, forcing a full browser reload and breaking the user experience. The new implementation resolves both issues by introducing a hybrid detection model that uses JavaScript for browser unload events and Blazor’s `NavigationManager.LocationChanged` for internal navigation.

A small JavaScript module now listens for the browser’s `beforeunload` event and uses the Navigation API to determine whether the user refreshed the page, closed the tab, or navigated externally. This information is passed into Blazor through a `[JSInvokable]` method, allowing the application to preserve refresh‑recovery state only when the user performs an actual page reload. Internal navigation is handled separately using Blazor’s own navigation events, ensuring that session storage is cleared when the user moves away from the JSON viewer or switches modes.

To prevent unsafe clearing during component teardown, all clearing and restoration now occur in `MainLayout.OnAfterRenderAsync(firstRender)`, which is the earliest safe point after the UI has stabilized. If the system detects a refresh, the previously loaded JSON file and viewer state are restored. If the system detects navigation, session storage is cleared in a controlled manner. This approach eliminates accidental browser reloads, prevents stale state from leaking across pages, and ensures a consistent and predictable user experience.

Overall, this pull request establishes a reliable refresh‑recovery pipeline for OpenRose, combining browser‑level detection, Blazor‑level navigation tracking, and safe deferred execution. It significantly improves stability, correctness, and usability when working with JSON‑based requirement data.

